### PR TITLE
Fixed Text Field Support

### DIFF
--- a/frameworks/core_foundation/mixins/template_helpers/text_field_support.js
+++ b/frameworks/core_foundation/mixins/template_helpers/text_field_support.js
@@ -75,7 +75,7 @@ SC.TextFieldSupport = /** @scope SC.TextFieldSupport */{
       SC.Event.add(input, 'blur', this, this.focusOut);
     }
 
-    input.bind('change', function() {
+    input.bind('keyup', function() {
       self.domValueDidChange(SC.$(this));
     });
   },


### PR DESCRIPTION
"Change" event didn't fire on a text field preventing value from
updating during focus. Changed to "keyup" event to allow live value
updating without switching focus.
