### PR TITLE
Fix for picker pane margin area, which was obscured for clicks

### DIFF
--- a/themes/ace/resources/picker/popover/popover.css
+++ b/themes/ace/resources/picker/popover/popover.css
@@ -25,6 +25,8 @@
       right: -25px;
       
       @include slices("popover_notoolbar.png", $left: 40, $top: 40, $bottom: 40, $right: 40, $fill: 1 1, $skip: middle);
+
+      .middle { display: none }
       
       div { z-index: 5; }
     }


### PR DESCRIPTION
added .middle { display: none } within theme(popover) to fix margin obscuring on picker panes
