### PR TITLE
Moved default 'right' value for the 'right-icon' class so that it has proper scope

### DIFF
--- a/frameworks/desktop/resources/list_item.css
+++ b/frameworks/desktop/resources/list_item.css
@@ -77,10 +77,10 @@
   	left: 25px;
   }
   
-  .has-count img.right-icon {
-    right: 32px;
-  }
-  &.has-count{
+  &.has-count {
+    img.right-icon {
+      right: 32px;
+    }
     &.two-digit img.right-icon {
       right: 38px;
     }


### PR DESCRIPTION
While investigating another issue I noticed that when the 'unread' option on a SC.ListItemView was set, if the unread value is a single digit, there is a CSS bug. See screenshot below.

Broken CSS (before):
![Broken CSS](http://i.imgur.com/rVCFE.png)

Fixed CSS (after):
![Fixed CSS](http://i.imgur.com/Au86K.png)
