### PR TITLE
Fix Desktop vs Touch for experimental SC.ScrollView

### DIFF
--- a/frameworks/experimental/frameworks/scroll_view/views/scroll.js
+++ b/frameworks/experimental/frameworks/scroll_view/views/scroll.js
@@ -10,6 +10,6 @@ sc_require('views/touch/scroll');
 SC.ScrollView = SC.platform.touch ? SC.TouchScrollView : SC.DesktopScrollView;
 
 // Spoofed browsers should use TouchScrollView.
-if (SC.browser && SC.platform && SC.browser.mobileSafari && !SC.platform.touch) {
+if (SC.browser && SC.platform && SC.browser.isMobileSafari && !SC.platform.touch) {
   SC.ScrollView = SC.TouchScrollView;
 }


### PR DESCRIPTION
SC.ScrollView always defaults to SC.TouchScrollView because since SC.browser changes, SC.browser.mobileSafari always has a value (version number or 0).  This uses the correct conditional and fixes mouse wheel scrolling.
