### PR TITLE
This fixes the textarea implementation by adding a required overloaded method

### DIFF
--- a/frameworks/foundation/views/text_field.js
+++ b/frameworks/foundation/views/text_field.js
@@ -65,6 +65,16 @@ SC.TextFieldView = SC.FieldView.extend(SC.StaticLayout, SC.Editable,
   */
   isTextArea: NO,
 
+  /** @private
+    Override to specify the HTML element type to use as the field. For
+    example, "input" or "textarea".
+  */
+  _inputElementTagName: function() {
+    var tagName = this.get("isTextArea") ? 'textarea' : 'input';
+    return tagName;
+  },
+
+
   /**
     The hint to display while the field is not active.
     
@@ -637,7 +647,7 @@ SC.TextFieldView = SC.FieldView.extend(SC.StaticLayout, SC.Editable,
       }
     }
     else {
-      var input= this.$input(),
+      var input=this.$input(),
           elem = input[0],
           val = this.get('value');
 


### PR DESCRIPTION
Without this overloaded method (which is inherited from SC.FieldView) whenever a text field is created with isTextArea:YES it would not work and crash the app.
