### PR TITLE
Add test for comparing by registered query comparison.

### DIFF
--- a/frameworks/datastore/tests/system/query/compare.js
+++ b/frameworks/datastore/tests/system/query/compare.js
@@ -197,3 +197,14 @@ test("specifying a custom orderBy comparison function", function() {
   equals(usedCustomFunction, YES, 'we should have used our custom comparison function');
 });
 
+test("compare by custom query comparison", function(){
+  var usedQueryComparison = NO;
+  SC.Query.registerComparison('firstName', function (r1, r2) {
+    usedQueryComparison = YES;
+    return SC.compare(r2, r1);
+  });
+  q.orderBy = 'firstName';
+  q.parse();
+  equals(q.compare(rec1,rec2), -1, 'Jane should be after John');
+  equals(usedQueryComparison, YES, 'we should have used our query comparison function');
+});


### PR DESCRIPTION
I didn't find test for this functionality.
If we remove these two lines https://github.com/sproutcore/sproutcore/blob/master/frameworks/datastore/system/query.js#L408 (407, 408)
all tests will pass.
