### PR TITLE
Mc

### DIFF
--- a/frameworks/desktop/views/list_item.js
+++ b/frameworks/desktop/views/list_item.js
@@ -609,6 +609,13 @@ SC.ListItemView = SC.View.extend(
   inlineEditorShouldEndEditing: function(inlineEditor, finalValue) {
    return YES ;
   },
+ 
+  /** @private
+   I suppose it makes sense to commit
+  */ 
+  inlineEditorShouldCommitEditing: function(inlineEditor){
+    return YES;
+  },
   
   /** @private
    Update the field value and make it visible again.

--- a/frameworks/foundation/mixins/inline_text_field.js
+++ b/frameworks/foundation/mixins/inline_text_field.js
@@ -127,8 +127,9 @@ SC.InlineTextFieldView = SC.TextFieldView.extend(
     }
     
     this._originalValue = options.value;
-    if (SC.none(this._originalValue))
+    if (SC.none(this._originalValue)){
       this._originalValue = "";
+    }
     this._multiline = (options.multiline !== undefined) ? options.multiline : NO ;
     if (this._multiline) {
       this.set('isTextArea', YES);
@@ -143,12 +144,11 @@ SC.InlineTextFieldView = SC.TextFieldView.extend(
     //this.set('selectedRange', options.selectedRange || { start: this._originalValue.length, length: 0 }) ;
     
     // add to window.
-    
-    pane = options.pane;
-
+    //modified to get the pane and tarLayout from the delegate;
+    pane = del.get('pane');
     layout.height = this._optframe.height;
     layout.width=this._optframe.width;
-    tarLayout = options.layout;
+    tarLayout = del.get('layout');
     paneElem = pane.$()[0];
     if (this._optIsCollection && tarLayout.left) {
       layout.left=this._optframe.x-tarLayout.left-paneElem.offsetLeft-1;

--- a/frameworks/foundation/views/label.js
+++ b/frameworks/foundation/views/label.js
@@ -191,12 +191,11 @@ SC.LabelView = SC.View.extend(SC.Control, SC.InlineEditorDelegate, SC.InlineEdit
     layer.css('opacity', 0.0);
   },
   
-  
   /** @private 
     Hide the label view while the inline editor covers it.
   */
   inlineEditorDidBeginEditing: function(editor) {
-    this._oldOpacity = this.get('layout').opacity ;
+    this._oldOpacity = this.get('layout').opacity ||1 ;
     this.adjust('opacity', 0);
   },
   
@@ -205,7 +204,7 @@ SC.LabelView = SC.View.extend(SC.Control, SC.InlineEditorDelegate, SC.InlineEdit
   */
   inlineEditorDidEndEditing: function(editor, finalValue) {
     this.setIfChanged('value', finalValue) ;
-    this.adjust('opacity', this._oldOpacity);
+    this.adjust('opacity',  this._oldOpacity);
     this._oldOpacity = null ;
     this.set('isEditing', NO) ;
   }


### PR DESCRIPTION
fixed:  inline editor in LabelView was turning label to opacity==0 after editing 

fixed:  ListItem inline editing was requiring variables for 'pane' and 'tarLayout'; changed to pull the 'pane' and 'tarLayout' from the properties of the delegate
