### PR TITLE
Fix parse error in SC.Math

### DIFF
--- a/frameworks/foundation/system/math.js
+++ b/frameworks/foundation/system/math.js
@@ -15,7 +15,7 @@
   @author Colin Campbell
 */
 SC.Math = SC.Object.create(
-/** @lends SC.Math.prototype */, {
+/** @lends SC.Math.prototype */ {
   
   /**
     Checks to see if the number is near the supplied parameter to a certain lambda.


### PR DESCRIPTION
It breaks SproutCore and makes my developers cry. 
