### PR TITLE
SelectFieldView with emptyName can't be selected

### DIFF
--- a/frameworks/desktop/views/select_field.js
+++ b/frameworks/desktop/views/select_field.js
@@ -247,7 +247,8 @@ SC.SelectFieldView = SC.FieldView.extend(
     var value = sc_super(); // get raw value... 
     var valueKey = this.get('valueKey') ;
     var objects = this.get('objects') ;
-    var found, object;
+    var found = null; // matching object goes here.
+    var object;
     
     // Handle empty selection.
     if (value == '***') {
@@ -260,7 +261,6 @@ SC.SelectFieldView = SC.FieldView.extend(
       
       var loc = (SC.typeOf(objects.length) === SC.T_FUNCTION) ? objects.length() : objects.length;
       
-      found = null ; // matching object goes here.
       while(!found && (--loc >= 0)) {
         object = objects.objectAt? objects.objectAt(loc) : objects[loc] ;
         if (!object) continue; // null means placeholder; just skip


### PR DESCRIPTION
When SelectFieldView has emptyName set it is imposibble to select it because when getFieldValue method is called it returns undefined value instead of null.
