### PR TITLE
Multiplexed data source

### DIFF
--- a/frameworks/datastore/data_sources/multiplexed.js
+++ b/frameworks/datastore/data_sources/multiplexed.js
@@ -1,0 +1,244 @@
+// ==========================================================================
+// Project:   SproutCore - JavaScript Application Framework
+// Copyright: ©2011 Junction Networks
+// License:   Licensed under MIT license (see license.js)
+// ==========================================================================
+sc_require('data_sources/data_source');
+
+/** @class
+
+  A multiplexed data source will forward data to a number of registered
+  {@link SC.DataSourceDelegate}s that accept the {@link SC.Record} type provided.
+  This should be used when you have a single channel that has a multitude of
+  record types that are non-trivial to transform into data hashes suitable for
+  the store.
+
+  For example,
+
+      MyApp.dataSource = SC.MultiplexedDataSource.create({
+        delegates: 'presence chat muc roster vcard'.w(),
+
+        presence: MyApp.PresenceDataSourceDelegate,
+        chat: MyApp.MessageDataSourceDelegate.extend({ type: 'chat' }),
+        muc: MyApp.MultiUserChatSourceDelegate,
+        roster: MyApp.RosterItemDataSourceDelegate,
+        vcard: MyApp.VCardTempDataSourceDelegate
+      });
+
+      MyApp.store.set('dataSource', MyApp.dataSource);
+
+  The order of the delegates is irrelevant. Queries and CRUD actions will
+  be forwarded to the apropriated delegate(s).
+
+  Alternatively, you can use a more jQuery-like API for defining your data
+  sources:
+
+      MyApp.dataSource = SC.MultiplexedDataSource.create()
+        .from(MyApp.PresenceDataSourceDelegate)
+        .from(MyApp.MessageDataSourceDelegate.extend({ type: 'chat' }))
+        .from(MyApp.MultiUserChatSourceDelegate)
+        .from(MyApp.RosterItemDataSourceDelegate)
+        .from(MyApp.VCardTempDataSourceDelegate)
+
+      MyApp.store.set('dataSource', MyApp.dataSource);
+
+  A similar API can be used before creation time that allows {@link SC.DataSourceDelegate}s
+  to be wired to their parent {@link SC.DataSource} via the `plugin` method.
+
+  The child delegates have direct access to the parent {@link SC.MultiplexedDataSource},
+  which acts like a hub where all common functions and properties should be
+  placed.
+
+  @since 1.7
+  @extends SC.DataStore
+ */
+SC.MultiplexedDataSource = SC.DataSource.extend(
+  /** @scope SC.MultiplexedDataSource.prototype */{
+
+  /** @private
+    A lookup table of delegates to use by record type.
+    @type Hash
+   */
+  _ds_delegates: null,
+
+  /**
+    The delegates to be used by the multiplexed data source.
+    
+    @type String|String[]|SC.DataSourceDelegate|SC.DataSourceDelegate[]
+   */
+  delegates: null,
+
+  /** @private
+    Adds class instances of the delegates to this instance of the data source.
+   */
+  init: function () {
+    var delegates = this.constructor.delegates || this.get('delegates') || [];
+    if (!this._ds_delegates) this._ds_delegates = {};
+    if (!SC.isArray(delegates)) delegates = [delegates];
+    delegates.forEach(this.from, this);
+  },
+
+  /**
+    Adds the delegate to be used by the DataSource for the record types
+    it indicates.
+
+    @param {SC.DataSourceDelegate|String} del The delegate to register for use
+    @returns {SC.MultiplexedDataSource} The reciever.
+   */
+  from: function (del) {
+    var delegate = del,
+        recordTypes, recordType, i, len;
+    if (SC.typeOf(del) === SC.T_STRING) {
+      delegate = this.get(del);
+    }
+
+    if (SC.none(delegate)) {
+      throw SC.$error("'%@' does not exist. Did you forget to require() it?".fmt(del));
+    }
+
+    delegate = delegate.create({
+      dataSource: this
+    });
+
+    recordTypes = delegate.get('isDelegateFor');
+    if (SC.none(recordTypes)) {
+      throw SC.$error("'%@' has no SC.Records that it is delegating for. Did you forget to require() the record type, or is this delegate unused?".fmt(del));
+    }
+    if (!SC.isArray(recordTypes)) recordTypes = [recordTypes];
+
+    len = recordTypes.length;
+    for (i = 0; i < len; i++) {
+      recordType = recordTypes[i];
+      if (SC.typeOf(recordType) === SC.T_STRING) {
+        recordType = SC.objectForPropertyPath(recordType);
+        if (SC.none(recordType)) {
+          throw SC.$error("'%@' does not exist. Did you forget to require() it?".fmt(recordTypes[i]));
+        }
+        recordType[i] = recordType;
+      }
+      this._ds_delegates[SC.guidFor(recordType)] = delegate;
+    }
+    return this;
+  },
+
+  /**
+    Returns the {@link SC.DataSourceDelegate} that will delegate for
+    the given {@link SC.Record}.
+
+    @param {SC.Record} recordType The record type to lookup the delegate for.
+    @returns {SC.DataSourceDelegate} The delegate responsible for the given record type.
+   */
+  delegateFor: function (recordType) {
+    return this._ds_delegates[SC.guidFor(recordType)];
+  },
+
+  /**
+    Invokes a method on a delegate, returning `YES` or `NO` depending on whether
+    or not the request was handled.
+
+    @param {SC.DataSourceDelegate} delegate The delegate to invoke the method on.
+    @param {String} methodName The method to invoke on the delegate.
+    @param {...} args The arguments to provide to the delegate.
+    @returns {Boolean} Whether or not the request was handled by the delegate.
+   */
+  invokeDelegateMethod: function (delegate, methodName) {
+    var args = SC.A(arguments).slice(2);
+    if (!SC.none(delegate) && !SC.none(delegate[methodName])) {
+      return delegate[methodName].apply(delegate, args);
+    }
+    return NO;
+  },
+
+  /**
+    Passes through queries triggered by the store through a find() to the
+    registered delegate for that record type.
+
+    @param {SC.Store} store The requesting store.
+    @param {SC.Query} query The query describing the request.
+    @returns {Boolean} Whether or not the query was handled.
+   */
+  fetch: function (store, query) {
+    return this.invokeDelegateMethod(this.delegateFor(query.recordType),
+      "fetch", store, query);
+  },
+
+  /**
+    Passes through queries triggered by the store through a find() to the
+    registered delegate for that record type.
+
+    @param {SC.Store} store The requesting store.
+    @param {Number} storeKey The store key of the record to update.
+    @param {Hash} [params] Parameters passed by commitRecords().
+    @returns {Boolean} Whether or not the record update was handled.
+   */
+  updateRecord: function (store, storeKey, params) {
+    return this.invokeDelegateMethod(this.delegateFor(store.recordTypeFor(storeKey)),
+       "updateRecord", store, storeKey, params);
+  },
+
+  /**
+    Passes through queries triggered by the store through a find() or a refresh()
+    to the registered delegate for that record type.
+
+    @param {SC.Store} store The requesting store.
+    @param {Number} storeKey The store key of the record to retrieve.
+    @param {String} id The ID of the record to retrieve.
+    @returns {Boolean} Whether or not the record retrieval was handled.
+   */
+  retrieveRecord: function (store, storeKey, id) {
+    return this.invokeDelegateMethod(this.delegateFor(store.recordTypeFor(storeKey)),
+       "retrieveRecord", store, storeKey, id);
+  },
+
+  /**
+    Passes through queries triggered by the store through a createRecord() to the
+    registered delegate for that record type.
+
+    @param {SC.Store} store The requesting store.
+    @param {Number} storeKey The store key of the record to create.
+    @param {Hash} [params] Parameters passed by commitRecords().
+    @returns {Boolean} Whether or not the record creation was handled.
+   */
+  createRecord: function (store, storeKey, params) {
+    return this.invokeDelegateMethod(this.delegateFor(store.recordTypeFor(storeKey)),
+       "createRecord", store, storeKey, params);
+  },
+
+  /**
+    Passes through queries triggered by the store through a destroy() to the
+    registered delegate for that record type.
+
+    @param {SC.Store} store The requesting store.
+    @param {Number} storeKey The store key of the record to destroy.
+    @param {Hash} [params] Parameters passed by commitRecords().
+    @returns {Boolean} Whether or not the record destroy was handled.
+   */
+  destroyRecord: function (store, storeKey, params) {
+    return this.invokeDelegateMethod(this.delegateFor(store.recordTypeFor(storeKey)),
+       "destroyRecord", store, storeKey, params);
+  }
+
+});
+
+SC.MultiplexedDataSource.mixin(
+  /** @scope SC.MultiplexedDataSource */{
+
+  /**
+    The list of registered delegates.
+    @default null
+    @type SC.DataSourceDelegate[]
+   */
+  delegates: null,
+
+  /**
+    Registers a delegate to be used for an instance of {@link SC.MultiplexedDataSource}.
+    @param {String|SC.DataSourceDelegate} delegate The delegate to register for all instances of the data source.
+    @returns {SC.MultiplexedDataSource} The reciever.
+   */
+  plugin: function (delegate) {
+    var delegates = this.delegates;
+    if (!delegates) this.delegates = delegates = [];
+    delegates.push(delegate);
+    return this;
+  }
+});

--- a/frameworks/datastore/mixins/delegate.js
+++ b/frameworks/datastore/mixins/delegate.js
@@ -1,0 +1,55 @@
+// ==========================================================================
+// Project:   SproutCore - JavaScript Application Framework
+// Copyright: ©2011 Junction Networks
+// License:   Licensed under MIT license (see license.js)
+// ==========================================================================
+
+/** @class
+
+  The data source delegate that provides the implementation
+  for it's registered record type(s). All unknown properties
+  will be proxied to to the parent data source.
+
+  Mix {@link SC.DataSourceDelegate} into a {@link SC.DataSource}
+  of your choice.
+
+  @since 1.7
+ */
+SC.DataSourceDelegate = {
+
+  /**
+    An array of record types that are either extensions of
+    `SC.Record` or are strings that reference the absolute
+    paths to the record.
+
+    @default 'SC.Record'
+    @type String|String[]|SC.Record|SC.Record[]
+   */
+  isDelegateFor: 'SC.Record',
+
+  /**
+    The parent data source.
+
+    This will be set by the owning {@link SC.MultiplexedDataSource}
+    when instantiating this delegate.
+
+    @default null
+    @type SC.MultiplexedDataSource
+   */
+  dataSource: null,
+
+  /**
+    Proxies all unknownProperties to the parent data source.
+    This allows all shared properties to be in a central location.
+
+    If this the parent dataSource is also a {@link SC.DataSourceDelegate},
+    and it's an unknown property there too, it will query until it reaches
+    the root `dataSource`, then bottom out.
+   */
+  unknownProperty: function (key, value) {
+    if (arguments.length === 2) {
+      this.setPath('dataSource.' + key, value);
+    }
+    return SC.get(this.get('dataSource'), key);
+  }
+};

--- a/frameworks/datastore/tests/data_sources/multiplexed.js
+++ b/frameworks/datastore/tests/data_sources/multiplexed.js
@@ -1,0 +1,267 @@
+// ==========================================================================
+// Project:   SC.MultiplexedDataSource Unit Test
+// Copyright: ©2011 Junction Networks
+// License:   Licensed under MIT license (see license.js)
+// ==========================================================================
+/*globals module test ok equals same stop start */
+
+var MyApp, wasCalled;
+module("SC.MultiplexedDataSource", {
+  setup: function () {
+    MyApp = window.MyApp = {};
+    MyApp.DataSource = SC.MultiplexedDataSource.extend({
+      foo: 'baz',
+
+      bar: function () {
+        return 'qux';
+      }.property()
+    });
+
+    MyApp.store = SC.Store.create();
+    MyApp.Foo = SC.Record.extend();
+    MyApp.Bar = SC.Record.extend();
+    MyApp.FooDelegate = SC.DataSource.extend(
+      SC.DataSourceDelegate, {
+
+      isDelegateFor: 'MyApp.Foo',
+
+      init: function () {
+        wasCalled = true;
+        ok(this.get('dataSource'),
+           "The dataStore property should be populated on this delegate");
+
+        equals(this.get('foo'), "baz",
+               "unknown properties should be proxied to the parent data source. (raw)");
+        equals(this.get('bar'), "qux",
+               "unknown properties should be proxied to the parent data source. (computed)");
+        equals(this.get('isDelegateFor'), "MyApp.Foo",
+               "known properties should be intercepted by this object.");
+      },
+
+      fetch: function (store, query) {
+        wasCalled = true;
+        equals(query.recordType, MyApp.Foo,
+               "The record type should match.");
+        equals(arguments.length, 2);
+        return YES;
+      },
+
+      createRecord: function (store, storeKey, params) {
+        wasCalled = true;
+        equals(store.recordTypeFor(storeKey), MyApp.Foo,
+               "The record type should match.");
+        equals(arguments.length, 3);
+        return YES;
+      },
+
+      updateRecord: function (store, storeKey, params) {
+        wasCalled = true;
+        equals(store.recordTypeFor(storeKey), MyApp.Foo,
+               "The record type should match.");
+        equals(arguments.length, 3);
+        return YES;
+      },
+
+      retrieveRecord: function (store, storeKey, params) {
+        wasCalled = true;
+        equals(store.recordTypeFor(storeKey), MyApp.Foo,
+               "The record type should match.");
+        equals(arguments.length, 3);
+        return YES;
+      },
+
+      destroyRecord: function (store, storeKey, params) {
+        wasCalled = true;
+        equals(store.recordTypeFor(storeKey), MyApp.Foo,
+               "The record type should match.");
+        equals(arguments.length, 3);
+        return YES;
+      }
+    });
+
+    // Assume checking once on a single method will cover all of them.
+    MyApp.FooBarDelegate = SC.DataSource.extend(
+      SC.DataSourceDelegate, {
+      isDelegateFor: 'MyApp.Foo MyApp.Bar'.w(),
+
+      fetch: function (store, query) {
+        wasCalled = true;
+        return YES;
+      }
+    });
+
+  }
+});
+
+test("The dataSource will return NO for all records with no delegates", function () {
+  var ds = MyApp.DataSource.create();
+  ok(!wasCalled, "`init` should have not been called");
+  MyApp.store.set('dataSource', ds);
+  ok(MyApp.store.find(SC.Query.remote(MyApp.Foo)),
+     "the fetch should return a record array");
+  ok(!MyApp.store.find(MyApp.Foo, "testing retrieve"),
+     "no results should come from the retrieve");
+
+  var rec = MyApp.store.createRecord(MyApp.Foo, {});
+
+  equals(MyApp.store.commitRecord(MyApp.Foo, 'foo', rec.get('storeKey')), NO,
+         "commiting a new record should return NO");
+  MyApp.store.writeStatus(rec.get('storeKey'), SC.Record.READY_CLEAN);
+
+  rec.set('zero', 0);
+  equals(MyApp.store.commitRecord(MyApp.Foo, 'foo', rec.get('storeKey')), NO,
+         "updating the record should return NO");
+  MyApp.store.writeStatus(rec.get('storeKey'), SC.Record.READY_CLEAN);
+
+  rec.destroy();
+  equals(MyApp.store.commitRecord(MyApp.Foo, 'foo', rec.get('storeKey')), NO,
+         "destroying the record should return NO");
+});
+
+test("The dataSource will delegate calls to its registered delegates", function () {
+  var ds = MyApp.DataSource.create().from(MyApp.FooDelegate);
+  ok(wasCalled, "`init` should have been called");
+  wasCalled = NO;
+  MyApp.store.set('dataSource', ds);
+  ok(MyApp.store.find(SC.Query.remote(MyApp.Foo)),
+     "the fetch should return a record array");
+  ok(wasCalled, "`fetch` should have been called");
+  wasCalled = NO;
+
+  ok(MyApp.store.find(SC.Query.remote(SC.Record)),
+     "the fetch should return a record array");
+  ok(!wasCalled, "`fetch` should have not been called");
+  
+  ok(MyApp.store.find(MyApp.Foo, "testing retrieve"),
+     "retrieve should return a new record (because the dataSource handled the request YES)");
+  ok(wasCalled, "`retrieve` should have been called");
+  wasCalled = NO;
+
+  ok(!MyApp.store.find(SC.Record, "testing retrieve"),
+     "retrieve should not return anything");
+  ok(!wasCalled, "`retrieve` should have not been called");
+
+  var rec = MyApp.store.createRecord(MyApp.Foo, {});
+
+  equals(MyApp.store.commitRecord(MyApp.Foo, 'foo', rec.get('storeKey')), YES,
+         "commiting a new record should return YES");
+  ok(wasCalled, "`createRecord` should have been called");
+  wasCalled = NO;
+
+  MyApp.store.writeStatus(rec.get('storeKey'), SC.Record.READY_CLEAN);
+
+  rec.set('zero', 0);
+  equals(MyApp.store.commitRecord(MyApp.Foo, 'foo', rec.get('storeKey')), YES,
+         "updating a record should return YES");
+  ok(wasCalled, "`updateRecord` should have been called");
+  wasCalled = NO;
+
+  MyApp.store.writeStatus(rec.get('storeKey'), SC.Record.READY_CLEAN);
+
+  rec.destroy();
+
+  equals(MyApp.store.commitRecord(MyApp.Foo, 'foo', rec.get('storeKey')), YES,
+     "destroying the record should return YES");
+  ok(wasCalled, "`destroyRecord` should have been called");
+  wasCalled = NO;
+
+  rec = MyApp.store.createRecord(SC.Record, {});
+
+  equals(MyApp.store.commitRecord(SC.Record, 'foo', rec.get('storeKey')), NO,
+         "commiting a new record should return NO");
+  ok(!wasCalled, "`createRecord` should have not been called");
+
+  MyApp.store.writeStatus(rec.get('storeKey'), SC.Record.READY_CLEAN);
+
+  rec.set('zero', 0);
+  equals(MyApp.store.commitRecord(SC.Record, 'foo', rec.get('storeKey')), NO,
+         "updating a record should return NO");
+  ok(!wasCalled, "`updateRecord` should have not been called");
+
+  MyApp.store.writeStatus(rec.get('storeKey'), SC.Record.READY_CLEAN);
+
+  rec.destroy();
+
+  equals(MyApp.store.commitRecord(SC.Record, 'foo', rec.get('storeKey')), NO,
+         "destroying the record should return NO");
+  ok(!wasCalled, "`destroyRecord` should have not been called");
+});
+
+test("The dataSource will delegate calls to its registered delegates that were plugged into its prototype", function () {
+  MyApp.DataSource.plugin(MyApp.FooDelegate);
+
+  var ds = MyApp.DataSource.create();
+  ok(wasCalled, "`init` should have been called");
+  wasCalled = NO;
+
+  ds = MyApp.DataSource.create();
+  ok(wasCalled, "`init` should have been called");
+  wasCalled = NO;
+});
+
+test("The dataSource will delegate calls to its registered delegates that were provided via the `delegates` property (String property lookup)", function () {
+  var ds = MyApp.DataSource.create({
+    delegates: 'fooDelegate',
+    fooDelegate: MyApp.FooDelegate
+  });
+
+  ok(wasCalled, "`init` should have been called");
+  wasCalled = NO;
+});
+
+test("The dataSource will delegate calls to its registered delegates that were provided via the `delegates` property (String[] property lookup)", function () {
+  var ds = MyApp.DataSource.create({
+    delegates: ['fooDelegate'],
+    fooDelegate: MyApp.FooDelegate
+  });
+
+  ok(wasCalled, "`init` should have been called");
+  wasCalled = NO;
+});
+
+test("The dataSource will delegate calls to its registered delegates that were provided via the `delegates` property (raw SC.DataSourceDelegate)", function () {
+  var ds = MyApp.DataSource.create({
+    delegates: MyApp.FooDelegate
+  });
+
+  ok(wasCalled, "`init` should have been called");
+  wasCalled = NO;
+});
+
+test("The dataSource will delegate calls to its registered delegates that were provided via the `delegates` property (SC.DataSourceDelegate[])", function () {
+  var ds = MyApp.DataSource.create({
+    delegates: [MyApp.FooDelegate]
+  });
+
+  ok(wasCalled, "`init` should have been called");
+  wasCalled = NO;
+});
+
+test("Multiple recordTypes are allowed", function () {
+  MyApp.store.set('dataSource', MyApp.DataSource.create().from(MyApp.FooBarDelegate));
+  MyApp.store.find(SC.Query.remote(MyApp.Foo));
+  ok(wasCalled, "MyApp.Foo should be handled by the dataSource delegate");
+  wasCalled = NO;
+
+  MyApp.store.find(SC.Query.remote(MyApp.Bar));
+  ok(wasCalled, "MyApp.Bar should be handled by the dataSource delegate");
+  wasCalled = NO;
+
+  MyApp.store.find(SC.Query.remote(SC.Record));
+  ok(!wasCalled, "SC.Record should not be handled by the dataSource delegate");
+});
+
+test("Chained MultiplexedDataSources are allowed", function () {
+  var ds = MyApp.DataSource.create()
+         .from(SC.MultiplexedDataSource.extend(
+                 SC.DataSourceDelegate, {
+                   isDelegateFor: 'MyApp.Foo MyApp.Bar'.w(),
+                   delegates: 'fooDelegate barDelegate'.w(),
+
+                   fooDelegate: MyApp.FooDelegate,
+                   barDelegate: SC.DataSource.extend(SC.DataSourceDelegate)
+                 }));
+
+  ok(wasCalled, "`init` should have been called");
+  wasCalled = NO;
+});


### PR DESCRIPTION
I'm proposing an addition to the provided `SC.DataSource`s that allows for the multiplexing / demultiplexing of data from one parent data source to specific child data sources. This looks similar to `SC.CascadeDataSource`, but in the end allows for data sources to be designed in trees rather than cascades, with a link back to it's parent data source.

`SC.MultiplexedDataSource` is designed to be used by a single stream / source of data that has lots of different / complex record types that would require spaghetti code like so:

``` javascript
createRecord: function (store, storeKey) {
  switch(recordType) {
  case MyApp.ChatMessage:
    // dispatch to chat message record creator
  case MyApp.Buddy:
    // dispatch to buddy record creator
  case MyApp.VCard:
    // dispatch to vCard record creator
  default:
    return NO;
  }
}
```

Instead, each record can be handled by a stand-alone data source, which can be a `SC.DataSource`, `SC.CascadeDataSource`, or `SC.MultiplexedDataSource`. It _optionally_ requires the helper mixin `SC.DataSourceDelegate` which will help with accessing parent data source(s) by overriding `unknownProperty`.

This is designed to ease unit testing and reduce spaghetti / boiler plate in applications / frameworks that require a non-trivial data source.

A simple, non-trivial, working example of a multiplexed data source can be found at https://gist.github.com/1507264 (the cascade version can be found at https://gist.github.com/1510948).
