### PR TITLE
Fixed typo in SC.Query.build method.

### DIFF
--- a/frameworks/datastore/system/query.js
+++ b/frameworks/datastore/system/query.js
@@ -1429,7 +1429,7 @@ SC.Query.mixin( /** @scope SC.Query */ {
 
       // pass one or more recordTypes.
       if (recordType && recordType.isEnumerable) {
-        opts.recordsTypes = recordType;
+        opts.recordTypes = recordType;
       } else opts.recordType = recordType;
 
       // set conditions and params if needed

--- a/frameworks/datastore/tests/system/query/builders.js
+++ b/frameworks/datastore/tests/system/query/builders.js
@@ -144,6 +144,13 @@ function performBasicTests(methodName, loc) {
     equals(q5, q4, 'second call for different conditions should return cache');
   });
 
+  test("query with record types and conditions hash", function() {
+
+    var q = invokeWith([TestRecord, TestRecord2], {});
+    queryEquals(q, loc, [TestRecord, TestRecord2], null, 'first query');
+
+  });
+
   test("query with no record type and with conditions", function() {
     var q1, q2;
 


### PR DESCRIPTION
Using multiple record types and conditions hash when calling
SC.Query.build method a wrong property name was used: recordsTypes
instead of recordType.
