### PR TITLE
Make sure SC doesn't barf in IE-7

### DIFF
--- a/frameworks/core_foundation/tests/views/template/handlebars.js
+++ b/frameworks/core_foundation/tests/views/template/handlebars.js
@@ -695,7 +695,7 @@ test("should be able to bind boolean element attributes using {{bindAttr}}", fun
   var template = SC.Handlebars.compile('<input type="check" {{bindAttr disabled="content.isDisabled" checked="content.isChecked"}} />');
   var content = SC.Object.create({
     isDisabled: false,
-    isChecked: true,
+    isChecked: true
   });
 
   var view = SC.TemplateView.create({

--- a/frameworks/core_foundation/tests/views/view/view.js
+++ b/frameworks/core_foundation/tests/views/view/view.js
@@ -14,7 +14,7 @@ test("setting themeName should trigger a theme observer", function() {
   var view = SC.View.create({
     themeDidChange: function() {
       count++;
-    }.observes('theme'),
+    }.observes('theme')
   });
 
   view.set('themeName', 'hello');
@@ -26,7 +26,7 @@ test("setting themeName should trigger a theme observer when extending", functio
   var View = SC.View.extend({
     themeDidChange: function() {
       count++;
-    }.observes('theme'),
+    }.observes('theme')
   });
 
   View.create().set('themeName', 'hello');
@@ -39,7 +39,7 @@ test("it still works with the backward compatible theme property", function() {
     theme: 'sc-base',
     themeDidChange: function() {
       count++;
-    }.observes('theme'),
+    }.observes('theme')
   });
 
   equals(SC.Theme.find('sc-base'), view.get('theme'));
@@ -53,7 +53,7 @@ test("it still works with the backward compatible theme property when extending"
     theme: 'sc-base',
     themeDidChange: function() {
       count++;
-    }.observes('theme'),
+    }.observes('theme')
   });
 
   view = View.create();

--- a/frameworks/foundation/mixins/content_value_support.js
+++ b/frameworks/foundation/mixins/content_value_support.js
@@ -212,6 +212,6 @@ SC.ContentValueSupport = {
   _control_contentValueKeyDidChange: function() {
     // notify that value did change.
     this.contentPropertyDidChange(this.get('content'), '*') ;
-  }.observes('contentValueKey'),
+  }.observes('contentValueKey')
 };
 

--- a/frameworks/foundation/mixins/control.js
+++ b/frameworks/foundation/mixins/control.js
@@ -248,6 +248,6 @@ SC.Control = SC.mixin(SC.clone(SC.ContentValueSupport), {
         this.$input().attr('disabled', disabled);
       }
     }
-  },
+  }
 });
 

--- a/frameworks/foundation/system/utils/misc.js
+++ b/frameworks/foundation/system/utils/misc.js
@@ -153,6 +153,5 @@ SC.mixin( /** @scope SC */ {
     }else{
       $('head').prepend('<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=0" />');
     }
-  },
-
+  }
 });


### PR DESCRIPTION
This is another set of fixes to make sure that SC boots in IE7.

As an aside, because this has been an issue in the past, I wrote a validator based on Google Closure Compiler to catch these errors (YUI Compressor doesn't).  In addition to catching more errors, Closure seems to do a better job compressing as well, albeit a bit slower.  Are there any plans/interest to fold this back into Abbot as a replacement of YUI Compressor or as a separate validator script?
