### PR TITLE
Remove unused variable

### DIFF
--- a/frameworks/runtime/core.js
+++ b/frameworks/runtime/core.js
@@ -248,8 +248,6 @@ SC.mixin(/** @scope SC */ {
     @returns {Boolean}
   */
   isArray: function(obj) {
-    var type;
-
     if ( !obj || obj.setInterval ) {
       return false;
     } else if ( obj.objectAt ) {


### PR DESCRIPTION
Found an unused variable in SC.isArray(). Simple commit removes it.
