### PR TITLE
Only call SC.Query if it is defined 

### DIFF
--- a/frameworks/datastore/models/record.js
+++ b/frameworks/datastore/models/record.js
@@ -1439,7 +1439,7 @@ SC.Record.mixin( /** @scope SC.Record */ {
   /** @private - enhance extend to notify SC.Query as well. */
   extend: function() {
     var ret = SC.Object.extend.apply(this, arguments);
-    SC.Query._scq_didDefineRecordType(ret);
+    if(SC.Query) SC.Query._scq_didDefineRecordType(ret);
     return ret ;
   }
 }) ;


### PR DESCRIPTION
This allows you to use Record without needing to pull in Query.
