### PR TITLE
SC.CheckboxView mouse handling bug

### DIFF
--- a/frameworks/desktop/views/checkbox.js
+++ b/frameworks/desktop/views/checkbox.js
@@ -71,7 +71,7 @@ SC.CheckboxView = SC.ButtonView.extend(SC.StaticLayout, SC.Button,
   },
   
   mouseUp: function(evt) {
-	this.set('isActive', NO);
+    this.set('isActive', NO);
     this._isMouseDown = NO;
 
     if(!this.get('isEnabled') || 


### PR DESCRIPTION
Hello all,

If you mouse down over an SC.CheckboxView, drag out of the view, release the mouse button, and then hover over the checkbox again, it will appear pressed.  This is because `this._isMouseDown = NO;` is being set after the `mouseUp` function returns when the event occurs outside the bounds of the view.  I just moved the two lines to the top of the function to fix it.

Hope this helps!
Devon
