### PR TITLE
SC.DateTime should invoke class methods using 'this' instead of 'SC.DateTime'.  

### DIFF
--- a/frameworks/datetime/frameworks/core/system/datetime.js
+++ b/frameworks/datetime/frameworks/core/system/datetime.js
@@ -384,7 +384,7 @@ SC.DateTime = SC.Object.extend(SC.Freezable, SC.Copyable,
     @returns {Boolean}
   */
   isEqual: function(aDateTime) {
-    return SC.DateTime.compare(this, aDateTime) === 0;
+    return this.constructor.compare(this, aDateTime) === 0;
   },
 
   /**
@@ -982,7 +982,7 @@ SC.DateTime.mixin(SC.Comparable,
       delete opts.meridian;
     }
 
-    d = SC.DateTime.create(opts);
+    d = this.create(opts);
 
     if (!SC.none(check.dayOfWeek) && d.get('dayOfWeek') !== check.dayOfWeek) {
       return null;

--- a/frameworks/datetime/frameworks/core/tests/system/datetime.js
+++ b/frameworks/datetime/frameworks/core/tests/system/datetime.js
@@ -394,3 +394,11 @@ test('timezones', function() {
   timeShouldBeEqualToHash(dt.toTimezone(-120), {year: o.year, month: o.month, day: o.day, hour: 6, minute: o.minute, second: o.second, millisecond: o.millisecond, timezone: -120 });
   timeShouldBeEqualToHash(dt.toTimezone(-330), {year: o.year, month: o.month, day: o.day, hour: 9, minute: 30, second: o.second, millisecond: o.millisecond, timezone: -330 });
 });
+
+test('extend', function() {
+  var dateTimeExt = SC.DateTime.extend();
+  
+  // Should parse and produce a date object that is an instance of 'dateTimeExt'
+  var parsedDateTimeExt = dateTimeExt.parse('2011-10-15T21:30:00Z');
+  ok(SC.instanceOf(parsedDateTimeExt, dateTimeExt), 'Correctly produced an instance of the extended type.');
+});


### PR DESCRIPTION
I've modified SC.DateTime to invoke class methods using 'this' instead of 'SC.DateTime'. This allows SC.DateTime to be extended for use in other apps and frameworks. Additionally added unit tests to verify it.

The particular offender here was SC.DateTime#parse. After it parses the date value from the string it invoked SC.DateTime.create, rather than this.create. This resulted in our subclass of SC.DateTime, call it Our.DateTime, always producing SC.DateTime objects when we invoked Our.DateTime.create.
