### PR TITLE
Make it possible for the handlebars helpers to generate tags other than <span>

### DIFF
--- a/frameworks/core_foundation/ext/handlebars/bind.js
+++ b/frameworks/core_foundation/ext/handlebars/bind.js
@@ -51,7 +51,8 @@ sc_require('ext/handlebars');
         displayTemplate: fn,
         inverseTemplate: inverse,
         property: property,
-        previousContext: this
+        previousContext: this,
+        tagName: (options.hash.tagName || "span")
       });
 
       var observer, invoker;


### PR DESCRIPTION
Currently, the helpers "bind", "boundIf", "if", "with", and "unless"
always generate a span.  This makes them unsuitable for rendering
block-level content, because HTML does not technically allow block
elements (like div) inside a span.

While browsers tend to gracefully handle such invalid HTML, it can
cause subtle breakage.  For example, jQueryUI makes assumptions that
break if you put divs inside spans.

This change allows an optional "tagName" parameter on the
aforementioned helpers.  So you can do:

```
{{#if someProperty tagName="div"}}
    <div>Some Content...</div>
{{/if}}
```
