### PR TITLE
Popover pickerpane: add css to implement left and right pointer

### DIFF
--- a/themes/ace/resources/picker/popover/popover.css
+++ b/themes/ace/resources/picker/popover/popover.css
@@ -110,4 +110,48 @@
       .sc-pointer { left: 70px; }
     }
   }
+
+  $theme.picker.perfectLeft {
+    .sc-pointer {
+      z-index: 6;
+      position: absolute; width: 20px; height: 50px; margin-left: -20px; right: 0px; top: 40px;
+      @include slice("popover_pointers.png", $right: 0, $top: 85, $width: 20, $height: 50);
+    }
+
+    &.solid .sc-pointer, .solid .sc-pointer {
+      bottom: 0px;
+      @include slice("popover_pointers.png", $right: 0, $top: 85, $width: 20, $height: 50);
+    }
+
+    .top-toolbar .sc-pointer { 
+      bottom: 0px;
+      @include slice("popover_pointers.png", $right: 0, $top: 85, $width: 20, $height: 50);
+    }
+
+    &.extra-left {
+      .sc-pointer { left: 70px; }
+    }
+  }
+
+  $theme.picker.perfectRight {
+    .sc-pointer {
+      z-index: 6;
+      position: absolute; width: 20px; height: 50px; margin-left: 0px; left: 0px; top: 40px;
+      @include slice("popover_pointers.png", $left: 0, $top: 85, $width: 20, $height: 50);
+    }
+
+    &.solid .sc-pointer, .solid .sc-pointer {
+      bottom: 0px;
+      @include slice("popover_pointers.png", $left: 0, $top: 85, $width: 20, $height: 50);
+    }
+
+    .top-toolbar .sc-pointer { 
+      bottom: 0px;
+      @include slice("popover_pointers.png", $left: 0, $top: 85, $width: 20, $height: 50);
+    }
+
+    &.extra-left {
+      .sc-pointer { left: 70px; }
+    }
+  }
 }


### PR DESCRIPTION
Previously picker pane only had styling for top and bottom pointers.
This adds left and right. It basically has the same purpose of:

https://github.com/sproutcore/sproutcore/pull/615

but applies against master (615 instead was for 1.6).
