### PR TITLE
Fixed display of SC.SliderView

### DIFF
--- a/frameworks/desktop/english.lproj/slider.css
+++ b/frameworks/desktop/english.lproj/slider.css
@@ -1,9 +1,8 @@
 /* @override http://localhost:4020/static/sproutcore/en/desktop/_cache/sc.theme/1228020574/slider.css */
 
 /* @group SC.SliderView */
-
 .sc-slider-view {
-	height: 21px;
+  height: 21px;
 }
 
 .blur .sc-slider-view,
@@ -14,46 +13,50 @@
 }
 
 /* sc-inner is the slider bar */
- .sc-slider-view .sc-inner {
-	position: absolute;
-	left: 8px;
-	right: 8px;
-	height: 5px;
-	top: 6px;
-	background: gray ;
-	-webkit-border-radius: 3px;
-	-moz-border-radius: 3px;
-	border-radius: 3px;
+.sc-slider-view .track {
+  position: absolute;
+  left: 8px;
+  right: 8px;
+  height: 5px;
+  top: 6px;
+  background: gray;
+  -webkit-border-radius: 3px;
+  -moz-border-radius: 3px;
+  border-radius: 3px;
+}
+.sc-slider-view .track .middle {
+
 }
 
-.sc-slider-view .sc-inner .sc-leftcap,
-.sc-slider-view .sc-inner .sc-righcap {
+.sc-slider-view .track .left,
+.sc-slider-view .track .right {
   display: none;
 }
 
-.blur .sc-slider-view .sc-inner,
-.focus .sc-slider-view.disabled .sc-inner {
-	border: 1px #ccc solid;
+.blur .sc-slider-view .track,
+.focus .sc-slider-view.disabled .track {
+  border: 1px #ccc solid;
 }
 
-.focus .sc-slider-view .sc-inner {
-	border: 1px #999 solid;
+.focus .sc-slider-view .track {
+  border: 1px #999 solid;
 }
 
- .sc-slider-view .sc-handle {
-	height: 12px;
-	width: 12px;
-	margin-left: -9px;
-	top: -4px;
-	position: absolute ;
-	background: black;
-	border-radius:6px;
-	-moz-border-radius:6px;
-	-webkit-transform: translate3d(0,0,0);
-	-webkit-transition: left 0.01s ease-in-out;
+.sc-slider-view .sc-handle {
+  height: 12px;
+  width: 12px;
+  margin-left: -9px;
+  top: -4px;
+  position: absolute;
+  background: black;
+  border-radius: 6px;
+  -moz-border-radius: 6px;
+  -webkit-transform: translate3d(0, 0, 0);
+  -webkit-transition: left 0.01s ease-in-out;
 }
 
 .focus .sc-slider-view .sc-handle {
+
 }
 
 .blur .sc-slider-view .sc-handle,

--- a/frameworks/desktop/render_delegates/slider.js
+++ b/frameworks/desktop/render_delegates/slider.js
@@ -37,13 +37,15 @@ SC.BaseTheme.sliderRenderDelegate = SC.RenderDelegate.create({
 
     context = context.begin('span').addClass('track');
     this.includeSlices(dataSource, context, SC.THREE_SLICE);
-    context = context.end();
-
     context.push(
-      '<img src="', blankImage, 
+      '<img src="', blankImage,
       '" class="sc-handle" style="left: ', dataSource.get('value'), '%" />',
       '</span>'
     );
+
+    context = context.end();
+
+
 
     dataSource.get('renderState')._cachedHandle = null;
   },


### PR DESCRIPTION
Fixed display of SC.SliderView, when not using Ace as a base theme (nor the legacy theme).
Updated CSS to match new naming scheme using the renderDelegate. Changed renderDelegate to keep knob/handle inside the track (formerly sc-inner).

It may need some unit tests to prove it.
