### PR TITLE
#163 Select view should compare store keys when objects are records

### DIFF
--- a/frameworks/desktop/views/select.js
+++ b/frameworks/desktop/views/select.js
@@ -463,7 +463,10 @@ SC.SelectView = SC.ButtonView.extend(
         object.get(valueKey) : object[valueKey]) : object ;
 
       if (!SC.none(currentSelectedVal) && !SC.none(value)){
-        if( currentSelectedVal === value ) {
+        if( currentSelectedVal === value ||
+            (SC.kindOf(currentSelectedVal, SC.Record) &&
+             SC.kindOf(value, SC.Record) &&
+                       currentSelectedVal.get('storeKey') === value.get('storeKey'))) {
           this.set('title', name) ;
           this.set('icon', icon) ;
         }


### PR DESCRIPTION
If value object and list objects are both records, compare store key to see if they are really the same thing.
