### PR TITLE
TextFieldSupport Value Changes

### DIFF
--- a/frameworks/core_foundation/mixins/template_helpers/text_field_support.js
+++ b/frameworks/core_foundation/mixins/template_helpers/text_field_support.js
@@ -21,6 +21,12 @@ SC.TextFieldSupport = /** @scope SC.TextFieldSupport.prototype */{
   didCreateLayer: function() {
     SC.Event.add(this.$('input'), 'focus', this, this.focusIn);
     SC.Event.add(this.$('input'), 'blur', this, this.focusOut);
+
+    // It is possible for the user to alter the value of a textfield without
+    // a keydown, keypress, keyup, change or blur, by pasting or cutting text
+    // using the edit or contextual menus of the browser.
+    SC.Event.add(this.$('input'), 'paste', this, this.valueChanged);
+    SC.Event.add(this.$('input'), 'cut', this, this.valueChanged);
   },
 
   focusIn: function(event) {
@@ -33,12 +39,24 @@ SC.TextFieldSupport = /** @scope SC.TextFieldSupport.prototype */{
     this.tryToPerform('blur', event);
   },
 
+  valueChanged: function(event) {
+    this.invokeLast(function() {
+      this.notifyPropertyChange('value');
+    });
+  },
+
   keyUp: function(event) {
-    if (event.keyCode === 13) {
+    if (event.keyCode === SC.Event.KEY_RETURN) {
       return this.tryToPerform('insertNewline', event);
-    } else if (event.keyCode === 27) {
+    } else if (event.keyCode === SC.Event.KEY_ESC) {
       return this.tryToPerform('cancel', event);
     }
+
+    // Observers will often want the value of the textfield as
+    // it changes so notify on each key up.
+    // Note: this will not capture repeated keypress events
+    // (which the root responder relays through keyDown)
+    this.notifyPropertyChange('value');
   }
 };
 


### PR DESCRIPTION
I found that value observers weren't being updated as the input's value changed, so added a couple notifications.  This includes notifying on keyUp and when cutting or pasting the text using the browser's menus, the latter is important for commonly pasted and possibly validated text like usernames or passwords.
