### PR TITLE
Defined SC.Request Constant

### DIFF
--- a/frameworks/foundation/system/request.js
+++ b/frameworks/foundation/system/request.js
@@ -594,3 +594,11 @@ SC.Request.manager = SC.Object.create( SC.DelegateSupport, {
   }
   
 });
+
+/**
+  Defines a 201 HTTP status code for successful requests.
+
+  @constant
+  @type Number
+*/
+SC.Request.CREATED = 201;


### PR DESCRIPTION
I added this, because the documentation stated its usage, but I couldn't find it anywhere with in SC.Request itself. I think 201 isn't enough, though. I was wondering what thoughts were on adding constants for common status codes?
