### PR TITLE
instantiated views referenced from inside an #if block only get properly destroyed the first time they are removed

### DIFF
--- a/frameworks/core_foundation/tests/views/template/handlebars.js
+++ b/frameworks/core_foundation/tests/views/template/handlebars.js
@@ -60,6 +60,8 @@
 */
 module("SC.TemplateView - handlebars integration");
 
+TemplateTests = {};
+
 test("template view should call the function of the associated template", function() {
   var view = SC.TemplateView.create({
     templateName: 'test_template',
@@ -540,6 +542,34 @@ test("should update the block when object passed to #if helper changes and an in
 
     equals(view.$('h1').text(), "BOOOOOOOONG doodoodoodoodooodoodoodoo", "precond - renders block when conditional is true");
   });
+});
+
+test("views nested within an #if helper should be destroyed every time they are removed", function() {
+  var view, didCreateLayerCalled = 0, willDestroyLayerCalled = 0;
+
+  TemplateTests.someView = SC.TemplateView.create({
+    template: SC.Handlebars.compile("<h1>hello</h1>"),
+    didCreateLayer: function() { didCreateLayerCalled++; },
+    willDestroyLayer: function() { willDestroyLayerCalled++; }
+  });
+
+  view = SC.TemplateView.create({
+    template: SC.Handlebars.compile('{{#if foo}}{{view TemplateTests.someView}}{{/if}}'),
+    foo: true
+  });
+
+  view.createLayer();
+
+  SC.run(function() { view.set('foo', false); });
+
+  equals(didCreateLayerCalled, 1, 'didCreateLayer should have been called once');
+  equals(willDestroyLayerCalled, 1, 'willDestroyLayer should have been called once');
+
+  SC.run(function() { view.set('foo', true); });
+  SC.run(function() { view.set('foo', false); });
+
+  equals(didCreateLayerCalled, 2, 'didCreateLayer should have been called twice');
+  equals(willDestroyLayerCalled, 2, 'willDestroyLayer should have been called twice');
 });
 
 test("Should insert a localized string if the {{loc}} helper is used", function() {


### PR DESCRIPTION
When an already instantiated view is used inside of an `#if` block its `destroy` method is called the first time the condition becomes false. Then, when the condition becomes true again, the view is properly re-rendered, however when the condition becomes false once again, the nested view is removed from the document but its `willDestroyLayer` method is never invoked. I believe that this is happening because the nested view's `isDestroyed` property is set the first time it is torn down and then never reset.

A failing unit test to demonstrate the issue is attached.
