### PR TITLE
Chrome 14.0.803+ "Maximum call stack size exceeded!" error

### DIFF
--- a/frameworks/runtime/mixins/observable.js
+++ b/frameworks/runtime/mixins/observable.js
@@ -527,7 +527,7 @@ SC.Observable = /** @scope SC.Observable.prototype */{
         keys = dependentKeys;
         lim  = 0;
       } else {
-        keys = arguments;
+        keys = Array.prototype.slice.call(arguments);
         lim  = 1;
       }
       idx  = keys.length;


### PR DESCRIPTION
Since Chrome 14.0.803, I sometimes have a "Maximum call stack size exceeded!" in SproutCore apps. The bug is weird and hard to reproduce, but I've narrowed it down to that specific line.

I'm not sure if it's just the Chrome dev channel being unstable or if this behaviour will stay.
