### PR TITLE
Disabled menu item Ace theme bug

### DIFF
--- a/themes/ace/resources/theme.css
+++ b/themes/ace/resources/theme.css
@@ -395,7 +395,7 @@
   background: transparent;
 }
 .sc-menu-item.disabled a:hover {
-  color: white;
+  text-shadow: none;
   background: transparent;
 }
 .sc-theme .sc-view.ace.sc-panel.sc-picker.sc-menu .sc-menu-item .checkbox {


### PR DESCRIPTION
Disabled menu items should not be given a text-shadow or be changed to white.
