### PR TITLE
Added '_inputElementTagName' override back to SC.TextFieldView. 

### DIFF
--- a/frameworks/foundation/views/text_field.js
+++ b/frameworks/foundation/views/text_field.js
@@ -1131,6 +1131,18 @@ SC.TextFieldView = SC.FieldView.extend(SC.StaticLayout, SC.Editable,
   },
   
   /** @private
+    Overridden from SC.FieldView. Provides correct tag name based on the 
+    'isTextArea' property.
+   */
+  _inputElementTagName: function() {
+    if (this.get('isTextArea')) {
+      return 'textarea';
+    } else {
+      return 'input';
+    }
+  },
+  
+  /** @private
     This observer makes sure to hide the hint when a value is entered, or
     show it if it becomes empty.
   */


### PR DESCRIPTION
This provides the correct tag name based on the 'isTextArea' property. Lost in the merge_public force push.

Fixes issue #693 and broken foundation unit tests.
