### PR TITLE
Fixed conflict with SC.AlertPane target property

### DIFF
--- a/frameworks/desktop/panes/alert.js
+++ b/frameworks/desktop/panes/alert.js
@@ -390,7 +390,7 @@ SC.AlertPane = SC.PanelPane.extend(
       } else {
         rootResponder = this.getPath('pane.rootResponder');
         if(rootResponder) {
-          target = sender.get('target');
+          target = sender.get('customTarget');
           rootResponder.sendAction(action, target || del, this, this, null, this);
         }
       }
@@ -451,7 +451,7 @@ SC.AlertPane.mixin(
         
         buttonView.set('title'.fmt(idx), title);
         if(action) buttonView.set('customAction'.fmt(idx), action);
-        if(target) buttonView.set('target'.fmt(idx), target);
+        if(target) buttonView.set('customTarget'.fmt(idx), target);
         buttonView.set('isVisible', !!title);
         buttonView.set('themeName', themeName);
       });

--- a/frameworks/desktop/tests/panes/alert/ui.js
+++ b/frameworks/desktop/tests/panes/alert/ui.js
@@ -212,16 +212,22 @@ test("AlertPane.info with individual actions and targets for three buttons", fun
     clickValue = null;
   }
   
+  function clickButton(button) {
+    var elem = button.$();
+    SC.Event.trigger(elem, 'mousedown');
+    SC.Event.trigger(elem, 'mouseup');
+  }
+  
   showPane();
-  pane.dismiss(pane.get('button1'));
+  clickButton(pane.get('button1'));
   equals(clickValue, 'OK', 'Action for the OK button was clicked');
 
   showPane();
-  pane.dismiss(pane.get('button2'));
+  clickButton(pane.get('button2'));
   equals(clickValue, 'Cancel', 'Action for the Cancel button was clicked');
   
   showPane();
-  pane.dismiss(pane.get('button3'));
+  clickButton(pane.get('button3'));
   equals(clickValue, 'Extra', 'Action for the Extra button was clicked');
   
 });


### PR DESCRIPTION
Changed `target` property to `customTarget` when setting button arguments on alert panes to prevent conflict. Also modified existing test to expose the current problem.

This fixes #570 .
