### PR TITLE
Render the correct tags for items in a template collection

### DIFF
--- a/frameworks/core_foundation/tests/views/template/collection.js
+++ b/frameworks/core_foundation/tests/views/template/collection.js
@@ -17,6 +17,7 @@ test("creating a collection view works", function() {
 
   var ListItemChildView = CollectionChildView.extend({ tagName: "li" });
   var DefinitionTermChildView = CollectionChildView.extend({ tagName: "dt" });
+  var OptionChildView = CollectionChildView.extend({ tagName: "option" });
 
   var CollectionView = SC.TemplateCollectionView.extend({
     content: [{title: 'Hello'}]
@@ -26,12 +27,14 @@ test("creating a collection view works", function() {
   var ulCollectionView  = CollectionView.create({ tagName: "ul" });
   var olCollectionView  = CollectionView.create({ tagName: "ol" });
   var dlCollectionView  = CollectionView.create({ tagName: "dl", itemView: DefinitionTermChildView });
+  var selectCollectionView  = CollectionView.create({ tagName: "select", itemView: OptionChildView });
   var customTagCollectionView = CollectionView.create({ tagName: "p" });
   
   defaultCollectionView.createLayer();
   ulCollectionView.createLayer();
   olCollectionView.createLayer();
   dlCollectionView.createLayer();
+  selectCollectionView.createLayer();
   customTagCollectionView.createLayer();
   
   ok(defaultCollectionView.$().is("ul"), "Unordered list collection view was rendered (Default)");
@@ -45,10 +48,14 @@ test("creating a collection view works", function() {
 
   ok(dlCollectionView.$().is("dl"), "Definition List collection view was rendered");
   equals(dlCollectionView.$('dt').length, 1, "Definition term view was rendered");
-  
+
+  ok(selectCollectionView.$().is("select"), "Select collection view was rendered");
+  equals(selectCollectionView.$('option').length, 1, "Option view was rendered");
+
   ok(customTagCollectionView.$().is("p"), "Paragraph collection view was rendered");
   equals(customTagCollectionView.$('div').length, 1, "Child view was rendered");
 });
+
 
 test("not passing a block to the collection helper creates a collection", function() {
   TemplateTests.CollectionTestView = SC.TemplateCollectionView.create({

--- a/frameworks/core_foundation/views/template_collection.js
+++ b/frameworks/core_foundation/views/template_collection.js
@@ -132,14 +132,10 @@ SC.TemplateCollectionView = SC.TemplateView.extend(
       extensions.template = itemViewTemplate;
     }
 
-    if (this.get('tagName') === 'ul' || this.get('tagName') === 'ol') {
-      extensions.tagName = 'li';
-    } else if (this.get('tagName') === 'table' || this.get('tagName') === 'thead' || this.get('tagName') === 'tbody') {
-      extensions.tagName = 'tr';
-    }
+    extensions.tagName = this.get('itemTagName');
 
     return itemView.extend(extensions);
-  }.property('itemView').cacheable(),
+  }.property('itemView', 'itemTagName').cacheable(),
 
   /**
     @private
@@ -306,6 +302,10 @@ SC.TemplateCollectionView = SC.TemplateView.extend(
       case 'tbody':
       case 'tfoot':
         return 'tr';
+      case 'select':
+        return 'option';
+      case 'dl':
+        return 'dt';
     }
   }.property('tagName'),
 


### PR DESCRIPTION
Template collections were not rendering the correct item tags when passed a tagName for some tags. For example when using a tagName of select divs and spans were used instead of option tags. It appeared like the logic for determining the correct item tag was also being defined in two places.
