### PR TITLE
SC.ChildArray does not work properly with array observers

### DIFF
--- a/frameworks/datastore/tests/models/nested_records/nested_record_array.js
+++ b/frameworks/datastore/tests/models/nested_records/nested_record_array.js
@@ -360,4 +360,26 @@ test("Create Parent with Broken Child Array", function(){
 
 });
 
+test("pushObject should trigger an arrayContentDidChange with only 1 added item", function() {
+  var didChangeCalls = [], target;
 
+  target = SC.Object.create({
+    willChange: function() {},
+    didChange: function() {
+      didChangeCalls.push(arguments)
+    }
+  });
+
+  testParent.get('elements').addArrayObservers({
+    target: target,
+    willChange: 'willChange',
+    didChange: 'didChange'
+  })
+
+  testParent.get('elements').pushObject({});
+
+  equals(didChangeCalls.length, 1, 'didChange should only be called once');
+  equals(didChangeCalls[0][0], 4, 'didChange should be called with a start index of 4');
+  equals(didChangeCalls[0][1], 0, 'didChange should be called with a removed count of 0');
+  equals(didChangeCalls[0][2], 1, 'didChange should be called with an added count of 1');
+});


### PR DESCRIPTION
Adding objects to an `SC.ChildArray` instance triggers two calls to array content observers - one indicating the entire content array has changed and one indicating that a new object as been added (as expected).  This means that if you have a list view bound to a child array, adding an object to the child array will cause the entire list to be re-rendered.

A failing unit test is attached.
