### PR TITLE
Label view changes

### DIFF
--- a/frameworks/foundation/english.lproj/label.css
+++ b/frameworks/foundation/english.lproj/label.css
@@ -1,5 +1,10 @@
 /* SC.LabelView */
 
+.sc-label-view {
+  font-weight: normal;
+  text-align: left;
+}
+
 .sc-label-view.sc-large-size {
 	font-size: 18px;
 	line-height: 24px;

--- a/frameworks/foundation/render_delegates/label.js
+++ b/frameworks/foundation/render_delegates/label.js
@@ -45,11 +45,13 @@ SC.BaseTheme.labelRenderDelegate = SC.RenderDelegate.create({
       ariaLabeledBy = view.get('ariaLabeledBy');
     }
 
-    // CONSIDER DEPRECATING THESE PROPERTIES BECAUSE THEY ARE
-    // ANNOYING PAINS IN THE BUTT THAT EVERYONE HATES
+    /*
+      TODO [CC @ 1.5] These properties have been deprecated. We should remove them
+            in the next release
+    */
     context.addStyle({
-      'textAlign': dataSource.get('textAlign'),
-      'fontWeight': dataSource.get('fontWeight')
+      fontWeight: dataSource.get('fontWeight') || null,
+      textAlign: dataSource.get('textAlign') || null
     });
     
     context.setClass('ellipsis', dataSource.get('needsEllipsis') || NO);
@@ -77,11 +79,13 @@ SC.BaseTheme.labelRenderDelegate = SC.RenderDelegate.create({
       ariaLabeledBy = view.get('ariaLabeledBy');
     }
 
-    // CONSIDER DEPRECATING THESE PROPERTIES BECAUSE THEY ARE
-    // ANNOYING PAINS IN THE BUTT THAT EVERYONE HATES
+    /*
+      TODO [CC @ 1.5] These properties have been deprecated. We should remove them
+            in the next release
+    */
     jquery.css({
-      'textAlign': dataSource.get('textAlign') || null,
-      'fontWeight': dataSource.get('fontWeight') || null
+      fontWeight: dataSource.get('fontWeight') || null,
+      textAlign: dataSource.get('textAlign') || null
     });
     
     jquery.setClass('ellipsis', dataSource.get('needsEllipsis') || NO);

--- a/frameworks/foundation/tests/views/label/ui.js
+++ b/frameworks/foundation/tests/views/label/ui.js
@@ -106,13 +106,14 @@ test("Check that all Label are visible", function() {
 });
   
 
-test("Check that all labels have the right classes set", function() {
+test("Check that all labels have the right classes and styles set", function() {
   var viewElem=pane.view('basic').$();
   ok(viewElem.hasClass('sc-view'), 'basic.hasClass(sc-view) should be YES');
   ok(viewElem.hasClass('sc-label-view'), 'basic.hasClass(sc-label-view) should be YES');
   ok(!viewElem.hasClass('icon'), 'basic.hasClass(icon) should be NO');
   ok(!viewElem.hasClass('disabled'), 'basic.hasClass(disabled) should be YES');
-  
+  ok(viewElem.css('fontWeight') === 'normal', 'basic should have normal fontWeight');
+  ok(viewElem.css('textAlign') === 'left', 'basic should have left textAlign');
   
   viewElem=pane.view('disabled').$();
   ok(viewElem.hasClass('sc-view'), 'title.hasClass(sc-view) should be YES');
@@ -137,12 +138,14 @@ test("Check that all labels have the right classes set", function() {
   ok(viewElem.hasClass('sc-label-view'), 'title,icon.hasClass(sc-label-view) should be YES');
   ok(!viewElem.hasClass('icon'), 'title,icon.hasClass(icon) should be YES');
   ok(!viewElem.hasClass('disabled'), 'title,icon.hasClass(disabled) should be NO');
+  ok(viewElem.css('textAlign') === 'center', 'centered should have center textAlign');
  
   viewElem=pane.view('centered,icon').$();
   ok(viewElem.hasClass('sc-view'), 'title,icon,disabled.hasClass(sc-view) should be YES');
   ok(viewElem.hasClass('sc-label-view'), 'title,icon,disabled.hasClass(sc-label-view) should be YES');
   ok(viewElem.hasClass('icon'), 'title,icon,disabled.hasClass(icon) should be YES');
   ok(!viewElem.hasClass('disabled'), 'title,icon,disabled.hasClass(disabled) should be YES');
+  ok(viewElem.css('textAlign') === 'center', 'centered,icon should have center textAlign');
  
   viewElem=pane.view('regular size').$();
   ok(viewElem.hasClass('sc-view'), 'title,icon,default.hasClass(sc-view) should be YES');
@@ -155,6 +158,7 @@ test("Check that all labels have the right classes set", function() {
   ok(viewElem.hasClass('sc-label-view'), 'title,icon,selected.hasClass(sc-label-view) should be YES');
   ok(!viewElem.hasClass('icon'), 'title,icon,selected.hasClass(icon) should be YES');
   ok(!viewElem.hasClass('disabled'), 'title,icon,selected.hasClass(disabled) should be NO');
+  ok(viewElem.css('fontWeight') === 'bold', 'bold view should have bold fontWeight');
    
 });
 
@@ -171,4 +175,5 @@ test("Check that the aria-labelledby is set to Label View", function() {
   var viewElem=pane.view('aria-labelledby').$();
   equals(viewElem.attr('aria-labelledby'), 'Label View', 'should have value set to Label view');
 });
+
 })();

--- a/frameworks/foundation/views/label.js
+++ b/frameworks/foundation/views/label.js
@@ -62,8 +62,12 @@ SC.LabelView = SC.View.extend(SC.Control, SC.InlineEditorDelegate, SC.InlineEdit
   
   /**
     Specify the font weight for this.  You may pass SC.REGULAR_WEIGHT, or SC.BOLD_WEIGHT.
+    
+    @property {String} SC.REGULAR_WEIGHT|SC.BOLD_WEIGHT
+    @default null
+    @deprecated
   */
-  fontWeight: SC.REGULAR_WEIGHT,
+  fontWeight: null,
   
   /**
     If true, value will be escaped to avoid scripting attacks.
@@ -113,8 +117,12 @@ SC.LabelView = SC.View.extend(SC.Control, SC.InlineEditorDelegate, SC.InlineEdit
   
   /**
     Set the alignment of the label view.
+    
+    @property {String} SC.ALIGN_LEFT|SC.ALIGN_MIDDLE|SC.ALIGN_RIGHT
+    @default null
+    @deprecated
   */
-  textAlign: SC.ALIGN_LEFT,
+  textAlign: null,
 
   /**
     The name of the theme's SC.LabelView render delegate.


### PR DESCRIPTION
Deprecated the fontWeight and textAlign properties on LabelView. Everything still works as expected if someone sets those properties on a design/subclass. Defaults are now in CSS. Tests are updated (and actually more thorough). Pull req'ing this because I know we've been talking about doing this for a while and wanted to run it by everyone
