### PR TITLE
Added bindings between the tree controller and it's tree item observer to keep the selection options in sync

### DIFF
--- a/frameworks/foundation/controllers/tree.js
+++ b/frameworks/foundation/controllers/tree.js
@@ -73,6 +73,9 @@ SC.TreeController = SC.ObjectController.extend(SC.SelectionSupport,
     var ret, content = this.get('content');
     if (content) {
       ret = SC.TreeItemObserver.create({ item: content, delegate: this });
+      ret.bind('allowsSelection', this, 'allowsSelection');
+      ret.bind('allowsMultipleSelection', this, 'allowsMultipleSelection');
+      ret.bind('allowsEmptySelection', this, 'allowsEmptySelection');
     } else ret = null; // empty!
     this._sctc_arrangedObjects = ret ;
 

--- a/frameworks/foundation/tests/controllers/tree/selection_support.js
+++ b/frameworks/foundation/tests/controllers/tree/selection_support.js
@@ -338,3 +338,29 @@ function() {
   equals(selectionSet.get('length'), 0, 'selection set should have length 0');
   ok(indexSet === null, 'selection set should not have an indexSet');
 });
+
+test("SC.TreeController(SC.SelectionSupport) selection settings should persist between controller and tree item observer",
+function() {
+  var treeItemObserver = controller.get('arrangedObjects');
+  
+  SC.RunLoop.begin();
+  controller.set('allowsSelection', YES);
+  controller.set('allowsMultipleSelection', YES);
+  controller.set('allowsEmptySelection', YES);
+  SC.RunLoop.end();
+  
+  equals(treeItemObserver.get('allowsSelection'), YES, 'allowsSelection on the treeItemObserver should be YES');
+  equals(treeItemObserver.get('allowsMultipleSelection'), YES, 'allowsMultipleSelection on the treeItemObserver should be YES');
+  equals(treeItemObserver.get('allowsEmptySelection'), YES, 'allowsEmptySelection on the treeItemObserver should be YES');
+  
+  SC.RunLoop.begin();
+  controller.set('allowsSelection', NO);
+  controller.set('allowsMultipleSelection', NO);
+  controller.set('allowsEmptySelection', NO);
+  SC.RunLoop.end();
+  
+  equals(treeItemObserver.get('allowsSelection'), NO, 'allowsSelection on the treeItemObserver should be NO');
+  equals(treeItemObserver.get('allowsMultipleSelection'), NO, 'allowsMultipleSelection on the treeItemObserver should be NO');
+  equals(treeItemObserver.get('allowsEmptySelection'), NO, 'allowsEmptySelection on the treeItemObserver should be NO');
+  
+});


### PR DESCRIPTION
The options referred to in the title are 'allowsSelection', 'allowsMultipleSelection' and 'allowsEmptySelection'.

This was prompted by #421, but we've run into this in our app as well. The problem here is that the SC.ListView expects to be able to get these properties from it's content object bound to the view ( 'content.allowsMultipleSelection' ). When a view is bound to an SC.ArrayController this works fine because the arrangedObjects property points to the controller it's self. But when bound to an SC.TreeController arrangedObjects points to the tree item observer, not the tree controller. So these properties are not properly retrieved by the view, because they do not reside on the content object.

My initial thought was to try mixing SC.SelectionSet into the tree item observer, however that makes it hard for the user to properly set the options. Additionally, the tree controller should have SC.SelectionSet mixed in because that's where selection needs to reside. 

So that brings me to my solution. These options need to persist via binds between the tree controller and the tree item observer. As always, I'd welcome any alternative solutions.
