### PR TITLE
Attach prefix for core_tools' urls to allow to run apps on path other than /

### DIFF
--- a/frameworks/core_tools/core.js
+++ b/frameworks/core_tools/core.js
@@ -15,6 +15,12 @@
 CoreTools = SC.Object.create( /** @scope CoreTools.prototype */ {
 
   NAMESPACE: 'CoreTools',
-  VERSION: '1.0.0'
-  
+  VERSION: '1.0.0',
+
+  attachUrlPrefix: function(url) {
+    if(url && SC.urlPrefix) {
+      url = SC.urlPrefix + url;
+    }
+    return url;
+  }
 }) ;

--- a/frameworks/core_tools/data_source.js
+++ b/frameworks/core_tools/data_source.js
@@ -41,7 +41,7 @@ CoreTools.DataSource = SC.DataSource.extend({
     
     if (!query.get('isRemote')) return NO ; 
     
-    SC.Request.getUrl('/sc/targets.json')
+    SC.Request.getUrl(CoreTools.attachUrlPrefix('/sc/targets.json'))
       .set('isJSON', YES)
       .notify(this, 'fetchTargetsDidComplete', { query: query, store: store })
       .send();

--- a/frameworks/core_tools/models/target.js
+++ b/frameworks/core_tools/models/target.js
@@ -34,7 +34,7 @@ CoreTools.Target = SC.Record.extend(
     URL to use to load the app.  If no an app, returns null
   */
   appUrl: function() {
-    return (this.get('kind') === 'app') ? this.get('name') : null;
+    return (this.get('kind') === 'app') ? CoreTools.attachUrlPrefix(this.get('name')) : null;
   }.property('kind', 'name').cacheable(),
   
   /**


### PR DESCRIPTION
This uses function added here: https://github.com/sproutcore/abbot/pull/47
