### PR TITLE
Added a helper method for PATCH requests

### DIFF
--- a/frameworks/ajax/system/request.js
+++ b/frameworks/ajax/system/request.js
@@ -510,6 +510,19 @@ SC.Request.mixin(
     var req = this.create().set('address', address).set('type', 'PUT');
     if(body) { req.set('body', body) ; }
     return req ;
+  },
+
+  /**
+    Helper method for quickly setting up a PATCH request.
+
+    @param {String} address url of request
+    @param {String} body
+    @returns {SC.Request} receiver
+  */
+  patchUrl: function(address, body) {
+    var req = this.create().set('address', address).set('type', 'PATCH');
+    if(body) { req.set('body', body) ; }
+    return req ;
   }
 
 });


### PR DESCRIPTION
SC.Request has helper methods for GET, POST, PUT and DELETE requests but not for the PATCH request. In this commit I added this request method.
