### PR TITLE
SC.TextFieldView instantiates and adds accessory views as a child multiple times.

### DIFF
--- a/frameworks/foundation/tests/views/text_field/ui.js
+++ b/frameworks/foundation/tests/views/text_field/ui.js
@@ -589,6 +589,44 @@ test("Adding both left and right accessory views changes style -- using design()
   ok(!paddingElement.style.left, 'after removing the left accessory view the padding element should have no left style');
 });
 
+test("Accessory views should only be instantiated once", function() {  
+  var view = pane.view('with value');
+  
+  // Test the left accessory view
+  SC.RunLoop.begin();
+  var leftAccessoryViewInitCount = 0;
+  var leftAccessoryView = SC.View.design({
+   layout:  { top:1, left:2, width:16, height:16 },
+   init: function() {
+     sc_super();
+     leftAccessoryViewInitCount++;
+   }
+  });
+  view.set('leftAccessoryView', leftAccessoryView);
+  SC.RunLoop.end();
+  
+  // Check it
+  equals(leftAccessoryViewInitCount, 1, 'the left accessory view should only be initialized once');
+  
+  // Reset to null so it isn't created a second time when rightAccessoryView is set
+  view.set('leftAccessoryView', null);
+  
+  // Test the right accessory view
+  SC.RunLoop.begin();
+  var rightAccessoryViewInitCount = 0;
+  var rightAccessoryView = SC.View.design({
+   layout:  { top:1, right:3, width:17, height:16 },
+    init: function() {
+      sc_super();
+      rightAccessoryViewInitCount++;
+    }
+  });
+  view.set('rightAccessoryView', rightAccessoryView);
+  SC.RunLoop.end();
+  
+  // Check it
+  equals(rightAccessoryViewInitCount, 1, 'the right accessory view should only be initialized once');
+});
 
 
 // ..........................................................

--- a/frameworks/foundation/views/text_field.js
+++ b/frameworks/foundation/views/text_field.js
@@ -719,28 +719,19 @@ SC.TextFieldView = SC.FieldView.extend(SC.StaticLayout, SC.Editable,
         position, accessoryView, frames, width, layout, offset, frame;
     for (i = 0;  i < numberOfAccessoryViewPositions;  i++) {
       position = accessoryViewPositions[i];
-      accessoryView = this.get(position + 'AccessoryView');
-      if (accessoryView) {
-        // need acessoryView as an instance, not class...
-        if (accessoryView.isClass) {
-          accessoryView = accessoryView.create({
-            layoutView: this
-          });
-        }
-        // sanity check
-        if (accessoryView.get) {
-          frame = accessoryView.get('frame');
-          if (frame) {
-            width = frame.width;
-            if (width) {
-              // Also account for the accessory view's inset.
-              layout = accessoryView.get('layout');
-              if (layout) {
-                offset = layout[position];
-                width += offset;
-              }
-              widths[position] = width;
+      accessoryView = this['_' + position + 'AccessoryView'];
+      if (accessoryView && accessoryView.isObservable) {
+        frame = accessoryView.get('frame');
+        if (frame) {
+          width = frame.width;
+          if (width) {
+            // Also account for the accessory view's inset.
+            layout = accessoryView.get('layout');
+            if (layout) {
+              offset = layout[position];
+              width += offset;
             }
+            widths[position] = width;
           }
         }
       }


### PR DESCRIPTION
Added unit test to prove accessory views are getting instantiated more than once, then fixed the problem. 

To elaborate further, _getAccessoryViewWidths() was referring to the accessory view classes instead the instantiated views.  

It was calling: `accessoryView = this.get(position + 'AccessoryView');`
Instead of: `accessoryView = this['_' + position + 'AccessoryView'];`

Additionally, in the event _getAccessoryViewWidths() found a class it would improperly create a view from it (not adding it to the SC.TextFieldView's internal cache). Since I have updated this function to **always** find the instantiated view, there is no need for it to create views. This code was removed.

The result in all of this was the same view being created and added as a child multiple times. Not only is this incorrect, but it causes major issues with accessory views using preset layerIds. 
