### PR TITLE
SC.Button template view class / mixin conflict.

### DIFF
--- a/frameworks/foundation/mixins/button.js
+++ b/frameworks/foundation/mixins/button.js
@@ -5,10 +5,7 @@
 // License:   Licensed under MIT license (see license.js)
 // ==========================================================================
 
-SC.Button = {
-  
-  initMixin: function(){
-    SC.Logger.warn("SC.Button is deprecated and does nothing. Subclass SC.ButtonView instead.");
-  }
-  
-} ;
+SC.Button.initMixin = function(){
+  SC.Logger.warn("SC.Button is deprecated and does nothing. Subclass SC.ButtonView instead.");
+};
+


### PR DESCRIPTION
Core foundation framework defines SC.Button class, but foundation
framework overrides it with deprecated SC.Button.mixin. This commit
fixes it while keeping deprecation message.
