### PR TITLE
Use thinner borders on popover-themed pickerpane

### DIFF
--- a/themes/ace/resources/picker/popover/popover.css
+++ b/themes/ace/resources/picker/popover/popover.css
@@ -34,7 +34,7 @@
     &.top-toolbar .popover-background {
       top: -20px;
       @include slices(
-        "popover.png", $left: 30, $top: 75, $bottom: 40, $right: 30, 
+        "popover.png", $left: 30, $top: 75, $bottom: 34, $right: 30, 
         $skip: left middle right bottom-left bottom bottom-left bottom-right
       );
 
@@ -44,7 +44,7 @@
     &.bottom-toolbar .popover-background {
       bottom: -20px;
       @include slices(
-        "popover.png", $left: 30, $bottom: 75, $top: 40, $right: 30, 
+        "popover.png", $left: 30, $bottom: 75, $top: 34, $right: 30, 
         $skip: left middle right top-left top top-right
       );
       


### PR DESCRIPTION
The popover themed picker pane has thick left and right borders (40 px wide) which means that they trasparently overlay the inner view and prevent events from reaching it. In the case discussed below the inner view has a checkbox on the far left which was inaccessibile until I applied a padding to the list view item.

This pullrequest fixes the issue by making the borders as thin as possible, while preserving their aspect.

Discussion here (with sshot):

https://groups.google.com/d/msg/sproutcore/sEj2fm4xkg4/YkOXKK9A0iwJ
