### PR TITLE
Fix TemplateCollectionView using custom tagName in ItemView

### DIFF
--- a/frameworks/core_foundation/tests/views/template/collection.js
+++ b/frameworks/core_foundation/tests/views/template/collection.js
@@ -3,20 +3,43 @@ module("SC.TemplateCollectionView");
 TemplateTests = {};
 
 test("creating a collection view works", function() {
-  var ExampleView = SC.TemplateView.extend({
-    tagName: 'li',
-    template: SC.Handlebars.compile('{{content/title}}')
+  var CollectionChildView = SC.TemplateView.extend({
+    template: SC.Handlebars.compile('<b>{{content.title}}</b>')
   });
+
+  var ListItemChildView = CollectionChildView.extend({ tagName: "li" });
+  var DefinitionTermChildView = CollectionChildView.extend({ tagName: "dt" });
 
   var CollectionView = SC.TemplateCollectionView.extend({
-    content: [{title: 'Hello'}],
-    itemView: ExampleView
+    content: [{title: 'Hello'}]
   });
+  
+  var defaultCollectionView = CollectionView.create();
+  var ulCollectionView  = CollectionView.create({ tagName: "ul" });
+  var olCollectionView  = CollectionView.create({ tagName: "ol" });
+  var dlCollectionView  = CollectionView.create({ tagName: "dl", itemView: DefinitionTermChildView });
+  var customTagCollectionView = CollectionView.create({ tagName: "p" })
+  
+  defaultCollectionView.createLayer();
+  ulCollectionView.createLayer();
+  olCollectionView.createLayer();
+  dlCollectionView.createLayer();
+  customTagCollectionView.createLayer();
+  
+  ok(defaultCollectionView.$().is("ul"), "Unordered list collection view was rendered (Default)");
+  equals(defaultCollectionView.$('li').length, 1, "List item view was rendered (Default)");
 
-  var collectionView = CollectionView.create();
-  collectionView.createLayer();
+  ok(ulCollectionView.$().is("ul"), "Unordered list collection view was rendered");
+  equals(ulCollectionView.$('li').length, 1, "List item view was rendered");
 
-  ok(collectionView.$('li').length === 1, "The child example view was rendered");
+  ok(olCollectionView.$().is("ol"), "Ordered collection collection view was rendered");
+  equals(olCollectionView.$('li').length, 1, "List item view was rendered");
+
+  ok(dlCollectionView.$().is("dl"), "Definition List collection view was rendered");
+  equals(dlCollectionView.$('dt').length, 1, "Definition term view was rendered");
+  
+  ok(customTagCollectionView.$().is("p"), "Paragraph collection view was rendered");
+  equals(customTagCollectionView.$('div').length, 1, "Child view was rendered");
 });
 
 test("passing a block to the collection helper sets it as the template for example views", function() {

--- a/frameworks/core_foundation/views/template_collection.js
+++ b/frameworks/core_foundation/views/template_collection.js
@@ -15,7 +15,7 @@ SC.TemplateCollectionView = SC.TemplateView.extend({
     }
   },
 
-  itemView: "SC.TemplateView",
+  itemView: 'SC.TemplateView',
 
   itemViewClass: function() {
     var itemView = this.get('itemView');
@@ -31,8 +31,8 @@ SC.TemplateCollectionView = SC.TemplateView.extend({
       extensions.template = this.get('itemViewTemplate');
     }
 
-    if (this.get('tagName') === 'ul') {
-      extensions.tagname = 'li';
+    if (this.get('tagName') === 'ul' || this.get('tagName') === 'ol') {
+      extensions.tagName = 'li';
     }
 
     return itemView.extend(extensions);
@@ -109,8 +109,6 @@ SC.TemplateCollectionView = SC.TemplateView.extend({
       item = addedObjects.objectAt(idx);
       view = this.createChildView(itemViewClass.extend({
         content: item,
-        tagName: 'li',
-
         render: renderFunc
       }));
 


### PR DESCRIPTION
There was a small typo ("tagname" instead of "tagName") causing part of dead.

Previously each collection child view was wrapped in "li" element, even if child view "tagName" was set to sth different, i.e: "p" 

This patch fixes this. Additionally when "tagName" of TemplateCollectionView will be set to "ol", child views will be wrapped in "li" element, without need of declaring custom itemView class.
