### PR TITLE
Removed layer check from SC.TemplateCollectionView when cleaning up old items

### DIFF
--- a/frameworks/template_view/tests/views/template/collection.js
+++ b/frameworks/template_view/tests/views/template/collection.js
@@ -425,3 +425,16 @@ test("#collection helper should raise an error when passing a first argument tha
   ok(errored, "throws an error when creating the view");
 });
 
+test("should still cleanup childViews after removed from DOM", function() {
+  var view = SC.TemplateCollectionView.create({
+    content: [1, 2, 3]
+  });
+
+  view.createLayer();
+  equals(view.get('childViews').length, 3, "precond - creates three child views");
+
+  view.destroyLayer();
+
+  view.set('content', null);
+  equals(view.get('childViews').length, 0, "should not have any child views");
+});

--- a/frameworks/template_view/views/template_collection.js
+++ b/frameworks/template_view/views/template_collection.js
@@ -203,8 +203,6 @@ SC.TemplateCollectionView = SC.TemplateView.extend(
   }.observes('content'),
 
   arrayContentWillChange: function(start, removedCount, addedCount) {
-    if (!this.get('layer')) { return; }
-
     // If the contents were empty before and this template collection has an empty view
     // remove it now.
     var emptyView = this.get('emptyView');
@@ -218,9 +216,11 @@ SC.TemplateCollectionView = SC.TemplateView.extend(
     len = childViews.get('length');
     for (idx = start+removedCount-1; idx >= start; idx--) {
       childView = childViews[idx];
-      childView.$().remove();
-      childView.removeFromParent();
-      childView.destroy();
+      if(childView) {
+        childView.$().remove();
+        childView.removeFromParent();
+        childView.destroy();
+      }
     }
   },
 


### PR DESCRIPTION
Removed layer check from SC.TemplateCollectionView when cleaning up old items to ensure that childViews are cleaned up when the view is removed from the DOM.

I provided a test to illustrate the problem and fixed it.
