### PR TITLE
Added definition of 'willLoseFirstResponder' for SC.TextFieldView

### DIFF
--- a/frameworks/foundation/tests/views/text_field/ui.js
+++ b/frameworks/foundation/tests/views/text_field/ui.js
@@ -669,6 +669,24 @@ test("focus and blur an empty text field", function() {
   pane.verifyEmpty(view, 'Full Name');
 });
 
+test("loosing first responder should blur", function() {
+  var view = pane.view('empty');
+  var input = view.$('input');
+  var testResponder = SC.Responder.create(SC.ResponderContext, {});
+
+  // attempt to focus...
+  SC.Event.trigger(input, 'focus');
+
+  // verify it did receive focus
+  ok(view.get('focused'), 'view should have focus');
+  
+  // tell the pane to make our test responder the first responder
+  view.get('pane').makeFirstResponder(testResponder);
+  
+  // verify it no longer has focus
+  ok(!view.get('focused'), 'view should no longer have focus');
+});
+
 test("editing a field should not change the cursor position", function() {
   var textField = pane.view('empty');
   var input = textField.$('input');

--- a/frameworks/foundation/views/text_field.js
+++ b/frameworks/foundation/views/text_field.js
@@ -966,6 +966,15 @@ SC.TextFieldView = SC.FieldView.extend(SC.StaticLayout, SC.Editable,
   },
   
   /** @private
+    When we loose first responder, ensure that the field has been blurred.
+  */
+  willLoseFirstResponder: function () {
+    if(this.get('focused')) {
+      this.$input().blur();
+    }
+  },
+  
+  /** @private
     In IE, you can't modify functions on DOM elements so we need to wrap the
     call to select() like this.
   */


### PR DESCRIPTION
Added definition of 'willLoseFirstResponder' for SC.TextFieldView ensure that the input field is properly blurred when it looses first responder status.

This fixes issue #637 . For more details about the bug being fixed here, please see the issue.
