### PR TITLE
Timezone Fixes

### DIFF
--- a/frameworks/datastore/models/record_attribute.js
+++ b/frameworks/datastore/models/record_attribute.js
@@ -442,9 +442,11 @@ SC.RecordAttribute.registerTransform(Date, {
     // figure timezone
     var zp = this._zeropad,
         tz = 0-date.getTimezoneOffset()/60;
-        
-    tz = (tz === 0) ? 'Z' : '%@:00'.fmt(zp(tz));
-    
+
+    tz = (tz === 0) ?
+      'Z' :
+      (tz > 0 ? '+%@:00' : '%@:00').fmt(zp(tz));
+
     this._dates[date.getTime()] = ret = "%@-%@-%@T%@:%@:%@%@".fmt(
       zp(date.getFullYear()),
       zp(date.getMonth()+1),

--- a/frameworks/datastore/tests/models/record_attribute.js
+++ b/frameworks/datastore/tests/models/record_attribute.js
@@ -219,6 +219,17 @@ test("writing a date should generate an ISO date" ,function() {
   equals(rec.readAttribute('date'), '2009-04-02T05:28:03Z', 'should have time in ISO format');
 });
 
+test("writing a date with timezone should generate an ISO date" ,function() {
+  var date = new Date(1238650083966);
+
+  // Work with timezones
+  var utcDate = new Date(Number(date) + (date.getTimezoneOffset() * 60000)); // Adjust for timezone offset
+  date.getTimezoneOffset = function(){ return -120; }; // Hack the offset to respond 0
+
+  equals(rec.set('date', date), rec, 'returns reciever');
+  equals(rec.readAttribute('date'), '2009-04-02T07:28:03+02:00', 'should have time in ISO format with timezone');
+});
+
 test("writing an attribute should make relationship aggregate dirty" ,function() {
   equals(bar.get('status'), SC.Record.READY_CLEAN, "precond - bar should be READY_CLEAN");
   equals(rec2.get('status'), SC.Record.READY_CLEAN, "precond - rec2 should be READY_CLEAN");


### PR DESCRIPTION
When using Date as a record attribute, transformation to ISO format was not specifying timezone offset properly - it was missing + sign when timezone offset was positive.
