### PR TITLE
Last pushback broke not running main in non application setting

### DIFF
--- a/frameworks/core_foundation/system/ready.js
+++ b/frameworks/core_foundation/system/ready.js
@@ -82,7 +82,7 @@ SC.mixin({
         SC._readyQueue = null;
       }
       
-      if(window.main && !SC.suppressMain) { main(); }
+      if(window.main && !SC.suppressMain && (SC.mode === SC.APP_MODE)) { window.main(); }
       SC.RunLoop.end();
     }
   }

--- a/frameworks/core_foundation/tests/system/ready/done.js
+++ b/frameworks/core_foundation/tests/system/ready/done.js
@@ -14,6 +14,7 @@ module("SC.onReady.done", {
   teardown: function() {
     window.main = realMainFunction;
     SC.mode = realApplicationMode;
+    SC.isReady = false;
   }
 });
 


### PR DESCRIPTION
Before the last apple pushback main was not called unless SC.mode was SC.APP_MODE. Also the adding of SC.isReady state necessitated cleanup in the onReady.done unit test.
