### PR TITLE
Clicking on a content-less collection view results in a thrown error.

### DIFF
--- a/frameworks/desktop/tests/views/collection/mouse.js
+++ b/frameworks/desktop/tests/views/collection/mouse.js
@@ -153,6 +153,19 @@ test("first responder", function() {
   equals(view.get('isFirstResponder'), YES, 'view.isFirstResponder should be YES after mouse down');
 });
 
+test("clicking on a collection view with null content should not throw an error", function() {
+  var failed = NO;
+  view.set('content', null);
+  try {
+    var l = view.get('layer'),
+        evt = SC.Event.simulateEvent(l, 'mousedown');
+    SC.Event.trigger(l, 'mousedown', [evt]);
+  }
+  catch (e) { failed = YES; }
+  ok(!failed, "clicking on a collection view with null content should not throw an error");
+});
+
+
 // ..........................................................
 // ctrl-click mouse down
 // 

--- a/frameworks/desktop/views/collection.js
+++ b/frameworks/desktop/views/collection.js
@@ -2149,8 +2149,11 @@ SC.CollectionView = SC.View.extend(SC.CollectionViewDelegate, SC.CollectionConte
     @returns {Boolean} Usually YES.
   */
   mouseDown: function(ev) {
+    var content = this.get('content');
+
+    if (!content) return this.get('isSelectable');
+
     var itemView      = this.itemViewForEvent(ev),
-        content       = this.get('content'),
         contentIndex  = itemView ? itemView.get('contentIndex') : -1,
         info, anchor, sel, isSelected, modifierKeyPressed, didSelect = NO,
         allowsMultipleSel = content.get('allowsMultipleSelection');


### PR DESCRIPTION
CollectionView.mouseDown assumes content.  This is a bad assumption in (e.g.) situations where content is bound.
