### PR TITLE
Make if and unless work in handlebars templates

### DIFF
--- a/frameworks/core_foundation/tests/views/template/handlebars.js
+++ b/frameworks/core_foundation/tests/views/template/handlebars.js
@@ -600,3 +600,41 @@ test("should be able to add multiple classes using {{bindAttr class}}", function
 
   ok(!view.$('div').hasClass('is-awesome-sauce'), "removes dasherized class when property is set to false");
 });
+
+
+test("should support basic if statements", function() {
+  var template = SC.Handlebars.compile('<p>{{#if "content.isRed"}}red{{/if}}{{#if "content.isBlue"}}blue{{/if}}</p>');
+  var content = SC.Object.create({
+    isRed: false,
+    isBlue: true
+  });
+
+  var view = SC.TemplateView.create({
+    template: template,
+    content: content
+  });
+
+  view.createLayer();
+
+  console.debug(view.$('p'));
+  ok(view.$('p').text().match(/blue/), 'if shows content when given a true value');
+  ok(!view.$('p').text().match(/red/), 'if hides content when given a false value');
+});
+
+test("should support basic unless statements", function() {
+  var template = SC.Handlebars.compile('<p>{{#unless "content.isRed"}}red{{/unless}}{{#unless "content.isBlue"}}blue{{/unless}}</p>');
+  var content = SC.Object.create({
+    isRed: false,
+    isBlue: true
+  });
+
+  var view = SC.TemplateView.create({
+    template: template,
+    content: content
+  });
+
+  view.createLayer();
+
+  ok(view.$('p').text().match(/red/), 'unless shows content when given a false value');
+  ok(!view.$('p').text().match(/blue/), 'unless hides content when given a true value');
+});

--- a/frameworks/handlebars/handlebars.js
+++ b/frameworks/handlebars/handlebars.js
@@ -524,8 +524,9 @@ Handlebars.registerHelper('each', function(context, fn, inverse) {
   return ret;
 });
 
-Handlebars.registerHelper('if', function(context, fn, inverse) {
-  if(!context || context == []) {
+Handlebars.registerHelper('if', function(property, fn, inverse) {
+  var value = this.getPath(property);
+  if(!value || value == []) {
     return inverse(this);
   } else {
     return fn(this);
@@ -533,7 +534,7 @@ Handlebars.registerHelper('if', function(context, fn, inverse) {
 });
 
 Handlebars.registerHelper('unless', function(context, fn, inverse) {
-  Handlebars.helpers['if'].call(this, context, inverse, fn);
+  return Handlebars.helpers['if'].call(this, context, inverse, fn);
 });
 
 Handlebars.registerHelper('with', function(context, fn) {


### PR DESCRIPTION
The if and unless helpers aren't looking up the properties supplied to them on the view object, so the test is testing the string property path, which always evaluates to true.

This patch fixes this, and also adds a return to the unless helper so content gets output.
