### PR TITLE
Removed self-closing HTML since they don't really mean anything anymore

### DIFF
--- a/lib/index.rhtml
+++ b/lib/index.rhtml
@@ -9,10 +9,7 @@
    # change.
 -%>
 <!doctype html>
-<!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7" lang="<%=language%>"> <![endif]-->
-<!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8" lang="<%=language%>"> <![endif]-->
-<!--[if IE 8]>         <html class="no-js lt-ie9" lang="<%=language%>"> <![endif]-->
-<!--[if gt IE 8]><!--> <html<% unless @content_for_html5_manifest.blank? %> manifest="manifest.appcache"<% end %> class="no-js" lang="<%=language%>"> <!--<![endif]-->
+<html<% unless @content_for_html5_manifest.blank? %> manifest="manifest.appcache"<% end %> class="no-js" lang="<%=language%>">
   <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge<%= config.chrome_frame ? ',chrome=1' : '' %>"  >
 


### PR DESCRIPTION
Self-closing HTML is a thing of the past, removed the /> to save some bytes and make browsers happy. (per http://www.webkit.org/blog/68/understanding-html-xml-and-xhtml/ )

Added no-js class name so developers can include messaging to users when JS is not turned on
Added lang attribute to HTML tag for better accessibility support see: http://www.w3.org/TR/html4/struct/dirlang.html
Also updated the manifest file name per abbot#20e22b16afed69d1316a94f74e75245d970601b8
