### PR TITLE
encodedBody function should not only be checking for isJSON or isXML

### DIFF
--- a/frameworks/ajax/system/request.js
+++ b/frameworks/ajax/system/request.js
@@ -159,8 +159,8 @@ SC.Request = SC.Object.extend(SC.Copyable, SC.Freezable,
     var ret = this.get('body'),
         ct = this.header('Content-Type');
     if (ret && this.get('isJSON') && typeof(ret) !== 'string') {
-      if (ct.test(/urlencoded/)) { ret = $.param(ret); }
-      if (ct.test(/json/)) { ret = SC.json.encode(ret); }
+      if (/urlencoded/.test(ct)) { ret = $.param(ret); }
+      if (/json/.test(ct)) { ret = SC.json.encode(ret); }
     }
     return ret;
   }.property('isJSON', 'isXML', 'body').cacheable(),


### PR DESCRIPTION
Way more important for the encoded body is the content type header, because even if I want json in return, it doesn't mean that it is a json encoded string that I'm sending. So I changed the function that it initially checks if the body is a string (if already string we don't need to encode at all) and then for the content type header. If the content type is application/json the body should be encoded to a json string if it is urlencoded we can use the $.param function from jQuery to create an urlencoded string.
