### PR TITLE
Nested record test

### DIFF
--- a/frameworks/datastore/tests/models/nested_records/nested_record.js
+++ b/frameworks/datastore/tests/models/nested_records/nested_record.js
@@ -222,9 +222,9 @@ test("Child Status Changed", function() {
   equals(cr.get('status'), testParent.get('status'), 'after initializing the parent to READY_NEW, check that the child record matches');
   
   SC.RunLoop.begin();
-  store.writeStatus(testParent.storeKey, SC.Record.DIRTY_NEW);
+  store.writeStatus(testParent.storeKey, SC.Record.READY_DIRTY);
   store.dataHashDidChange(testParent.storeKey);
-  equals(cr.get('status'), testParent.get('status'), 'after setting the parent to DIRTY_NEW, check that the child record matches');
+  equals(cr.get('status'), testParent.get('status'), 'after setting the parent to READY_DIRTY, check that the child record matches');
   SC.RunLoop.end();
   
   SC.RunLoop.begin();
@@ -232,4 +232,44 @@ test("Child Status Changed", function() {
   store.dataHashDidChange(testParent.storeKey);
   equals(cr.get('status'), testParent.get('status'), 'after setting the parent to BUSY_REFRESH, check that the child record matches');
   SC.RunLoop.end();
+});
+
+test("Child Status Matches Store Status", function() {
+  var cr;
+  var storeStatus;
+  cr = testParent.get('info');
+  
+  storeStatus = store.readStatus(cr.storeKey);
+  equals(storeStatus, cr.get('status'), 'after initializing the parent to READY_NEW, check that the store status matches for the child');
+  equals(cr.get('status'), testParent.get('status'), 'after initializing the parent to READY_NEW, check that the child record matches');
+  
+  SC.RunLoop.begin();
+  store.writeStatus(testParent.storeKey, SC.Record.READY_CLEAN);
+  store.dataHashDidChange(testParent.storeKey);
+  SC.RunLoop.end();
+  
+  storeStatus = store.readStatus(cr.storeKey);
+  equals(testParent.get('status'), SC.Record.READY_CLEAN, 'parent status should be READY_CLEAN');
+  equals(storeStatus, cr.get('status'), 'after setting the parent to READY_CLEAN, the child\'s status and store status should be READY_CLEAN before calling get(\'status\') on the child');
+  equals(cr.get('status'), testParent.get('status'), 'after setting the parent to READY_CLEAN, check that the child record matches');
+  
+  SC.RunLoop.begin();
+  store.writeStatus(testParent.storeKey, SC.Record.READY_DIRTY);
+  store.dataHashDidChange(testParent.storeKey);
+  SC.RunLoop.end();
+  
+  storeStatus = store.readStatus(cr.storeKey);
+  equals(testParent.get('status'), SC.Record.READY_DIRTY, 'parent status should be READY_DIRTY');
+  equals(storeStatus, cr.get('status'), 'after setting the parent to READY_DIRTY, the child\'s status and store status should be READY_DIRTY before calling get(\'status\') on the child');
+  equals(cr.get('status'), testParent.get('status'), 'after setting the parent to READY_DIRTY, check that the child record matches');
+  
+  SC.RunLoop.begin();
+  store.writeStatus(testParent.storeKey, SC.Record.BUSY_REFRESH);
+  store.dataHashDidChange(testParent.storeKey);
+  storeStatus = store.readStatus(cr.storeKey);
+  SC.RunLoop.end();
+  
+  equals(testParent.get('status'), SC.Record.BUSY_REFRESH, 'parent status should be BUSY_REFRESH');
+  equals(storeStatus, cr.get('status'), 'after setting the parent to BUSY_REFRESH, the child\'s status and store status should be BUSY_REFRESH before calling get(\'status\') on the child');
+  equals(cr.get('status'), testParent.get('status'), 'after setting the parent to BUSY_REFRESH, check that the child record matches');
 });


### PR DESCRIPTION
Added a failing unit test showing how a nested record's status and the status in the store are not in sync. This is because the store isn't updated until after 'getting' the status of the nested record.  If you don't 'get' the nested record status, then the store is never updated.  This can become very problematic when you call store.commitRecords() and the store thinks the nested records still have a status of READY_NEW for instance.

Notice that after cr.get('status') is called, further matching tests pass for the current status setting.

Finally, I would rather someone that understands the theory behind nested records fully, come up with a fix before I attempt it.  Thanks.
