### PR TITLE
Fixing pasting in SC.TextFieldView. 

### DIFF
--- a/frameworks/foundation/views/text_field.js
+++ b/frameworks/foundation/views/text_field.js
@@ -913,6 +913,9 @@ SC.TextFieldView = SC.FieldView.extend(SC.StaticLayout, SC.Editable,
     // our key/mouse down/up handlers (such as the user choosing Select All
     // from a menu).
     SC.Event.add(input, 'select', this, this._textField_selectionDidChange);
+    
+    // handle a "paste" from app menu and context menu
+    SC.Event.add(input, 'input', this, this._textField_inputDidChange);
   },
 
   /**
@@ -926,6 +929,7 @@ SC.TextFieldView = SC.FieldView.extend(SC.StaticLayout, SC.Editable,
     SC.Event.remove(input, 'blur',   this, this._textField_fieldDidBlur);
     SC.Event.remove(input, 'select', this, this._textField_selectionDidChange);
     SC.Event.remove(input, 'keypress',  this, this._firefox_dispatch_keypress);
+    SC.Event.remove(input, 'input', this, this._textField_inputDidChange);
   },
 
   /** @private
@@ -1003,6 +1007,20 @@ SC.TextFieldView = SC.FieldView.extend(SC.StaticLayout, SC.Editable,
       }, this);
     }
     this.updateHintOnFocus();
+  },
+  
+  /** @private
+    Context-menu paste does not trigger fieldValueDidChange normally. To do so, we'll capture the
+    input event and avoid duplicating the "fieldValueDidChange" call if it was already issued elsewhere.
+    
+    I welcome someone else to find a better solution to this problem. However, please make sure that it
+    works with pasting via shortcut, context menu and the application menu on *All Browsers*.
+   */
+  _textField_inputDidChange: function() {
+    var timerNotPending = SC.empty(this._fieldValueDidChangeTimer) || !this._fieldValueDidChangeTimer.get('isValid');
+    if(this.get('applyImmediately') && timerNotPending) {
+      this.invokeLater(this.fieldValueDidChange, 10);
+    }
   },
 
   /** @private
@@ -1166,12 +1184,10 @@ SC.TextFieldView = SC.FieldView.extend(SC.StaticLayout, SC.Editable,
     }
 
     if (this.get('applyImmediately')) {
-      // There used to be an invokeLater here instead of setTimeout. What we
-      // really need is setTimeout.
-      var self = this;
-      setTimeout(function () {
-        self.fieldValueDidChange();
-      }, 10);
+      // This has gone back and forth several times between invokeLater and setTimeout.
+      // Now we're back to invokeLater, please read the code comment above 
+      // this._textField_inputDidChange before changing it again.
+      this._fieldValueDidChangeTimer = this.invokeLater(this.fieldValueDidChange, 10);
     }
 
     return YES;


### PR DESCRIPTION
Previous when pasting from the context menu or the application menu the value property was not properly updated. That is now resolved with this pull request. I tried for hours to produce a unit test to validate this change, but could not.

This fixes #598.
