### PR TITLE
Allow CSS to have border-color defined

### DIFF
--- a/frameworks/core_foundation/resources/core.css
+++ b/frameworks/core_foundation/resources/core.css
@@ -9,7 +9,8 @@
 /* Set here so when we set a border-width we'll see something
  * Only set on div, since occasionally we rely on native styling */
 div.sc-view {
-  border: solid 0 black;
+  border-width: 0;
+  border-style: solid;
 }
 
 .ellipsis {


### PR DESCRIPTION
This removes the color of the border for all `div.sc-views`, allowing color to be defined via CSS. I was having issues setting CSS border colors, and this did the trick.
