### PR TITLE
Custom error message broke datasource framework

### DIFF
--- a/frameworks/datastore/models/record.js
+++ b/frameworks/datastore/models/record.js
@@ -398,7 +398,7 @@ SC.Record = SC.Object.extend(
     
     attrs = store.readEditableDataHash(storeKey);
     if (!attrs) {
-      throw SC.$error("Internal Inconsistency (BAD_STATE_ERROR): Cannot write property '%@' on %@.".fmt(key, this.toString()));
+      throw SC.Record.BAD_STATE_ERROR;
     }
 
     // if value is the same, do not flag record as dirty
@@ -1092,7 +1092,15 @@ SC.Record.mixin( /** @scope SC.Record */ {
 
   // ..........................................................
   // ERRORS
-  // 
+  //
+
+  /**
+    Error for when you try to modify a record while it is a bad
+    state.
+
+    @property {SC.Error}
+  */
+  BAD_STATE_ERROR: SC.$error("Internal Inconsistency"),
   
   /**
     Error for when you try to create a new record that already exists.


### PR DESCRIPTION
The singleton error needed to be available; maybe a future project would be to make errors more informative rather than these amorphous and very unhelpful ones.
