### PR TITLE
Class names from classNameBindings should be preserved through updateLayer

### DIFF
--- a/frameworks/core_foundation/tests/views/view/class_name_bindings_test.js
+++ b/frameworks/core_foundation/tests/views/view/class_name_bindings_test.js
@@ -45,3 +45,18 @@ test("should add, remove, or change class names if changed after element is crea
   ok(!view.$().hasClass('is-urgent', "removes dasherized class when changed from true to false"));
   ok(view.$().hasClass('can-ignore'), "adds dasherized class when changed from false to true");
 });
+
+test("should preserve class names applied via classNameBindings when view layer is updated",
+function(){
+  var view = SC.View.create({
+    classNameBindings: ['isUrgent'],
+    isUrgent: false
+  });
+  view.createLayer();
+  ok(!view.$().hasClass('is-urgent', "removes dasherized class when changed from true to false"));
+  view.set('isUrgent', true);
+  ok(view.$().hasClass('is-urgent', "adds dasherized class when changed from true to false"));
+  view.set('layerNeedsUpdate', YES);
+  view.updateLayer();
+  ok(view.$().hasClass('is-urgent', "still has class when view display property is updated"));
+});

--- a/frameworks/core_foundation/views/view.js
+++ b/frameworks/core_foundation/views/view.js
@@ -725,12 +725,14 @@ SC.CoreView.reopen(
         // If we had previously added a class to the element, remove it.
         if (oldClass) {
           elem.removeClass(oldClass);
+          classNames.removeObject(oldClass);
         }
 
         // If necessary, add a new class. Make sure we keep track of it so
         // it can be removed in the future.
         if (newClass) {
           elem.addClass(newClass);
+          classNames.push(newClass);
           oldClass = newClass;
         } else {
           oldClass = null;


### PR DESCRIPTION
This patch fixes a situation where classNameBindings adds a css class but an update of the layer is later triggered, resulting in the improper removal of the css class added by classNameBindings. 
