### PR TITLE
SC.TemplateCollectionView child views iteration fix + jslint

### DIFF
--- a/frameworks/core_foundation/views/template_collection.js
+++ b/frameworks/core_foundation/views/template_collection.js
@@ -129,7 +129,7 @@ SC.TemplateCollectionView = SC.TemplateView.extend({
   arrayContentWillChange: function(start, removedCount, addedCount) {
     // If the contents were empty before and this template collection has an empty view
     // remove it now.
-    emptyView = this.get('emptyView');
+    var emptyView = this.get('emptyView');
     if (emptyView) { emptyView.$().remove(); emptyView.removeFromParent(); }
 
     // Loop through child views that correspond with the removed items.
@@ -140,9 +140,11 @@ SC.TemplateCollectionView = SC.TemplateView.extend({
     len = childViews.get('length');
     for (idx = start+removedCount-1; idx >= start; idx--) {
       childView = childViews[idx];
-      childView.$().remove();
-      childView.removeFromParent();
-      childView.destroy();
+      if (childView) {
+        childView.$().remove();
+        childView.removeFromParent();
+        childView.destroy();
+      }
     }
   },
 
@@ -165,7 +167,8 @@ SC.TemplateCollectionView = SC.TemplateView.extend({
         itemViewClass = this.get('itemViewClass'),
         childViews    = this.get('childViews'),
         addedViews    = [],
-        renderFunc, childView, itemOptions, elem, insertAtElement, item, itemElem, idx, len;
+        renderFunc, childView, itemOptions, elem, insertAtElement, item,
+        itemElem, idx, len, view;
 
     var addedObjects = content.slice(start, start+addedCount);
 


### PR DESCRIPTION
SC.TemplateCollectionView.arrayContentDidChange() child views
iteration may cause (and in my case it did) a call on an undefined.
It is because child views are not in all cases present when
receiving arrayContentDidChange.
This commit also fixes jslint warnings (2 undefined variables) in
SC.TemplateCollectionView.
