### PR TITLE
This is a update to Issue #23.  Record status not reset to READY_CLEAN after updating record using store.commitRecords();

### DIFF
--- a/frameworks/datastore/models/record.js
+++ b/frameworks/datastore/models/record.js
@@ -93,7 +93,7 @@ SC.Record = SC.Object.extend(
   */
   status: function() {
     return this.store.readStatus(this.storeKey);
-  }.property(),
+  }.property('storeKey').cacheable(),
 
   /**
     The store that owns this record.  All changes will be buffered into this

--- a/frameworks/datastore/system/store.js
+++ b/frameworks/datastore/system/store.js
@@ -1980,6 +1980,10 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     
     statusOnly = dataHash || newId ? NO : YES;
     this.dataHashDidChange(storeKey, null, statusOnly);
+
+    // Force record to refresh its cached properties based on store key
+    var record = this.materializeRecord(storeKey);
+    record.notifyPropertyChange('storeKey', storeKey)
     
     return this ;
   },
@@ -2005,6 +2009,10 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     } 
     this.removeDataHash(storeKey, status) ;
     this.dataHashDidChange(storeKey);
+
+    // Force record to refresh its cached properties based on store key
+    var record = this.materializeRecord(storeKey);
+    record.notifyPropertyChange('storeKey', storeKey)
 
     return this ;
   },
@@ -2034,6 +2042,10 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
 
     this.writeStatus(storeKey, status) ;
     this.dataHashDidChange(storeKey, null, YES);
+
+    // Force record to refresh its cached properties based on store key
+    var record = this.materializeRecord(storeKey);
+    record.notifyPropertyChange('storeKey', storeKey)
 
     return this ;
   },


### PR DESCRIPTION
Used notifyPropertyChange('status') instead of making status not cacheable as suggested by rxcfc.
