### PR TITLE
DateTime.parse improvements

### DIFF
--- a/frameworks/foundation/system/datetime.js
+++ b/frameworks/foundation/system/datetime.js
@@ -895,6 +895,9 @@ SC.DateTime.mixin(SC.Comparable,
   parse: function(str, fmt) {
     var re = new RegExp('(?:%([aAbBcdHIjmMpSUWwxXyYZ%])|(.))', "g");
     var d, parts, opts = {}, check = {}, scanner = SC.Scanner.create({string: str});
+    
+    if (SC.none(fmt)) fmt = SC.DATETIME_ISO8601;
+    
     try {
       while ((parts = re.exec(fmt)) !== null) {
         switch(parts[1]) {

--- a/frameworks/foundation/tests/system/datetime.js
+++ b/frameworks/foundation/tests/system/datetime.js
@@ -299,6 +299,10 @@ test('bad parsing', function() {
   equals(SC.DateTime.parse("2010-09-17T18:35:08Z", SC.DATETIME_ISO8601).toISO8601(), "2010-09-17T18:35:08+00:00");
 });
 
+test('parse without a format uses default ISO8601', function() {
+  equals(SC.DateTime.parse("2010-09-17T18:35:08Z").toISO8601(), "2010-09-17T18:35:08+00:00");
+});
+
 test('binding', function() {
   var fromObject = SC.Object.create({value: dt});
   var toObject = SC.Object.create({value: ''});


### PR DESCRIPTION
Fixed an issue where DateTime.parse() would be broken for a while after a parse error occurred.  Also defaulted the format to ISO 8601 if the caller does not specify one.  See [this thread](http://groups.google.com/group/sproutcore/browse_thread/thread/7a9d9a07f76851d) for more info.
