### PR TITLE
Scroll view render delegates

### DIFF
--- a/frameworks/experimental/frameworks/scroll_view/render_delegates/desktop_scroller.js
+++ b/frameworks/experimental/frameworks/scroll_view/render_delegates/desktop_scroller.js
@@ -7,7 +7,7 @@
 
 
 SC.BaseTheme.desktopScrollerRenderDelegate = SC.RenderDelegate.create({
-  name: 'desktop-scroller',
+  className: 'desktop-scroller',
 
   render: function (dataSource, context) {
     var layoutDirection = dataSource.get('layoutDirection'),

--- a/frameworks/experimental/frameworks/scroll_view/render_delegates/native_scroll.js
+++ b/frameworks/experimental/frameworks/scroll_view/render_delegates/native_scroll.js
@@ -5,7 +5,7 @@
 // ==========================================================================
 
 SC.BaseTheme.nativeScrollRenderDelegate = SC.RenderDelegate.create({
-  name: 'native-scroll',
+  className: 'native-scroll',
 
   render: function (dataSource, context) {},
 

--- a/frameworks/experimental/frameworks/scroll_view/render_delegates/scroll.js
+++ b/frameworks/experimental/frameworks/scroll_view/render_delegates/scroll.js
@@ -5,7 +5,7 @@
 // ==========================================================================
 
 SC.BaseTheme.scrollRenderDelegate = SC.RenderDelegate.create({
-  name: 'scroll',
+  className: 'scroll',
 
   render: function (dataSource, context) {
     context.push('<div class="corner"></div>');

--- a/frameworks/experimental/frameworks/scroll_view/render_delegates/touch_scroller.js
+++ b/frameworks/experimental/frameworks/scroll_view/render_delegates/touch_scroller.js
@@ -6,7 +6,7 @@
 // ==========================================================================
 
 SC.BaseTheme.touchScrollerRenderDelegate = SC.RenderDelegate.create({
-  name: 'touch-scroller',
+  className: 'touch-scroller',
 
   render: function (dataSource, context) {
     var layoutDirection = dataSource.get('layoutDirection'),


### PR DESCRIPTION
Fix for the experimental SC.ScrollView having the wrong render delegate class name. It should've been `className`. Sorry about not catching this earlier.
