### PR TITLE
SC.Request.notify('progress', ... )

### DIFF
--- a/frameworks/ajax/system/response.js
+++ b/frameworks/ajax/system/response.js
@@ -563,7 +563,6 @@ SC.XHRResponse = SC.Response.extend(
             eventType = eventType.substring(eIndex+1);
         }
         if(reqObj && eventType){
-            console.log("Attaching event "+eventType+" on request object");
             var transport = this;
             SC.Event.add(reqObj, eventType, this, function(evt){
                 transport.notifyEvent(status, evt);

--- a/frameworks/ajax/tests/system/request.js
+++ b/frameworks/ajax/tests/system/request.js
@@ -321,7 +321,7 @@ test("Test event listeners on request", function() {
 
     response = request.send();
     ok(SC.ok(response), 'response should not be error');
-    same(response.get('body'), {"message": "Yay!"}, 'repsonse.body');
+    same(response.get('body'), {"message": "Yay!"}, 'response.body');
 
     stop() ; // stops the test runner - wait for response
 });


### PR DESCRIPTION
- SC.Request#notifyUpload registers the callback methods for various upload events.
- SC.Response attaches those upload events to xmlHttpRequest object for supported browsers.
- Unit Test case for sanity check. Basically tests if the upload events are added properly to the SC.Response.
