### PR TITLE
Bugfixe for the experimental SplitView

### DIFF
--- a/frameworks/experimental/frameworks/split_view/views/split.js
+++ b/frameworks/experimental/frameworks/split_view/views/split.js
@@ -178,10 +178,10 @@ SC.SplitView = SC.View.extend({
     }
   }.property('frame', 'layoutDirection').cacheable(),
 
-  viewDidResize: function() {
-    this.notifyPropertyChange('frame');
+  viewDidResize: function(orig) {
     this.invokeOnce('_scsv_tile');
-  },
+    orig();
+  }.enhance(),
   
   layoutDirectionDidChange: function() {
     this.invokeOnce('_scsv_tile');


### PR DESCRIPTION
Overlay splitViews wasn't updated when parent splitView was resize.
