### PR TITLE
Fix the CSS for ModalPane backdrop for PanelPane

### DIFF
--- a/frameworks/desktop/resources/modal.css
+++ b/frameworks/desktop/resources/modal.css
@@ -5,4 +5,12 @@
   .msie &{
     background-image: url('.');
   }
+
+  &.for-sc-panel {
+    background: black;
+    opacity: 0.3;
+    -moz-opacity: 0.3;
+    -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=30)";
+    filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=30);
+  }
 }

--- a/frameworks/desktop/resources/panel.css
+++ b/frameworks/desktop/resources/panel.css
@@ -3,14 +3,7 @@
 .sc-pane.sc-panel {
   overflow: visible;
   z-index: 100;
-  &.for-sc-panel {
-    background: black;
-    opacity: 0.3;
-    -moz-opacity: 0.3;
-    -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=30)"; 
-    filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=30);
-  }
-  
+
   > .sc-view {
     border: 0px #444 solid;
     background-color: #eaeaea ;


### PR DESCRIPTION
The ModalPane that's used as a backdrop for PanelPane no longer gets darkened styling because the **.for-sc-panel** selector is applied to **.sc-panel** rather than **.sc-modal**

The backdrop definition is here:
https://github.com/sproutcore/sproutcore/blob/master/frameworks/desktop/panes/panel.js#L101
