### PR TITLE
Updated SC.TextFieldView style so that '.hint' will match '.sc-hint'

### DIFF
--- a/frameworks/foundation/resources/text_field.css
+++ b/frameworks/foundation/resources/text_field.css
@@ -54,7 +54,7 @@
   }
   
   
-  .sc-hint {
+  .sc-hint, .hint {
   	z-index: 1;
   	position: absolute;
   	top: 3px;
@@ -66,7 +66,8 @@
   	font-size: 12px;
   }
 
-  &.text-area .sc-hint {
+  &.text-area .sc-hint,
+  &.text-area .hint {
   	top: 2px;
   	left: 3px;
   	right: 3px;


### PR DESCRIPTION
The Apple push back contains a new feature, 'hintOnFocus' which uses div to act in place of a 'placeholder' so that it remain in view when the text field has focus. This feature is enabled by default, however does not have any styles and looks awkward. I updated the stylesheet so that traditional hint (placeholder) and the new hint (div overlap) now both share the same styles. So regardless of whether or not you use 'hintOnFocus' your hint will look the same (grey and centered).

This fixes part of issue #685 (issue #685 is contains two separated issues).
