### PR TITLE
Fixed an issue that prevented inline editing inside SourceView

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ tmp/
 bin
 .bundle
 Gemfile*
+.project

--- a/frameworks/desktop/views/list_item.js
+++ b/frameworks/desktop/views/list_item.js
@@ -554,8 +554,10 @@ SC.ListItemView = SC.View.extend(
     escapeHTML = this.get('escapeHTML');
 
     ret = SC.InlineTextFieldView.beginEditing({
-      frame: f, 
-      exampleElement: el, 
+    	pane: this.get('pane'),
+    	frame: f, 
+      exampleElement: el,
+      layout: this.get('layout'),
       delegate: this, 
       value: v,
       multiline: NO,
@@ -575,6 +577,10 @@ SC.ListItemView = SC.View.extend(
   commitEditing: function() {
    if (!this.get('isEditing')) return YES ;
    return SC.InlineTextFieldView.commitEditing();
+  },
+  
+  inlineEditorShouldCommitEditing: function() {
+  		return YES;
   },
   
   discardEditing: function() {


### PR DESCRIPTION
I have following code in my main_page

```
                flows : SC.SourceListView.design({
                    layout: { top: 0, left: 0, bottom: 0, right: 0 },
                    contentValueKey : 'name',
                    contentBinding : 'Elastic.flowsController.content',
                    selectionBinding : 'Elastic.flowsController.selection',
                    selectOnMouseDown: YES,
                    canEditContent: YES
                }),
```

However inline editing of SourceListView content wasn't able because one parameter was missing from the call to SC.InlineTextFieldView.beginEditing, namely the pane was missing. That led to the fatal exception. My fix adding a missing parameter so now everything works fine.
I also added a new line to .gitignore to ignore Eclipse artifact (.project).
