### PR TITLE
Mikail cliftov

### DIFF
--- a/frameworks/desktop/views/list_item.js
+++ b/frameworks/desktop/views/list_item.js
@@ -591,6 +591,13 @@ SC.ListItemView = SC.View.extend(
   },
   
   /** @private
+  *** Should Commit?
+  */
+  inlineEditorShouldCommitEditing:function(inlineEditor){
+    return YES;
+  },
+  
+  /** @private
    Set editing to true so edits will no longer be allowed.
   */
   inlineEditorWillBeginEditing: function(inlineEditor) {

--- a/frameworks/foundation/mixins/inline_text_field.js
+++ b/frameworks/foundation/mixins/inline_text_field.js
@@ -127,8 +127,9 @@ SC.InlineTextFieldView = SC.TextFieldView.extend(
     }
     
     this._originalValue = options.value;
-    if (SC.none(this._originalValue))
-      this._originalValue = "";
+    if (SC.none(this._originalValue)){  //style cleanup to conform;  surrounded single line if statement with {}
+      this._originalValue = ""; 
+    }
     this._multiline = (options.multiline !== undefined) ? options.multiline : NO ;
     if (this._multiline) {
       this.set('isTextArea', YES);
@@ -144,11 +145,25 @@ SC.InlineTextFieldView = SC.TextFieldView.extend(
     
     // add to window.
     
-    pane = options.pane;
+    
+    //pane isn't passed when a collection item is being edited.
+    //pane = options.pane;
+    if (this._optIsCollection){
+      pane = del.get('pane');
+    }else{
+      pane = options.pane;
+    }
+    
 
     layout.height = this._optframe.height;
     layout.width=this._optframe.width;
-    tarLayout = options.layout;
+    //layout isn't passed when a collection item is being edited
+    //tarLayout = options.layout;
+    if (this._optIsCollection){
+      tarLayout = del.get('layout');
+    }else{
+      tarLayout = options.layout;
+    }
     paneElem = pane.$()[0];
     if (this._optIsCollection && tarLayout.left) {
       layout.left=this._optframe.x-tarLayout.left-paneElem.offsetLeft-1;
@@ -245,6 +260,7 @@ SC.InlineTextFieldView = SC.TextFieldView.extend(
     
     if (!this.get('isEditing') || !del) return YES ;
     
+    //ListItem doesn't have this method so I created it!
     if (!del.inlineEditorShouldCommitEditing(this, finalValue)) {
       //@if(debug)
       SC.Logger.warn('InlineTextField._endEditing() cannot end without inlineEditorShouldCommitEditing() on the delegate.');

--- a/frameworks/foundation/views/label.js
+++ b/frameworks/foundation/views/label.js
@@ -187,7 +187,7 @@ SC.LabelView = SC.View.extend(SC.Control, SC.InlineEditorDelegate, SC.InlineEdit
   */
   inlineEditorDidBeginEditing: function(inlineEditor) {
     var layer = this.$();
-    this._oldOpacity = layer.css('opacity') ;
+    this._oldOpacity = layer.css('opacity'); 
     layer.css('opacity', 0.0);
   },
   
@@ -196,7 +196,10 @@ SC.LabelView = SC.View.extend(SC.Control, SC.InlineEditorDelegate, SC.InlineEdit
     Hide the label view while the inline editor covers it.
   */
   inlineEditorDidBeginEditing: function(editor) {
-    this._oldOpacity = this.get('layout').opacity ;
+    //doesn't work if the layout doesn't explicity set an opacity
+    //this._oldOpacity = this.get('layout').opacity ;
+    var layer = this.$();
+    this._oldOpacity = layer.css('opacity');  //gets the opacity from the layer
     this.adjust('opacity', 0);
   },
   


### PR DESCRIPTION
multiple fixes to inline editor: 
1.  ListItemView doesn't pass either pane or layout in the options array.  Added if/else statements to pull the pane and layout information from the delegate. 
2.  ListItemView did not have a method: inlineEditorShouldCommitEditing;  method added with default to YES
   1.  LabelView's inlineEditorDidBeginEditing function (which hides the original LabelView for ediitng), was saving the LabelViews opacity from the value of the layout's opacity.  This value can be undefined, and when editing completes the LabelView's opacity is then set to undefined and the label is invisible. *

**\* I can't figure out how to unit test these items, but the behaviour of the invisible LabelView can be seen in the test at: http://localhost:4020/sproutcore/foundation/en/current/tests/views/label/ui.html If someone wants to give me an example of how to test the ListItems, I'd be happy to write the tests, but I can't figure it out (boohoo for me);
