### PR TITLE
In Firefox, parts of the text field were unclickable when hintOnFocus was YES

### DIFF
--- a/frameworks/foundation/resources/text_field.css
+++ b/frameworks/foundation/resources/text_field.css
@@ -53,9 +53,11 @@
     -webkit-appearance:none;
   }
   
+  .sc-hint {
+    z-index: 1;
+  }  
   
   .sc-hint, .hint {
-  	z-index: 1;
   	position: absolute;
   	top: 3px;
   	left: 1px;


### PR DESCRIPTION
Fixed Style bug introduced my previous commit. On firefox parts of the text field were unclickable when hintOnFocus was YES and the hint was visible. This was due to a z-index value being set. My apologizes on not testing this more throughly. All is well on other browsers.
