### PR TITLE
Template #collection block helpers can now specify itemTagName.

### DIFF
--- a/frameworks/core_foundation/views/template_collection.js
+++ b/frameworks/core_foundation/views/template_collection.js
@@ -255,7 +255,7 @@ SC.TemplateCollectionView = SC.TemplateView.extend(
       childView = this.createChildView(itemViewClass.extend(itemOptions, {
         content: item,
         render: renderFunc,
-        tagName: itemOptions.tagName || itemViewClass.prototype.tagName
+        tagName: itemOptions.tagName || itemViewClass.prototype.tagName || this.get('itemTagName')
       }));
 
       var contextProperty = childView.get('contextProperty');


### PR DESCRIPTION
The itemTagName in the #collection block helper was getting overridden. If the itemTagName isn't specified in the TemplateCollectionView and instead specified #collection Handlebars block helper, it will get overridden by the arrayContentDidChange method. itemOptions.tagName will hold the correct tag name, so that is being used first and it will fall back to a specified default otherwise. This allows something like the following:

```
MyApp.ArrayContent = [
  { label: 'first', title: 'first title }
];

{{#collection contentBinding="MyApp.ArrayContent" tagName="tr" itemTagName="td"}}
  {{content.label}}
{{/collection}}
```

With update:

```
<tr>
  <td><span>first</span></td>
</tr>
```

Without:

```
<tr>
  <div><span>first</span></div>
</tr>
```

All tests pass.

Nicholas Boll
