### PR TITLE
Fix for extra click event on touch devices (makes SC.Checkbox work on touch)

### DIFF
--- a/frameworks/core_foundation/system/root_responder.js
+++ b/frameworks/core_foundation/system/root_responder.js
@@ -1708,6 +1708,7 @@ SC.RootResponder = SC.Object.extend({
   mousedown: function(evt) {
     if (SC.platform.touch) {
       evt.allowDefault();
+      this._lastMouseDownCustomHandling = YES;
       return YES;
     }
 
@@ -1765,6 +1766,7 @@ SC.RootResponder = SC.Object.extend({
   mouseup: function(evt) {
     if (SC.platform.touch) {
       evt.allowDefault();
+      this._lastMouseUpCustomHandling = YES;
       return YES;
     }
 


### PR DESCRIPTION
On touch platforms, 'mousedown' & 'mouseup' were allowing default, but not tracking it for the later click event.  This resulted in 'click' calling preventDefault & stopPropagation.
