### PR TITLE
SC.SegmentedView doesn't set 'disabled' class name of segments

### DIFF
--- a/frameworks/desktop/renderers/segment.js
+++ b/frameworks/desktop/renderers/segment.js
@@ -35,6 +35,7 @@ SC.BaseTheme.renderers.Segment = SC.Renderer.extend({
     classes["sc-middle-segment"] = this.isMiddleSegment;
     classes["sc-last-segment"] = this.isLastSegment;
     classes["sc-segment"] = YES;
+    classes['disabled'] = !this.isEnabled;
     
     this._class_hash = classes;
     return classes;


### PR DESCRIPTION
It looks like SegmentedView is expecting SC.Control to add the 'disabled' class name, but that doesn't happen, because SC.View is now responsible for rendering that class name (I'm opening a separate issue for that).

Since I believe that SC.View is probably the right renderer of 'disabled', then it's just a matter of rendering it for SegmentedView's too.
