### PR TITLE
Fixing duplicate status change notifications

### DIFF
--- a/frameworks/datastore/system/store.js
+++ b/frameworks/datastore/system/store.js
@@ -2151,11 +2151,6 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     statusOnly = dataHash || newId ? NO : YES;
     this.dataHashDidChange(storeKey, null, statusOnly);
 
-    // Force record to refresh its cached properties based on store key
-    var record = this.materializeRecord(storeKey);
-    if (record != null) {
-      record.notifyPropertyChange('status');
-    }
     //update callbacks
     this._retreiveCallbackForStoreKey(storeKey);
     
@@ -2184,12 +2179,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     this.removeDataHash(storeKey, status) ;
     this.dataHashDidChange(storeKey);
 
-    // Force record to refresh its cached properties based on store key
-    var record = this.materializeRecord(storeKey);
-    if (record != null) {
-      record.notifyPropertyChange('status');
-    }
-
+    
     this._retreiveCallbackForStoreKey(storeKey);
 
     return this ;
@@ -2221,11 +2211,6 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     this.writeStatus(storeKey, status) ;
     this.dataHashDidChange(storeKey, null, YES);
 
-    // Force record to refresh its cached properties based on store key
-    var record = this.materializeRecord(storeKey);
-    if (record != null) {
-      record.notifyPropertyChange('status');
-    }
 
     this._retreiveCallbackForStoreKey(storeKey);
     return this ;


### PR DESCRIPTION
Notifying here caused a duplicate notifcation for status changes on materialized records
