### PR TITLE
Fix two datetime parse issues with tests.

### DIFF
--- a/frameworks/foundation/system/datetime.js
+++ b/frameworks/foundation/system/datetime.js
@@ -103,16 +103,20 @@ SC.Scanner = SC.Object.extend(
   
   /**
     Reads some characters from the string and interprets it as an integer.
-    
-    @param {integer} len the amount of characters to read
+
+    @param {integer} len the maximum amount of characters to read
     @throws {SC.SCANNER_INT_ERROR} if asked to read non numeric characters
     @returns {integer} the scanned integer
   */
   scanInt: function(len) {
     var str = this.scan(len);
-    var re = new RegExp("\\d{"+len+"}");
-    if (!str.match(re)) throw SC.SCANNER_INT_ERROR;
-    return parseInt(str, 10);
+    var re = new RegExp("^\\d{1,"+len+"}");
+    var match = str.match(re);
+    if (!match){ throw SC.SCANNER_INT_ERROR; }
+    if(match[0].length<str.length){
+      this.scanLocation -= (str.length-match[0].length);
+    }
+    return parseInt(match[0], 10);
   },
   
   /**

--- a/frameworks/foundation/tests/system/datetime.js
+++ b/frameworks/foundation/tests/system/datetime.js
@@ -295,6 +295,10 @@ test('parse', function() {
     SC.DateTime.parse('07/01/20201 18:33:22 %a Z', '%d/%m/%Y %H:%M:%S %%a %Z') === null
     , 'Should be able to fail to parse multiple times');
   timeShouldBeEqualToHash(
+    SC.DateTime.parse('1/1/01 00:00:00', '%m/%d/%y %H:%M:%S'),
+    { year: 2001, month: 1, day: 1, hour: 0, minute: 0, second: 0, millisecond: 0 },
+    'Should be able to have single digit month and day');
+  timeShouldBeEqualToHash(
     SC.DateTime.parse('70-01-01 00:00:00', '%y-%m-%d %H:%M:%S'),
     { year: 2070, month: 1, day: 1, hour: 0, minute: 0, second: 0, millisecond: 0 }); 
   timeShouldBeEqualToHash(


### PR DESCRIPTION
Trying to parse an incorrectly formatted date would put subsequent parses into a bad state.
Also should be able to parse a date of the format '1/1/10' with '%m/%d/%y'
