### PR TITLE
delete emptyView in template_collection after removing from tree

### DIFF
--- a/frameworks/template_view/views/template_collection.js
+++ b/frameworks/template_view/views/template_collection.js
@@ -208,7 +208,7 @@ SC.TemplateCollectionView = SC.TemplateView.extend(
     // If the contents were empty before and this template collection has an empty view
     // remove it now.
     var emptyView = this.get('emptyView');
-    if (emptyView) { emptyView.$().remove(); emptyView.removeFromParent(); }
+    if (emptyView) { emptyView.$().remove(); emptyView.removeFromParent(); emptyView.destroy(); }
 
     // Loop through child views that correspond with the removed items.
     // Note that we loop from the end of the array to the beginning because


### PR DESCRIPTION
There is a small memory leak in the template collection view. arrayContentDidChange creates a new empty view every time if necessary. arrayContentWillChange removes this view, but doesn't destroy it.
