### PR TITLE
Updated SC.RenderContext.escapeHTML to accept number arguments. 

### DIFF
--- a/frameworks/core_foundation/system/render_context.js
+++ b/frameworks/core_foundation/system/render_context.js
@@ -1007,9 +1007,13 @@ SC.RenderContext.fn.css = SC.RenderContext.fn.addStyle;
   plain text.  You should make sure you pass all user-entered data through
   this method to avoid errors.  You can also do this with the text() helper
   method on a render context.
+  
+  @param {String|Number} text value to escape
+  @returns {String} string with all HTML values properly escaped
 */
 SC.RenderContext.escapeHTML = function(text) {
     if (!text) return '';
+    if (SC.typeOf(text) === SC.T_NUMBER) { text = text.toString(); }
     return text.replace(_escapeHTMLRegex, _escapeHTMLMethod);
 };
 })();

--- a/frameworks/core_foundation/tests/system/render_context/escape_html.js
+++ b/frameworks/core_foundation/tests/system/render_context/escape_html.js
@@ -39,3 +39,10 @@ test("Tests stolen from Prototype.js", function() {
     ok(SC.RenderContext.escapeHTML(tests[idx++]) === tests[idx]);
   }
 });
+
+test("Should accept number argument", function() {
+  var number = 12345.6789,
+      numStr = number.toString();
+  
+  equals(numStr, SC.RenderContext.escapeHTML(number), "Properly produces string when invoked with a number argument");
+});


### PR DESCRIPTION
While it is not necessary to escape numbers, older versions of this function permitted number argument and we should maintain that functionality. Especially when it is trivial to do so. 

This resolves #748 .
