### PR TITLE
Resolved issue with removeObserver and @each

### DIFF
--- a/frameworks/runtime/private/chain_observer.js
+++ b/frameworks/runtime/private/chain_observer.js
@@ -166,8 +166,13 @@ SC._ChainObserver.prototype = {
 
     // remove observer
     var obj = this.object ;
-    if (obj && obj.removeObserver) {
-      obj.removeObserver(this.property, this, this.propertyDidChange) ;
+    if (obj) {
+      if (this.property === '@each' && this.next && obj._removeContentObserver) {
+        obj._removeContentObserver(this);
+      }
+      if (obj.removeObserver) {
+        obj.removeObserver(this.property, this, this.propertyDidChange) ;
+      }
     }
 
     // destroy next item in chain

--- a/frameworks/runtime/tests/mixins/observable/chained.js
+++ b/frameworks/runtime/tests/mixins/observable/chained.js
@@ -42,3 +42,23 @@ test("chained observers on enumerable properties are triggered when the observed
   equals(observerFiredCount, 0, "observer did not fire after removing changing property on a removed object");
 });
 
+test("content observers are removed correctly", function() {
+  var child1 = SC.Object.create({ name: "Bartholomew", age: 15 });
+  var child2 = SC.Object.create({ name: "Agnes", age: 12 });
+  var children = [child1, child2];
+
+  var observerFiredCount = 0;
+  var observerFunc = function() { observerFiredCount++; }
+
+  children.addObserver('@each.name', this, observerFunc);
+  children.removeObserver('@each.name', this, observerFunc);
+  observerFiredCount = 0;
+  SC.run(function() { children.setEach('name', "Hanna"); });
+  equals(observerFiredCount, 0, "name observer did not fire after it was removed");
+
+  children.addObserver('@each.age', this, observerFunc);
+  children.removeObserver('@each.age', this, observerFunc);
+  observerFiredCount = 0;
+  SC.run(function() { children.setEach('age', 14); });
+  equals(observerFiredCount, 0, "age observer did not fire after it was removed");
+});


### PR DESCRIPTION
Here's a patch for an issue I was running into when adding and removing content observers at runtime. I would start out by adding an observer for something like `@each.name` and then later on replace it with one on `@each.age`.

The problem is that SC._ChainObserver.destroyChain doesn't remove content observers, so when I removed the `@each.name` observer, `"name"` would still be in the `_kvo_content_observed_keys` set, and when I then added the `@each.age` observer, `_setupContentObservers` would loop through those keys and find `"name"`, even though the observer itself had been set to null. It would then call `_resumeChainObservingForItemWithChainObserver` and pass in null as the second argument (`observer`), which would throw an error because it would try to access `observer.property`.

To fix this I added a special case for `@each` in destroyChain, which calls `_removeContentObserver` on the object. Tests are included.
