### PR TITLE
pushRetrieve now updates primaryKey value of record + tests

### DIFF
--- a/frameworks/datastore/system/store.js
+++ b/frameworks/datastore/system/store.js
@@ -2258,6 +2258,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
       if(dataHash===undefined) this.writeStatus(storeKey, status) ;
       else this.writeDataHash(storeKey, dataHash, status) ;
 
+      if (id && this.idFor(storeKey) !== id) SC.Store.replaceIdFor(storeKey, id);
       this.dataHashDidChange(storeKey);
 
       return storeKey;

--- a/frameworks/datastore/tests/system/store/pushChanges.js
+++ b/frameworks/datastore/tests/system/store/pushChanges.js
@@ -59,3 +59,19 @@ test("Issue a pushError and check if there is conflicts", function() {
   ok(!res, "There is a conflict, because of the state, this is expected.");
 });
 
+test("A pushRetrieve updating the id of an existing record should update the primary Key cache", function(){
+  var tmpid, recFirst, recSecond, sK;
+  
+  tmpid = "@2345235asddsgfd";
+  recFirst = { firstname: 'me', lastname: 'too', guid: tmpid };
+  recSecond = { firstname: 'me', lastname: 'too', guid: 1 };
+  SC.RunLoop.begin();
+  var sK = store.loadRecord(SC.Record, rec, tmpid);
+  SC.RunLoop.end();
+  equals(store.idFor(sK),tmpid); //check whether the id is indeed tmpid
+  SC.RunLoop.begin();
+  store.pushRetrieve(SC.Record,1,recSecond,sK);
+  SC.RunLoop.end();
+  equals(store.idFor(sK),1); // id should now have been updated
+});
+


### PR DESCRIPTION
When pushRetrieve is used to update a record of which the primaryKey value has changed, it does not update the stores cache. 
This behaviour can be reproduced as follows: 

   var sK = store.loadRecord(Model, { firstname: 'me', lastname: 'too', guid: '@433247823'}, '@433247823');
   store.pushRetrieve(Model, 1, {firstname: 'me', lastname: 'too', guid: 1}, sK);
   store.idFor(sK); // returns @433247823 instead of 1 

The included patch solves this behaviour by mimicking the dataSourceDidComplete behaviour in updating the stores primaryKey value cache. A test is included.
