### PR TITLE
Make SC.json.encode able to handle SC.Record's

### DIFF
--- a/frameworks/datastore/tests/models/record/core_methods.js
+++ b/frameworks/datastore/tests/models/record/core_methods.js
@@ -53,3 +53,12 @@ test("Can commitRecord() specific SC.Record instance", function() {
   equals(dataSource.gotParams, YES, 'Params were properly passed through commitRecord');
   
 });
+
+test("If passed in an SC.Record, then encode the datahash instead", function(){
+  
+  var str = SC.json.encode(MyApp.foo);
+  var result = SC.json.decode(str);
+	
+	same(MyApp.json,result, "original = encoded record");
+	
+});

--- a/frameworks/runtime/system/json.js
+++ b/frameworks/runtime/system/json.js
@@ -16,6 +16,7 @@ SC.json = {
     @returns {String} encode JSON
   */
   encode: function(root) {
+    if(root.isRecord) root = root.get('attributes');
     return JSON.stringify(root) ;
   },
   


### PR DESCRIPTION
I've come across many issues where people have got the `JSON.stringify cannot serialize cyclic structures` error because they have passed in an SC.Record to be encoded. The expected result of doing so is that the datahash would be encoded. That is what this patch does:

  Encode the records datahash instead as this is almost certainly what we want.
