### PR TITLE
Allow SelectFieldView to obtain focus if the user presses TAB key from previous field.

### DIFF
--- a/frameworks/desktop/views/select_field.js
+++ b/frameworks/desktop/views/select_field.js
@@ -222,7 +222,9 @@ SC.SelectFieldView = SC.FieldView.extend(
     this.set('cpDidChange', YES);
   }.observes('valueKey'),
     
-  
+  acceptsFirstResponder: function() {
+    return this.get('isEnabled');
+  }.property('isEnabled'),
    
   // .......................................
   // PRIVATE


### PR DESCRIPTION
Found that acceptsFirstResponder exists in TextFieldView but not SelectFieldView.  Unless this function is present, I found that sproutcore did not allow me to TAB from an adjacent field into a SelectFieldView.
