### PR TITLE
Convert all the console.{log|warn|error} calls that aren't in a test or commented out to use SC.Logger

### DIFF
--- a/frameworks/datastore/system/store.js
+++ b/frameworks/datastore/system/store.js
@@ -841,7 +841,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     SproutCore.
   */
   findAll: function(recordType, conditions, params) {
-    console.warn("SC.Store#findAll() will be removed in a future version of SproutCore.  Use SC.Store#find() instead");
+    SC.Logger.warn("SC.Store#findAll() will be removed in a future version of SproutCore.  Use SC.Store#find() instead");
     
 
     if (!recordType || !recordType.isQuery) {
@@ -2599,7 +2599,7 @@ SC.Store._getDefaultStore = function() {
 */
 SC.Store.updateRecords = function(dataHashes, dataSource, recordType, isLoaded) {
   
-  console.warn("SC.Store.updateRecords() is deprecated.  Use loadRecords() instead");
+  SC.Logger.warn("SC.Store.updateRecords() is deprecated.  Use loadRecords() instead");
   
   var store = this._getDefaultStore(),
       len   = dataHashes.length,

--- a/frameworks/debug/invoke_once_last_debugging.js
+++ b/frameworks/debug/invoke_once_last_debugging.js
@@ -100,7 +100,7 @@ SC.addInvokeOnceLastDebuggingInfo = function() {
               // If we didn't capture information for this invocation, just
               // report what we can.  (We assume we'll always have all three
               // hashes or none.)
-              console.log("Invoking runloop-scheduled method %@ on %@, but we didn’t capture information about who scheduled it…".fmt(mName, target));
+              SC.Logger.log("Invoking runloop-scheduled method %@ on %@, but we didn’t capture information about who scheduled it…".fmt(mName, target));
             }
             else {
               originatingTargets = originatingTargets[originatingKey];             // Could be one target or an array of them
@@ -111,7 +111,7 @@ SC.addInvokeOnceLastDebuggingInfo = function() {
               // scheduled this target/method?  If so, display them all nicely.
               // Otherwise, optimize our output for only one.
               if (originatingMethods  &&  SC.typeOf(originatingMethods) === SC.T_ARRAY) {
-                console.log("Invoking runloop-scheduled method %@ on %@, which was scheduled by multiple target/method pairs:".fmt(mName, target));
+                SC.Logger.log("Invoking runloop-scheduled method %@ on %@, which was scheduled by multiple target/method pairs:".fmt(mName, target));
               
                 var i, len,
                   originatingTarget,
@@ -123,13 +123,13 @@ SC.addInvokeOnceLastDebuggingInfo = function() {
                   originatingMethod = originatingMethod.displayName || originatingMethod;
                   originatingStack  = originatingStacks[i];
   
-                  console.log("[%@]  originated by target %@,  method %@,  stack:".fmt(i, originatingTarget, originatingMethod), originatingStack);
+                  SC.Logger.log("[%@]  originated by target %@,  method %@,  stack:".fmt(i, originatingTarget, originatingMethod), originatingStack);
                 }
               }
               else {
                 var originatingMethodName = originatingMethods.displayName || originatingMethods;
 
-                console.log("Invoking runloop-scheduled method %@ on %@.  Originated by target %@,  method %@,  stack: ".fmt(mName, target, originatingTargets, originatingMethodName), originatingStacks);
+                SC.Logger.log("Invoking runloop-scheduled method %@ on %@.  Originated by target %@,  method %@,  stack: ".fmt(mName, target, originatingTargets, originatingMethodName), originatingStacks);
               }
             }
           }

--- a/frameworks/designer/views/drawing.js
+++ b/frameworks/designer/views/drawing.js
@@ -173,15 +173,15 @@ SC.DrawingView = SC.View.extend({
             this._drawShapes(cntx);
           }
           else {
-            console.error("SC.DrawingView.render(): Canvas object context is not accessible.");
+            SC.Logger.error("SC.DrawingView.render(): Canvas object context is not accessible.");
           }
         }
         else {
-          console.error("SC.DrawingView.render(): Canvas element array length is zero.");
+          SC.Logger.error("SC.DrawingView.render(): Canvas element array length is zero.");
         }
       }
       else {
-        console.error("SC.DrawingView.render(): Canvas element is not accessible.");
+        SC.Logger.error("SC.DrawingView.render(): Canvas element is not accessible.");
       }
     }
     
@@ -190,7 +190,7 @@ SC.DrawingView = SC.View.extend({
   
   registerShapeDrawing: function(name, drawingFunction){
     if (!name) {
-      console.error('Can\'t register this drawing paradigm because name is null');
+      SC.Logger.error('Can\'t register this drawing paradigm because name is null');
       return NO;
     }
     

--- a/frameworks/desktop/mixins/navigation_builder.js
+++ b/frameworks/desktop/mixins/navigation_builder.js
@@ -34,7 +34,7 @@ SC.NavigationBuilder = {
       this.mixin(animatable);
     } else if (!animatable) { 
       // check that we actually have SC.Animatable
-      console.error(
+      SC.Logger.error(
         "SC.NavigationView and SC.NavigationBuilder require SC.Animatable " + 
         "to perform animations, but it is not present. Please ensure your app or framework " +
         "references it."

--- a/frameworks/desktop/mixins/scrollable.js
+++ b/frameworks/desktop/mixins/scrollable.js
@@ -22,7 +22,7 @@ SC.Scrollable = {
   
 //@if(debug)
   initMixin: function() {
-    console.warn("SC.Scrollable is deprecated and will be removed in a future version of SproutCore.  Consider pulling the mixin into your own app if you want to keep using it.");
+    SC.Logger.warn("SC.Scrollable is deprecated and will be removed in a future version of SproutCore.  Consider pulling the mixin into your own app if you want to keep using it.");
   },
 //@endif 
 

--- a/frameworks/desktop/system/drag.js
+++ b/frameworks/desktop/system/drag.js
@@ -451,14 +451,14 @@ SC.Drag = SC.Object.extend(
         op = SC.DRAG_NONE;
       }
     } catch (e) {
-      console.error('Exception in SC.Drag.mouseUp(acceptDragOperation|performDragOperation): %@'.fmt(e)) ;
+      SC.Logger.error('Exception in SC.Drag.mouseUp(acceptDragOperation|performDragOperation): %@'.fmt(e)) ;
     }
     
     try {
       // notify last drop target that the drag exited, to allow it to cleanup
       if (target && target.dragExited) target.dragExited(this, evt) ;
     } catch (ex) {
-      console.error('Exception in SC.Drag.mouseUp(target.dragExited): %@'.fmt(ex)) ;
+      SC.Logger.error('Exception in SC.Drag.mouseUp(target.dragExited): %@'.fmt(ex)) ;
     }
     
     // notify all drop targets that the drag ended
@@ -467,7 +467,7 @@ SC.Drag = SC.Object.extend(
       try {
         ary[idx].tryToPerform('dragEnded', this, evt) ;
       } catch (ex2) {
-        console.error('Exception in SC.Drag.mouseUp(dragEnded on %@): %@'.fmt(ary[idx], ex2)) ;
+        SC.Logger.error('Exception in SC.Drag.mouseUp(dragEnded on %@): %@'.fmt(ary[idx], ex2)) ;
       }
     }
 

--- a/frameworks/desktop/views/button.js
+++ b/frameworks/desktop/views/button.js
@@ -521,7 +521,7 @@ SC.ButtonView = SC.View.extend(SC.Control, SC.Button,
             paddingLeft = parseInt(label.css('paddingLeft'),0),
             marginRight = parseInt(label.css('marginRight'),0),
             marginLeft = parseInt(label.css('marginLeft'),0);
-        if(marginRight=='auto') console.log(marginRight+","+marginLeft+","+paddingRight+","+paddingLeft);
+        if(marginRight=='auto') SC.Logger.log(marginRight+","+marginLeft+","+paddingRight+","+paddingLeft);
         if(!paddingRight && isNaN(paddingRight)) paddingRight = 0;
         if(!paddingLeft && isNaN(paddingLeft)) paddingLeft = 0;
         if(!marginRight && isNaN(marginRight)) marginRight = 0;

--- a/frameworks/desktop/views/file.js
+++ b/frameworks/desktop/views/file.js
@@ -97,7 +97,7 @@ SC.FileView = SC.FieldView.extend(
     
   */
   setFieldValue: function(newValue) {
-    console.log("SC.FileView: setFieldValue: %@ does nothing".fmt(newValue));
+    SC.Logger.log("SC.FileView: setFieldValue: %@ does nothing".fmt(newValue));
     //if (newValue) throw SC.$error('SC.FileView can not set the value of the file field');
   },
   

--- a/frameworks/foundation/mixins/collection_content.js
+++ b/frameworks/foundation/mixins/collection_content.js
@@ -159,7 +159,7 @@ SC.CollectionContent = {
     @returns {void}
   */
   contentIndexExpand: function(view, content, idx) {
-    console.log('contentIndexExpand(%@, %@, %@)'.fmt(view,content,idx));
+    SC.Logger.log('contentIndexExpand(%@, %@, %@)'.fmt(view,content,idx));
   },
   
   /**
@@ -172,7 +172,7 @@ SC.CollectionContent = {
     @returns {void}
   */
   contentIndexCollapse: function(view, content, idx) {
-    console.log('contentIndexCollapse(%@, %@, %@)'.fmt(view,content,idx));
+    SC.Logger.log('contentIndexCollapse(%@, %@, %@)'.fmt(view,content,idx));
   }
     
 };

--- a/frameworks/foundation/mixins/responder_context.js
+++ b/frameworks/foundation/mixins/responder_context.js
@@ -128,7 +128,7 @@ SC.ResponderContext = {
 
     if (this._locked) {
       if (trace) {
-        console.log('%@: AFTER ACTION: makeFirstResponder => %@'.fmt(this, this.responderNameFor(responder)));
+        SC.Logger.log('%@: AFTER ACTION: makeFirstResponder => %@'.fmt(this, this.responderNameFor(responder)));
       }
 
       this._pendingResponder = responder;
@@ -136,7 +136,7 @@ SC.ResponderContext = {
     }
     
     if (trace) {
-      console.log('%@: makeFirstResponder => %@'.fmt(this, this.responderNameFor(responder)));
+      SC.Logger.log('%@: makeFirstResponder => %@'.fmt(this, this.responderNameFor(responder)));
     }
     
     if (responder) responder.set("becomingFirstResponder", YES);
@@ -233,7 +233,7 @@ SC.ResponderContext = {
 
     this._locked = YES;
     if (trace) {
-      console.log("%@: begin action '%@' (%@, %@)".fmt(this, action, sender, context));
+      SC.Logger.log("%@: begin action '%@' (%@, %@)".fmt(this, action, sender, context));
     }
 
     if (!handled && !working && this.tryToPerform) {
@@ -251,8 +251,8 @@ SC.ResponderContext = {
     }
 
     if (trace) {
-      if (!handled) console.log("%@:  action '%@' NOT HANDLED".fmt(this,action));
-      else console.log("%@: action '%@' handled by %@".fmt(this, action, this.responderNameFor(working)));
+      if (!handled) SC.Logger.log("%@:  action '%@' NOT HANDLED".fmt(this,action));
+      else SC.Logger.log("%@: action '%@' handled by %@".fmt(this, action, this.responderNameFor(working)));
     }
     
     this._locked = NO ;

--- a/frameworks/foundation/panes/pane.js
+++ b/frameworks/foundation/panes/pane.js
@@ -937,7 +937,7 @@ SC.Pane = SC.View.extend(SC.ResponderContext,
   init: function() {
     // Backwards compatibility
     if (this.hasTouchIntercept === YES) {
-      console.warn("Do not set hasTouchIntercept directly. Use wantsTouchIntercept instead.");
+      SC.Logger.warn("Do not set hasTouchIntercept directly. Use wantsTouchIntercept instead.");
       this.hasTouchIntercept = SC.platform.touch;
     }
 

--- a/frameworks/foundation/system/benchmark.js
+++ b/frameworks/foundation/system/benchmark.js
@@ -195,7 +195,7 @@ SC.Benchmark = {
     }
     var start = stat._starts.pop() ;
     if (!start) {
-      console.log('SC.Benchmark "%@" ended without a matching start.  No information was saved.'.fmt(key));
+      SC.Logger.log('SC.Benchmark "%@" ended without a matching start.  No information was saved.'.fmt(key));
       return ;
     }
 
@@ -503,7 +503,7 @@ SC.Benchmark = {
     // log each line to make this easier to read on an iPad
     var lines = this.report(key).split('\n'),
         len   = lines.length, idx;
-    for(idx=0;idx<len;idx++) console.log(lines[idx]);
+    for(idx=0;idx<len;idx++) SC.Logger.log(lines[idx]);
   },
   
   /**
@@ -512,12 +512,12 @@ SC.Benchmark = {
   */
   startProfile: function(key) {
     if (!this.enabled) return ;
-    if (console && console.profile) console.profile(key) ;
+    SC.Logger.profile(key) ;
   },
   
   endProfile: function(key) {
     if (!this.enabled) return ;
-    if (console && console.profileEnd) console.profileEnd(key) ;
+    SC.Logger.profileEnd(key) ;
   },
   
   // PRIVATE METHODS

--- a/frameworks/foundation/system/datetime.js
+++ b/frameworks/foundation/system/datetime.js
@@ -945,7 +945,7 @@ SC.DateTime.mixin(SC.Comparable,
         }
       }
     } catch (e) {
-      console.log('SC.DateTime.createFromString ' + e.toString());
+      SC.Logger.log('SC.DateTime.createFromString ' + e.toString());
       return null;
     }
     

--- a/frameworks/foundation/system/module.js
+++ b/frameworks/foundation/system/module.js
@@ -44,13 +44,13 @@ SC.Module = SC.Object.create(/** @scope SC.Module */ {
       if(SC.LAZY_INSTANTIATION[moduleName]) {
         var lazyInfo = SC.LAZY_INSTANTIATION[moduleName];
 
-      if (SC.LOG_MODULE_LOADING) console.log("SC.loadModule(): Module '%@' is marked for lazy instantiation, instantiating it now…".fmt(moduleName));            
+      if (SC.LOG_MODULE_LOADING) SC.Logger.log("SC.loadModule(): Module '%@' is marked for lazy instantiation, instantiating it now…".fmt(moduleName));            
         
         for(var i=0, iLen = lazyInfo.length; i<iLen; i++) {
           try { 
             lazyInfo[i]();
           }catch(e) {
-            console.error("SC.loadModule(): Failted to lazily instatiate entry for  '%@'".fmt(moduleName));  
+            SC.Logger.error("SC.loadModule(): Failted to lazily instatiate entry for  '%@'".fmt(moduleName));  
           }
         }
         delete SC.LAZY_INSTANTIATION[moduleName];
@@ -101,7 +101,7 @@ SC.Module = SC.Object.create(/** @scope SC.Module */ {
     // If the method exists, try to call it. It could have been loaded 
     // through other means but the SC.MODULE_INFO entry doesn't exist.
     if(m || SC.LAZY_INSTANTIATION[moduleName]) {
-      if(SC.LOG_MODULE_LOADING) console.log("SC.loadModule(): Module '%@' found through other means, will attempt to load…".fmt(moduleName));
+      if(SC.LOG_MODULE_LOADING) SC.Logger.log("SC.loadModule(): Module '%@' found through other means, will attempt to load…".fmt(moduleName));
       SC.MODULE_INFO[moduleName] = {loaded: YES};
       return SC.MODULE_INFO[moduleName]; 
     }
@@ -128,11 +128,11 @@ SC.Module = SC.Object.create(/** @scope SC.Module */ {
         log        = SC.LOG_MODULE_LOADING;
 
     if (log) {
-      console.log("SC.loadModule(): Attempting to load '%@'".fmt(moduleName));
+      SC.Logger.log("SC.loSC.Logger.adModule(): Attempting to load '%@'".fmt(moduleName));
     }
     
     if (!moduleInfo) {
-      if (log) console.log("SC.loadModule(): Attemping to load %@ without SC.MODULE_INFO entry… could be loaded through other means.".fmt(moduleName));
+      if (log) SC.Logger.log("SC.loadModule(): Attemping to load %@ without SC.MODULE_INFO entry… could be loaded through other means.".fmt(moduleName));
       moduleInfo = this.tryToLoadModule(moduleName, target, method, args);
     }
     
@@ -141,7 +141,7 @@ SC.Module = SC.Object.create(/** @scope SC.Module */ {
       throw "SC.loadModule(): could not find module '%@'".fmt(moduleName) ;
     } else if (moduleInfo.loaded) {
 
-      if (log) console.log("SC.loadModule(): Module '%@' already loaded, skipping.".fmt(moduleName));
+      if (log) SC.Logger.log("SC.loadModule(): Module '%@' already loaded, skipping.".fmt(moduleName));
 
       if(method) {
         // call callback immediately if we're already loaded and SC.isReady
@@ -156,7 +156,7 @@ SC.Module = SC.Object.create(/** @scope SC.Module */ {
       }
     } else {
 
-      if (log) console.log("SC.loadModule(): Module '%@' is not loaded, loading now.".fmt(moduleName));
+      if (log) SC.Logger.log("SC.loadModule(): Module '%@' is not loaded, loading now.".fmt(moduleName));
 
       // queue callback for later
       callbacks = moduleInfo.callbacks || [] ;
@@ -193,7 +193,7 @@ SC.Module = SC.Object.create(/** @scope SC.Module */ {
 
               dependents.push(moduleName) ;
 
-              if (log) console.log("SC.loadModule(): '%@' depends on '%@', loading dependency…".fmt(moduleName, targetName));
+              if (log) SC.Logger.log("SC.loadModule(): '%@' depends on '%@', loading dependency…".fmt(moduleName, targetName));
               
               // recursively load targetName so it's own dependencies are
               // loaded first.
@@ -258,7 +258,7 @@ SC.Module = SC.Object.create(/** @scope SC.Module */ {
         var url = q.shift();
         
         if (url) {
-          if (SC.LOG_MODULE_LOADING) console.log("SC.scriptDidLoad(): Loading next file in '%@' -> '%@'".fmt(moduleName, url));
+          if (SC.LOG_MODULE_LOADING) SC.Logger.log("SC.scriptDidLoad(): Loading next file in '%@' -> '%@'".fmt(moduleName, url));
 
           var el = document.createElement('script') ;
           el.setAttribute('type', "text/javascript") ;
@@ -289,7 +289,7 @@ SC.Module = SC.Object.create(/** @scope SC.Module */ {
       return;
     }
     if (moduleInfo.loaded && log) {
-      console.log("SC.moduleDidLoad() called more than once for module '%@'. Skipping.".fmt(moduleName));
+      SC.Logger.log("SC.moduleDidLoad() called more than once for module '%@'. Skipping.".fmt(moduleName));
       return ;
     }
     
@@ -309,7 +309,7 @@ SC.Module = SC.Object.create(/** @scope SC.Module */ {
     // for each dependent module, try and load them again...
     var dependents = moduleInfo.dependents || [] ;
     for (var idx=0, len=dependents.length; idx<len; ++idx) {
-      if (log) console.log("SC.loadModule(): Module '%@' has completed loading, loading '%@' that depended on it.".fmt(moduleName, dependents[idx]));
+      if (log) SC.Logger.log("SC.loadModule(): Module '%@' has completed loading, loading '%@' that depended on it.".fmt(moduleName, dependents[idx]));
       SC.Module.loadModule(dependents[idx]) ;
     }
   },
@@ -319,7 +319,7 @@ SC.Module = SC.Object.create(/** @scope SC.Module */ {
     var moduleInfo = SC.MODULE_INFO[moduleName], callbacks ;
     if (!moduleInfo) return ; // shouldn't happen, but recover anyway
     
-    if (SC.LOG_MODULE_LOADING) console.log("SC.loadModule(): Module '%@' has completed loading, invoking callbacks.".fmt(moduleName));
+    if (SC.LOG_MODULE_LOADING) SC.Logger.log("SC.loadModule(): Module '%@' has completed loading, invoking callbacks.".fmt(moduleName));
 
     callbacks = moduleInfo.callbacks || [] ;
     

--- a/frameworks/foundation/system/ready.js
+++ b/frameworks/foundation/system/ready.js
@@ -58,7 +58,7 @@ SC.mixin({
     }
 
     if (SC.browser.safari && SC.browser.safari < 530.0 ) {
-      console.error("ready() is not yet supported on Safari 3.1 and earlier");
+      SC.Logger.error("ready() is not yet supported on Safari 3.1 and earlier");
       // TODO: implement ready() in < Safari 4 
       // var numStyles;
       // (function(){

--- a/frameworks/foundation/system/render_context.js
+++ b/frameworks/foundation/system/render_context.js
@@ -607,7 +607,7 @@ SC.RenderContext = SC.Builder.create(/** SC.RenderContext.fn */ {
   */
   addClass: function(nameOrClasses) {
     if(nameOrClasses === undefined || nameOrClasses === null) {
-      console.warn('You are adding an undefined or empty class'+ this.toString());
+      SC.Logger.warn('You are adding an undefined or empty class'+ this.toString());
       return this;
     }
 

--- a/frameworks/foundation/system/root_responder.js
+++ b/frameworks/foundation/system/root_responder.js
@@ -1198,7 +1198,7 @@ SC.RootResponder = SC.Object.extend({
         try { // keep in mind that it might only _be_ here because it crashed...
           if (responder[action]) responder[action](touchEntry, evt);
         } catch(e) {
-          console.error('crashed on endTouch');
+          SC.Logger.error('crashed on endTouch');
         }
         
         // check to see if the responder changed, and stop immediately if so.
@@ -1967,7 +1967,7 @@ SC.RootResponder = SC.Object.extend({
       var view = this.targetViewForEvent(evt) ;
       this.sendEvent('animationDidStart', evt, view) ;
     } catch (e) {
-      console.warn('Exception during animationDidStart: %@'.fmt(e)) ;
+      SC.Logger.warn('Exception during animationDidStart: %@'.fmt(e)) ;
       throw e;
     }
 
@@ -1979,7 +1979,7 @@ SC.RootResponder = SC.Object.extend({
       var view = this.targetViewForEvent(evt) ;
       this.sendEvent('animationDidIterate', evt, view) ;
     } catch (e) {
-      console.warn('Exception during animationDidIterate: %@'.fmt(e)) ;
+      SC.Logger.warn('Exception during animationDidIterate: %@'.fmt(e)) ;
       throw e;
     }
 
@@ -1991,7 +1991,7 @@ SC.RootResponder = SC.Object.extend({
       var view = this.targetViewForEvent(evt) ;
       this.sendEvent('animationDidEnd', evt, view) ;
     } catch (e) {
-      console.warn('Exception during animationDidEnd: %@'.fmt(e)) ;
+      SC.Logger.warn('Exception during animationDidEnd: %@'.fmt(e)) ;
       throw e;
     }
 
@@ -2003,7 +2003,7 @@ SC.RootResponder = SC.Object.extend({
       var view = this.targetViewForEvent(evt) ;
       this.sendEvent('transitionDidEnd', evt, view) ;
     } catch (e) {
-      console.warn('Exception during transitionDidEnd: %@'.fmt(e)) ;
+      SC.Logger.warn('Exception during transitionDidEnd: %@'.fmt(e)) ;
       throw e;
     }
 

--- a/frameworks/foundation/system/user_defaults.js
+++ b/frameworks/foundation/system/user_defaults.js
@@ -83,7 +83,7 @@ SC.UserDefaults = SC.Object.extend(/** @scope SC.UserDefaults.prototype */ {
       try{
         localStorage.load("SC.UserDefaults");
       }catch(e){
-        console.err("Couldn't load userDefaults in IE7: "+e.description);
+        SC.Logger.error("Couldn't load userDefaults in IE7: "+e.description);
       }
     }else if(this.HTML5DB_noLocalStorage){
       storageSafari3 = this._safari3DB;
@@ -183,7 +183,7 @@ SC.UserDefaults = SC.Object.extend(/** @scope SC.UserDefaults.prototype */ {
         try{
           localStorage[key] = encodedValue;
         }catch(e){
-          console.error("Failed using localStorage. "+e);
+          SC.Logger.error("Failed using localStorage. "+e);
         }
       }
     }
@@ -245,7 +245,7 @@ SC.UserDefaults = SC.Object.extend(/** @scope SC.UserDefaults.prototype */ {
         try{
           delete localStorage[key];
         } catch(e) {
-          console.warn('Deleting local storage encountered a problem. '+e);
+          SC.Logger.warn('Deleting local storage encountered a problem. '+e);
         }
       }
     }
@@ -325,7 +325,7 @@ SC.UserDefaults = SC.Object.extend(/** @scope SC.UserDefaults.prototype */ {
       var myDB;
       try {
         if (!window.openDatabase) {
-          console.error("Trying to load a database with safari version 3.1 "+
+          SC.Logger.error("Trying to load a database with safari version 3.1 "+
                   "to get SC.UserDefaults to work. You are either in a"+
                   " previous version or there is a problem with your browser.");
           return;
@@ -340,7 +340,7 @@ SC.UserDefaults = SC.Object.extend(/** @scope SC.UserDefaults.prototype */ {
     
         }
       } catch(e) {
-        console.error("Trying to load a database with safari version 3.1 "+
+        SC.Logger.error("Trying to load a database with safari version 3.1 "+
                 "to get SC.UserDefaults to work. You are either in a"+
                 " previous version or there is a problem with your browser.");
         return;

--- a/frameworks/foundation/views/view.js
+++ b/frameworks/foundation/views/view.js
@@ -2136,7 +2136,7 @@ SC.View = SC.Responder.extend(SC.DelegateSupport,
         } else key = null ;
 
         if (!view) {
-          console.error ("No view with name "+key+" has been found in "+this.toString());
+          SC.Logger.error ("No view with name "+key+" has been found in "+this.toString());
           // skip this one.
           continue;
         }
@@ -2667,7 +2667,7 @@ SC.View = SC.Responder.extend(SC.DelegateSupport,
         stLayout !== undefined && !stLayout) {
       error = SC.Error.desc(("%@.layout() cannot use width:auto if "+
                 "staticLayout is disabled").fmt(this), "%@".fmt(this), -1);
-      console.error(error.toString()) ;
+      SC.Logger.error(error.toString()) ;
       throw error ;
     }
 
@@ -2676,7 +2676,7 @@ SC.View = SC.Responder.extend(SC.DelegateSupport,
         stLayout !== undefined && !stLayout) {
        error = SC.Error.desc(("%@.layout() cannot use height:auto if "+
                 "staticLayout is disabled").fmt(this),"%@".fmt(this), -1);
-       console.error(error.toString())  ;
+       SC.Logger.error(error.toString())  ;
       throw error ;
     }
 
@@ -3134,14 +3134,14 @@ SC.View = SC.Responder.extend(SC.DelegateSupport,
     if (lW !== undefined && lW === SC.LAYOUT_AUTO && !stLayout) {
       error= SC.Error.desc("%@.layout() you cannot use width:auto if ".fmt(this) +
               "staticLayout is disabled","%@".fmt(this),-1);
-      console.error(error.toString()) ;
+      SC.Logger.error(error.toString()) ;
       throw error ;
     }
 
     if (lH !== undefined && lH === SC.LAYOUT_AUTO && !stLayout) {
       error = SC.Error.desc("%@.layout() you cannot use height:auto if ".fmt(this) +
                 "staticLayout is disabled","%@".fmt(this),-1);
-      console.error(error.toString()) ;
+      SC.Logger.error(error.toString()) ;
       throw error ;
     }
 
@@ -3159,7 +3159,7 @@ SC.View = SC.Responder.extend(SC.DelegateSupport,
 
             // TODO: If we want to allow it to be set as just a number for duration we need to add support here
             if (transformAnimationDuration && layout[key].duration !== transformAnimationDuration) {
-              console.warn("Can't animate transforms with different durations! Using first duration specified.");
+              SC.Logger.warn("Can't animate transforms with different durations! Using first duration specified.");
               layout[key].duration = transformAnimationDuration;
             }
             transformAnimationDuration = layout[key].duration;
@@ -3236,7 +3236,7 @@ SC.View = SC.Responder.extend(SC.DelegateSupport,
         ret.marginLeft = Math.floor(lcX - ret.width/2) ;
       }else {
         // This error message happens whenever width is not set.
-        console.warn("You have to set width and centerX using both percentages or pixels");
+        SC.Logger.warn("You have to set width and centerX using both percentages or pixels");
         ret.marginLeft = "50%";
       }
       ret.right = null ;
@@ -3315,7 +3315,7 @@ SC.View = SC.Responder.extend(SC.DelegateSupport,
       }else if(lH && lH >= 1 && !SC.isPercentage(lcY)){
         ret.marginTop = Math.floor(lcY - ret.height/2) ;
       }else {
-        console.warn("You have to set height and centerY to use both percentages or pixels");
+        SC.Logger.warn("You have to set height and centerY to use both percentages or pixels");
         ret.marginTop = "50%";
       }
     } else if (!SC.none(lH)) {
@@ -3508,7 +3508,7 @@ SC.View = SC.Responder.extend(SC.DelegateSupport,
     if (!SC.none(currentLayout.rotate)) {
       if (SC.none(currentLayout.rotateX)) {
         currentLayout.rotateX = currentLayout.rotate;
-        console.warn('Please set rotateX instead of rotate');
+        SC.Logger.warn('Please set rotateX instead of rotate');
       }
     }
     if (!SC.none(currentLayout.rotateX)) {
@@ -3520,7 +3520,7 @@ SC.View = SC.Responder.extend(SC.DelegateSupport,
     if (!SC.none(currentLayout.animateRotate)) {
       if (SC.none(currentLayout.animateRotateX)) {
         currentLayout.animateRotateX = currentLayout.animateRotate;
-        console.warn('Please set animateRotateX instead of animateRotate');
+        SC.Logger.warn('Please set animateRotateX instead of animateRotate');
       }
     }
     if (!SC.none(currentLayout.animateRotateX)) {

--- a/frameworks/media/views/audio.js
+++ b/frameworks/media/views/audio.js
@@ -433,7 +433,7 @@ SC.AudioView = SC.View.extend({
       media.GetVolume(); 
       // add media.GetTimeScale(); ?
     }catch(e){
-      console.log('loaded fail trying later');
+      SC.Logger.log('loaded fail trying later');
       this.invokeLater(this.didAppendToDocument, 100);
       return;
     }
@@ -560,7 +560,7 @@ SC.AudioView = SC.View.extend({
   */
   startSeek: function(){
     if(!this.get('paused')) {
-      console.log('startseetk');
+      SC.Logger.log('startseetk');
       this.stop();
       this._wasPlaying = true;
     }
@@ -574,7 +574,7 @@ SC.AudioView = SC.View.extend({
   */
   endSeek: function(){
     if(this._wasPlaying) {
-      console.log('startseetk');
+      SC.Logger.log('startseetk');
       this.play();
       this._wasPlaying = false;
     }
@@ -715,7 +715,7 @@ SC.AudioView.updateProperty = function(scid, property, value) {
   Function to log events coming from flash.
 */
 SC.AudioView.logFlash = function(message) {
-  console.log("FLASHLOG: "+message);
+  SC.Logger.log("FLASHLOG: "+message);
 } ;
 
 

--- a/frameworks/media/views/video.js
+++ b/frameworks/media/views/video.js
@@ -476,7 +476,7 @@ SC.VideoView = SC.View.extend({
     try{
       vid.GetVolume();
     }catch(e){
-      console.log('loaded fail trying later');
+      SC.Logger.log('loaded fail trying later');
       this.invokeLater(this.didAppendToDocument, 100);
       return;
     }
@@ -629,7 +629,7 @@ SC.VideoView = SC.View.extend({
   */
   startSeek: function(){
     if(!this.get('paused')) {
-      console.log('startseetk');
+      SC.Logger.log('startseetk');
       this.stop();
       this._wasPlaying = true;
     }
@@ -643,7 +643,7 @@ SC.VideoView = SC.View.extend({
   */
   endSeek: function(){
     if(this._wasPlaying) {
-      console.log('startseetk');
+      SC.Logger.log('startseetk');
       this.play();
       this._wasPlaying = false;
     }
@@ -674,7 +674,7 @@ SC.VideoView = SC.View.extend({
       if(this.loaded==="flash") vid.playVideo();
       this.set('paused', NO);
     }catch(e){
-      console.warn('The video cannot play!!!! It might still be loading the plugging');
+      SC.Logger.warn('The video cannot play!!!! It might still be loading the plugging');
     }
   },
   
@@ -800,7 +800,7 @@ SC.VideoView.updateProperty = function(scid, property, value) {
   Function to log events coming from flash.
 */
 SC.VideoView.logFlash = function(message) {
-  console.log("FLASHLOG: "+message);
+  SC.Logger.log("FLASHLOG: "+message);
 } ;
 
 

--- a/frameworks/runtime/mixins/observable.js
+++ b/frameworks/runtime/mixins/observable.js
@@ -10,7 +10,7 @@ require('private/observer_set') ;
 /*globals logChange */
 
 /**
-  Set to YES to have all observing activity logged to the console.  This
+  Set to YES to have all observing activity logged to the SC.Logger.  This
   should be used for debugging only.
 
   @property {Boolean}
@@ -470,7 +470,7 @@ SC.Observable = {
       changes.add(key) ;
 
       if (suspended) {
-        if (log) console.log("%@%@: will not notify observers because observing is suspended".fmt(SC.KVO_SPACES,this));
+        if (log) SC.Logger.log("%@%@: will not notify observers because observing is suspended".fmt(SC.KVO_SPACES,this));
         SC.Observers.objectHasPendingChanges(this) ;
       }
 
@@ -925,7 +925,7 @@ SC.Observable = {
 
     if (log) {
       spaces = SC.KVO_SPACES = (SC.KVO_SPACES || '') + '  ';
-      console.log('%@%@: notifying observers after change to key "%@"'.fmt(spaces, this, key));
+      SC.Logger.log('%@%@: notifying observers after change to key "%@"'.fmt(spaces, this, key));
     }
 
     // Get any starObservers -- they will be notified of all changes.
@@ -967,7 +967,7 @@ SC.Observable = {
           // value is a cacheable property, clear the cached value...
           if (keys && (loc = keys.length)) {
             if (log) {
-              console.log("%@...including dependent keys for %@: %@".fmt(spaces, key, keys));
+              SC.Logger.log("%@...including dependent keys for %@: %@".fmt(spaces, key, keys));
             }
             cache = this._kvo_cache;
             if (!cache) cache = this._kvo_cache = {};
@@ -1006,14 +1006,14 @@ SC.Observable = {
 
             if (member[3] === rev) continue ; // skip notified items.
 
-            if(!member[1]) console.log(member);
+            if(!member[1]) SC.Logger.log(member);
 
             target = member[0] || this;
             method = member[1] ;
             context = member[2];
             member[3] = rev;
 
-            if (log) console.log('%@...firing observer on %@ for key "%@"'.fmt(spaces, target, key));
+            if (log) SC.Logger.log('%@...firing observer on %@ for key "%@"'.fmt(spaces, target, key));
             if (context !== undefined) {
               method.call(target, this, key, null, context, rev);
             } else {
@@ -1034,7 +1034,7 @@ SC.Observable = {
             member = members[memberLoc];
             method = this[member] ; // try to find observer function
             if (method) {
-              if (log) console.log('%@...firing local observer %@.%@ for key "%@"'.fmt(spaces, this, member, key));
+              if (log) SC.Logger.log('%@...firing local observer %@.%@ for key "%@"'.fmt(spaces, this, member, key));
               method.call(this, this, key, null, rev);
             }
           }
@@ -1052,7 +1052,7 @@ SC.Observable = {
             method = member[1] ;
             context = member[2] ;
 
-            if (log) console.log('%@...firing * observer on %@ for key "%@"'.fmt(spaces, target, key));
+            if (log) SC.Logger.log('%@...firing * observer on %@ for key "%@"'.fmt(spaces, target, key));
             if (context !== undefined) {
               method.call(target, this, key, null, context, rev);
             } else {
@@ -1063,7 +1063,7 @@ SC.Observable = {
 
         // if there is a default property observer, call that also
         if (this.propertyObserver) {
-          if (log) console.log('%@...firing %@.propertyObserver for key "%@"'.fmt(spaces, this, key));
+          if (log) SC.Logger.log('%@...firing %@.propertyObserver for key "%@"'.fmt(spaces, this, key));
           this.propertyObserver(this, key, null, rev);
         }
       } // while(changes.length>0)
@@ -1359,7 +1359,7 @@ SC.Observable = {
   removeProbe: function(key) { this.removeObserver(key,SC.logChange); },
 
   /**
-    Logs the named properties to the console.
+    Logs the named properties to the SC.Logger.
 
     @param {String...} propertyNames one or more property names
   */
@@ -1368,7 +1368,7 @@ SC.Observable = {
         prop, propsLen, idx;
     for(idx=0, propsLen = props.length; idx<propsLen; idx++) {
       prop = props[idx] ;
-      console.log('%@:%@: '.fmt(SC.guidFor(this), prop), this.get(prop)) ;
+      SC.Logger.log('%@:%@: '.fmt(SC.guidFor(this), prop), this.get(prop)) ;
     }
   },
 
@@ -1378,7 +1378,7 @@ SC.Observable = {
 
 /** @private used by addProbe/removeProbe */
 SC.logChange = function logChange(target, key, value) {
-  console.log("CHANGE: %@[%@] =>".fmt(target, key), target.get(key));
+  SC.Logger.log("CHANGE: %@[%@] =>".fmt(target, key), target.get(key));
 };
 
 /**

--- a/frameworks/runtime/system/binding.js
+++ b/frameworks/runtime/system/binding.js
@@ -562,7 +562,7 @@ SC.Binding = {
 
     // loop through the changed queue...
     while ((queue = this._changeQueue).length > 0) {
-      if (log) console.log("Begin: Trigger changed bindings") ;
+      if (log) SC.Logger.log("Begin: Trigger changed bindings") ;
 
       didFlush = YES ;
 
@@ -579,7 +579,7 @@ SC.Binding = {
       // now loop back and see if there are additional changes pending in the
       // active queue.  Repeat this until all bindings that need to trigger
       // have triggered.
-      if (log) console.log("End: Trigger changed bindings") ;
+      if (log) SC.Logger.log("End: Trigger changed bindings") ;
     }
 
     // clean up
@@ -608,7 +608,7 @@ SC.Binding = {
     // the from property value will always be the binding value, update if
     // needed.
     if (!this._oneWay && this._fromTarget) {
-      if (log) console.log("%@: %@ -> %@".fmt(this, v, tv)) ;
+      if (log) SC.Logger.log("%@: %@ -> %@".fmt(this, v, tv)) ;
       if (bench) SC.Benchmark.start(this.toString() + "->") ;
       this._fromTarget.setPathIfChanged(this._fromPropertyKey, v) ;
       if (bench) SC.Benchmark.end(this.toString() + "->") ;
@@ -616,7 +616,7 @@ SC.Binding = {
 
     // update the to value with the transformed value if needed.
     if (this._toTarget) {
-      if (log) console.log("%@: %@ <- %@".fmt(this, v, tv)) ;
+      if (log) SC.Logger.log("%@: %@ <- %@".fmt(this, v, tv)) ;
       if (bench) SC.Benchmark.start(this.toString() + "<-") ;
       this._toTarget.setPathIfChanged(this._toPropertyKey, tv) ;
       if (bench) SC.Benchmark.start(this.toString() + "<-") ;

--- a/frameworks/runtime/system/run_loop.js
+++ b/frameworks/runtime/system/run_loop.js
@@ -52,7 +52,7 @@ SC.RunLoop = SC.Object.extend(/** @scope SC.RunLoop.prototype */ {
   beginRunLoop: function() {
     this._start = new Date().getTime() ; // can't use Date.now() in runtime
     if (SC.LOG_BINDINGS || SC.LOG_OBSERVERS) {
-      console.log("-- SC.RunLoop.beginRunLoop at %@".fmt(this._start));
+      SC.Logger.log("-- SC.RunLoop.beginRunLoop at %@".fmt(this._start));
     }
     this._runLoopInProgress = YES;
     return this ;
@@ -83,7 +83,7 @@ SC.RunLoop = SC.Object.extend(/** @scope SC.RunLoop.prototype */ {
     // out completely.
 
     if (SC.LOG_BINDINGS || SC.LOG_OBSERVERS) {
-      console.log("-- SC.RunLoop.endRunLoop ~ flushing application queues");
+      SC.Logger.log("-- SC.RunLoop.endRunLoop ~ flushing application queues");
     } 
     
     this.flushAllPending();
@@ -91,7 +91,7 @@ SC.RunLoop = SC.Object.extend(/** @scope SC.RunLoop.prototype */ {
     this._start = null ;
 
     if (SC.LOG_BINDINGS || SC.LOG_OBSERVERS) {
-      console.log("-- SC.RunLoop.endRunLoop ~ End");
+      SC.Logger.log("-- SC.RunLoop.endRunLoop ~ End");
     }
 
     SC.RunLoop.lastRunLoopEnd = Date.now();


### PR DESCRIPTION
This patch converts all the calls to console.{log|warn|error} littered throughout the source code--that wasn't in a test or commented out--to use SC.Logger. This encapsulates the console object away from the rest of the code and allows users to easily switch SC.Logger's reporter to something other than the console object, e.g. in a server-side scenario. We have SC.Logger, we might as well use it.

All tests pass except for a few that have nothing to do with this patch.
