### PR TITLE
SC.ObserverSet.add was being overloaded in debug mode by a version that mucked up passing along a context with addObserver. This problem doesn't arise in tests because the method is only overloaded when in debug mode.

### DIFF
--- a/frameworks/debug/invoke_once_last_debugging.js
+++ b/frameworks/debug/invoke_once_last_debugging.js
@@ -21,7 +21,7 @@ SC.addInvokeOnceLastDebuggingInfo = function() {
   
   SC.ObserverSet.add = function(target, method, context, originatingTarget, originatingMethod, originatingStack) {
     var targetGuid = (target) ? SC.guidFor(target) : "__this__";
-    
+
     // get the set of methods
     var methods = this[targetGuid] ;
     if (!methods) {
@@ -31,16 +31,16 @@ SC.addInvokeOnceLastDebuggingInfo = function() {
       this.targets++ ;
     }
     methods.add(method) ;
-    
+
     // context is really useful sometimes but not used that often so this
     // implementation is intentionally lazy.
     if (context !== undefined) {
-      var contexts = methods.contexts ;
-      if (!contexts) contexts = {};
-      contexts[SC.guidFor(method)] = context ;
+      if (!methods.contexts) methods.contexts = {} ;
+      methods.contexts[SC.guidFor(method)] = context ;
     }
-    
-    
+
+    this._membersCacheIsValid = NO ;
+
     // THIS IS THE PORTION THAT DIFFERS FROM THE STANDARD IMPLEMENTATION
     
     // Recording the calling object/function can be a useful debugging tool.
@@ -76,11 +76,6 @@ SC.addInvokeOnceLastDebuggingInfo = function() {
         originatingStacks[key]  = originatingStack;
       }
     }
-    
-    // THIS IS THE PORTION THAT DIFFERS FROM THE STANDARD IMPLEMENTATION
-    
-    
-    this._membersCacheIsValid = NO ;
   };
   
   


### PR DESCRIPTION
This problem doesn't arise in tests because the method is only overloaded when in debug mode.
