### PR TITLE
Fixed toolTip rendering in SC.LabelView.

### DIFF
--- a/frameworks/foundation/render_delegates/label.js
+++ b/frameworks/foundation/render_delegates/label.js
@@ -40,6 +40,11 @@ SC.BaseTheme.labelRenderDelegate = SC.RenderDelegate.create({
   render: function(dataSource, context) {
     this.addSizeClassName(dataSource, context);
 
+		var toolTip = dataSource.get('toolTip');
+		if (toolTip) {
+			context.attr('title', toolTip);
+		}
+
     /*
       TODO [CC @ 1.5] These properties have been deprecated. We should remove them
             in the next release
@@ -72,6 +77,14 @@ SC.BaseTheme.labelRenderDelegate = SC.RenderDelegate.create({
       fontWeight: dataSource.get('fontWeight') || null,
       textAlign: dataSource.get('textAlign') || null
     });
+		
+		var toolTip = dataSource.get('toolTip');
+		if (toolTip) {
+			jquery.attr('title', toolTip);
+		}
+		else {
+			jquery.removeAttr('title');
+		}
     
     jquery.setClass('ellipsis', dataSource.get('needsEllipsis') || NO);
 


### PR DESCRIPTION
Setting the tooltip property on SC.LabelView does not result in the title attribute being set on the element which is the expected behavior. 

SC.BaseTheme.labelRenderDelegate was not handling the toolTip property.

I added the missing code.

Cheers,

Cherif 
