### PR TITLE
CollectionView does not call destroy() to removed item views that won't be reused

### DIFF
--- a/frameworks/desktop/views/collection.js
+++ b/frameworks/desktop/views/collection.js
@@ -900,6 +900,9 @@ SC.CollectionView = SC.View.extend(
           // we'll destroy the layer now.
           existing.destroyLayer();
         }
+        else {
+          existing.destroy();
+        }
 
         // We don't want the old layer hanging around, even if we are going
         // to reuse it.
@@ -971,6 +974,9 @@ SC.CollectionView = SC.View.extend(
             // will likely change the layerId when re-using the view.  So
             // we'll destroy the layer now.
             view.destroyLayer();
+          }
+          else {
+            view.destroy();
           }
         }
       }


### PR DESCRIPTION
Here is the new pull request requested by Peter Wagenet.

To my understanding, item views were never destroyed. This caused random weird behaviour and noticeable performance penalty in long running applications.
