### PR TITLE
SC.SplitView is not properly resetting the cursor after a drag

### DIFF
--- a/frameworks/desktop/tests/views/split/methods.js
+++ b/frameworks/desktop/tests/views/split/methods.js
@@ -49,6 +49,18 @@ test("Layout direction is Vertical",function() {
   equals(view.getPath('thumbViewCursor.cursorStyle'),"ns-resize",'The Cursor is');
 });
 
+test("Cursor remains correct after drag", function() {
+  view.set('layoutDirection', SC.LAYOUT_HORIZONTAL) ;
+  equals(view.getPath('thumbViewCursor.cursorStyle'), "ew-resize", 'The Cursor is');
+ 	
+ 	// Trigger the action
+ 	var elem = view.getPath('dividerView.layer');
+ 	SC.Event.trigger(elem, 'mousedown'); 	
+ 	SC.Event.trigger(elem, 'mouseup');
+  
+  equals(view.getPath('thumbViewCursor.cursorStyle'), "ew-resize",'The Cursor is');
+});
+
 // 
 // test("performing the mouse up event", function() {
 // 	var elem = thumb.get('layer');

--- a/frameworks/desktop/views/split.js
+++ b/frameworks/desktop/views/split.js
@@ -570,13 +570,7 @@ SC.SplitView = SC.View.extend(
     	return YES;
     }
 
-    var cursor = this.get('thumbViewCursor'),
-        cloneCursor = SC.clone(cursor),
-        dV= this.get('dividerView');
-    cursor.set('cursorStyle', SC.SYSTEM_CURSOR);
-    dV.set('cursor', cloneCursor);
-    this.set('cursor', cursor);
-
+    this._setCursorStyle();
     return NO;
   },
 


### PR DESCRIPTION
SC.SplitView was not properly resetting the cursor after a drag had occurred. Provided a unit test to prove this issue, then fixed it.
