### PR TITLE
FixturesDataSource leaves objects in BUSY_COMMITTING state when initial fixtures array is empty

### DIFF
--- a/frameworks/datastore/data_sources/fixtures.js
+++ b/frameworks/datastore/data_sources/fixtures.js
@@ -358,7 +358,7 @@ SC.FixturesDataSource = SC.DataSource.extend(
       if (ret !== SC.MIXED_STATE) {
         var recordType = SC.Store.recordTypeFor(storeKey),
             fixtures   = recordType ? recordType.FIXTURES : null ;
-        if (fixtures && fixtures.length && fixtures.length>0) {
+        if (fixtures && typeof fixtures.length !== 'undefined') {
           if (ret === NO) ret = YES ;
         } else if (ret === YES) ret = SC.MIXED_STATE ;
       }


### PR DESCRIPTION
Fixes the following scenario:

Given:
App.MyObject.FIXTURES = [];
App.store = SC.Store.create().from(SC.Record.fixtures);
App.store.commitRecordsAutomatically = NO;

In app:
var myFoo = App.store.createRecord(App.MyObject, {foo: "bar"});
App.store.commitRecords();
myFoo.set('foo', 'baz');
App.store.commitRecords();
myFoo.set('foo', 'biz'); // ERROR -- myFoo has status BUSY_COMMITTING
