### PR TITLE
clippingFrame should always return a frame relative to the view itself, n

### DIFF
--- a/frameworks/core_foundation/views/view.js
+++ b/frameworks/core_foundation/views/view.js
@@ -1004,7 +1004,7 @@ SC.CoreView.reopen(
     pv = this.get('parentView');
     if (pv) {
       cf = pv.get('clippingFrame');
-      if (!cf) return f;
+      if (!cf) return { x: 0, y: 0, width: f.width, height: f.height};
       ret = SC.intersectRects(cf, f);
     }
     ret.x -= f.x;


### PR DESCRIPTION
clippingFrame should always return a frame relative to the view itself, not its parent
