### PR TITLE
collection with tagName="tbody" does not rerender properly when using {{#with content}}

### DIFF
--- a/frameworks/core_foundation/tests/views/template/collection.js
+++ b/frameworks/core_foundation/tests/views/template/collection.js
@@ -224,6 +224,58 @@ test("should pass content as context when using {{#each}} helper", function() {
   equals(view.$().text(), "Mac OS X 10.7: Lion Mac OS X 10.6: Snow Leopard Mac OS X 10.5: Leopard ", "prints each item in sequence");
 });
 
+test("should re-render view when using {{#with content}}, nested objects and tbody as tagName", function() {
+  TemplateTests.RerenderNestedTBodyTest = SC.TemplateCollectionView.extend({
+    content: []
+  });
+
+  var view = SC.TemplateView.create({
+    template: SC.Handlebars.compile('<table><thead><tr><th>Title</th><th>Name</th></tr></thead>{{#collection TemplateTests.RerenderNestedTBodyTest tagName="tbody"}}{{#with content}}<td>{{title}}</td><td>{{user.name}}</td>{{/with}}{{/collection}}</table>')
+  });
+
+  view.createLayer();
+
+  var user = SC.Object.create({ name: 'Murphy' }),
+      content = [SC.Object.create({user: user, title: 'SproutCore'})];
+
+  SC.run(function() {
+    view.childViews[0].set('content', content);
+  });
+
+  SC.run(function() {
+    content[0].set('title', 'Rails');
+    user.set('name', 'Paul');
+  });
+
+  equals(view.$('td:eq(0)').text(), "Rails");
+  equals(view.$('td:eq(1)').text(), "Paul");
+});
+
+test("should re-render view when using {{#with content}} and nested objects", function() {
+  TemplateTests.RerenderNestedTest = SC.TemplateCollectionView.extend({
+    content: []
+  });
+
+  var view = SC.TemplateView.create({
+    template: SC.Handlebars.compile('{{#collection TemplateTests.RerenderNestedTest}}{{#with content}}{{user.name}}{{/with}}{{/collection}}')
+  });
+
+  view.createLayer();
+
+  var user = SC.Object.create({ name: 'Murphy' }),
+      content = [SC.Object.create({user: user})];
+
+  SC.run(function() {
+    view.childViews[0].set('content', content);
+  });
+
+  SC.run(function() {
+    user.set('name', 'Paul');
+  });
+
+  equals(view.$('li:eq(0)').text(), "Paul");
+});
+
 test("should re-render when the content object changes", function() {
   TemplateTests.RerenderTest = SC.TemplateCollectionView.extend({
     content: []


### PR DESCRIPTION
This issue was originaly described here: https://github.com/sproutcore/sproutcore/pull/475, but it turned out that the real problem is usage of {{#with content}}, not tbody alone.

There are 2 failing tests added in this pull requests, both use collection and {{#with content}}, but only test without tagName passes. When tagName="tbody" is removed, it correctly update views (you have to change equals() functions though, td is not rendered in such scenario)
