### PR TITLE
Fixed called_buildInDidFinsih in a test, delimeter to delimiter in code ...

### DIFF
--- a/frameworks/core_foundation/tests/views/view/build_children.js
+++ b/frameworks/core_foundation/tests/views/view/build_children.js
@@ -57,7 +57,7 @@ test("Calling buildInChild adds child and builds it in.", function(){
   // check right after build in is called
   ok(v.called_buildIn, "child started build in.");
   ok(v.isBuildingIn, "child is building in.");
-  ok(!p.called_buildInDidFinsihFor, "child has not finished building in, according to parent.");
+  ok(!p.called_buildInDidFinishFor, "child has not finished building in, according to parent.");
   
   // the parent view should be set already
   equals(v.get("parentView"), p, "Parent view should be the parent");

--- a/frameworks/core_foundation/views/view/manipulation.js
+++ b/frameworks/core_foundation/views/view/manipulation.js
@@ -280,7 +280,7 @@ SC.View.reopen(
   },
 
   /**
-    Implement this, and call didFinsihBuildOut when you are done.
+    Implement this, and call didFinishBuildOut when you are done.
   */
   buildOut: function() {
     this.buildOutDidFinish();

--- a/frameworks/datastore/system/query.js
+++ b/frameworks/datastore/system/query.js
@@ -565,7 +565,7 @@ SC.Query = SC.Object.extend(SC.Copyable, SC.Freezable,
 
     'STRING': {
       firstCharacter:   /['"]/,
-      delimeted:        true,
+      delimited:        true,
       evalType:         'PRIMITIVE',
 
       /** @ignore */
@@ -575,7 +575,7 @@ SC.Query = SC.Object.extend(SC.Copyable, SC.Freezable,
     'PARAMETER': {
       firstCharacter:   /\{/,
       lastCharacter:    '}',
-      delimeted:        true,
+      delimited:        true,
       evalType:         'PRIMITIVE',
 
       /** @ignore */
@@ -903,7 +903,7 @@ SC.Query = SC.Object.extend(SC.Copyable, SC.Freezable,
         currentToken        = null,
         currentTokenType    = null,
         currentTokenValue   = null,
-        currentDelimeter    = null,
+        currentDelimiter    = null,
         endOfString         = false,
         endOfToken          = false,
         belongsToToken      = false,
@@ -920,11 +920,11 @@ SC.Query = SC.Object.extend(SC.Copyable, SC.Freezable,
       // handling of special cases
       // check format
       if (t.format && !t.format.test(tokenValue)) tokenType = "UNKNOWN";
-      // delimeted token (e.g. by ")
-      if (t.delimeted) skipThisCharacter = true;
+      // delimited token (e.g. by ")
+      if (t.delimited) skipThisCharacter = true;
       
       // reserved words
-      if ( !t.delimeted ) {
+      if ( !t.delimited ) {
         for ( var anotherToken in grammar ) {
           if ( grammar[anotherToken].reservedWord
                && anotherToken == tokenValue ) {
@@ -966,8 +966,8 @@ SC.Query = SC.Object.extend(SC.Copyable, SC.Freezable,
       // current character
       c = inputString.charAt(i);
     
-      // set true after end of delimeted token so that
-      // final delimeter is not catched again
+      // set true after end of delimited token so that
+      // final delimiter is not catched again
       skipThisCharacter = false;
         
     
@@ -977,7 +977,7 @@ SC.Query = SC.Object.extend(SC.Copyable, SC.Freezable,
       
         // some helpers
         t = grammar[currentToken];
-        endOfToken = t.delimeted ? c===currentDelimeter : t.notAllowed.test(c);
+        endOfToken = t.delimited ? c===currentDelimiter : t.notAllowed.test(c);
       
         // if still in token
         if ( !endOfToken ) currentTokenValue += c;
@@ -1007,10 +1007,10 @@ SC.Query = SC.Object.extend(SC.Copyable, SC.Freezable,
           t = grammar[currentToken];
           currentTokenValue = c;
           // handling of special cases
-          if ( t.delimeted ) {
+          if ( t.delimited ) {
             currentTokenValue = "";
-            if ( t.lastCharacter ) currentDelimeter = t.lastCharacter;
-            else currentDelimeter = c;
+            if ( t.lastCharacter ) currentDelimiter = t.lastCharacter;
+            else currentDelimiter = c;
           }
 
           if ( t.singleCharacter || endOfString ) {

--- a/frameworks/experimental/frameworks/designer/css/css_style_sheet.js
+++ b/frameworks/experimental/frameworks/designer/css/css_style_sheet.js
@@ -46,7 +46,7 @@ SC.CSSStyleSheet = SC.Object.extend(
   },
   
   /**
-    @property {Boolean} YES if the stylsheet is enabled.
+    @property {Boolean} YES if the stylesheet is enabled.
   */
   isEnabled: function(key, val) {
     if (val !== undefined) {
@@ -144,7 +144,7 @@ SC.mixin(SC.CSSStyleSheet,
         var ss2 = SC.CSSStyleSheet.find('style') ; // same thing
         sc_assert(ss === ss2) ; // SC.CSSStyleSheet objects are stable
     
-    @param {String} nameOrUrl a stylsheet name or href to find
+    @param {String} nameOrUrl a stylesheet name or href to find
     @returns {SC.CSSStyleSheet} null if not found
   */
   find: function(nameOrUrl) {

--- a/frameworks/runtime/system/logger.js
+++ b/frameworks/runtime/system/logger.js
@@ -1493,11 +1493,11 @@ SC.Logger = SC.Object.create(
   */
   _argumentsToString: function() {
     var ret       = "",
-        delimeter = SC.LOGGER_LOG_DELIMITER,
+        delimiter = SC.LOGGER_LOG_DELIMITER,
         i, len;
 
     for (i = 0, len = (arguments.length - 1);  i < len;  ++i) {
-      ret += arguments[i] + delimeter;
+      ret += arguments[i] + delimiter;
     }
     ret += arguments[len];
     return ret;

--- a/themes/ace/resources/master-detail/master-detail.css
+++ b/themes/ace/resources/master-detail/master-detail.css
@@ -5,7 +5,7 @@ $theme.master-detail {
     -webkit-border-top-left-radius: 10px;
     -webkit-border-top-right-radius: 10px;
     -moz-border-radius-topleft: 10px;
-    -moz-border-raidus-topright: 10px;
+    -moz-border-radius-topright: 10px;
   }
   
   & > .sc-view {
@@ -22,6 +22,6 @@ $theme.master-detail {
     -webkit-border-top-left-radius: 10px;
     -webkit-border-top-right-radius: 10px;
     -moz-border-radius-topleft: 10px;
-    -moz-border-raidus-topright: 10px;
+    -moz-border-radius-topright: 10px;
   }
 }

--- a/themes/iphone_theme/english.lproj/core.css
+++ b/themes/iphone_theme/english.lproj/core.css
@@ -1,5 +1,5 @@
 body {
-  background: sc_static('images/pinstripes') repeat;
+  background: sc_static('images/pinstripes.png') repeat;
   top: 0;
   bottom: 0;
   left: 0;

--- a/themes/legacy_theme/english.lproj/toolbar.css
+++ b/themes/legacy_theme/english.lproj/toolbar.css
@@ -1,5 +1,5 @@
 .sc-toolbar-view {
-  background: sc_static('images/sc-theme-repeat-x') repeat-x 0px -650px; 
+  background: sc_static('images/sc-theme-repeat-x.png') repeat-x 0px -650px;
   border: none;
   border-top: 1px solid #4d5567; /* #818ea4; */
   -webkit-box-shadow: 0px -1px 2px rgba(0,0,0,0.3);


### PR DESCRIPTION
...and comments, raidus to radius in css, stylsheet to stylesheet in css comments, and added several missing .png extensions in css image references

The called_buildInDidFinsih misspelling was in a test on this line:

ok(!p.called_buildInDidFinishFor, "child has not finished building in, according to parent.");

so was evaluating to true, even though it didn't fire apparently.

The raidus misspelling was in the css, as were the missing .png file extensions, but the other changes were in comments.
