### PR TITLE
use accelerated layers *on scroll* even if not touch if the platform supports them

### DIFF
--- a/frameworks/desktop/views/scroll.js
+++ b/frameworks/desktop/views/scroll.js
@@ -1940,12 +1940,12 @@ SC.ScrollView = SC.View.extend({
       content._viewFrameDidChange();
 
       // Use accelerated drawing if the browser supports it
-      if (SC.platform.touch) {
+      if (SC.platform.supportsAcceleratedLayers) {
         this._applyCSSTransforms(content.get('layer'));
       }
     }
 
-    if (container && !SC.platform.touch) {
+    if (container && !SC.platform.supportsAcceleratedLayers) {
       container = container.$()[0];
       
       if (container) {


### PR DESCRIPTION
what it says on the tin.

currently scrollview will only use accelerated layers on touch devices, but it really speeds up desktops too.
