### PR TITLE
DisclosureView: added ability to set classNames on the label

### DIFF
--- a/frameworks/desktop/render_delegates/disclosure.js
+++ b/frameworks/desktop/render_delegates/disclosure.js
@@ -14,7 +14,7 @@ SC.BaseTheme.disclosureRenderDelegate = SC.RenderDelegate.create({
 
     var theme = dataSource.get('theme'),
         value = dataSource.get('value'),
-        labelClassNames = SC.A(dataSource.get('labelClassNames'));
+        labelClassNames = ['sc-button-label', 'sc-disclosure-label'];
 
     var labelId = SC.guidFor(dataSource) + "-label";
 
@@ -30,7 +30,6 @@ SC.BaseTheme.disclosureRenderDelegate = SC.RenderDelegate.create({
     
     context.push('<img src = "' + SC.BLANK_IMAGE_URL + '" class = "disclosure button ' + state + '" />');
 
-    labelClassNames.push('sc-button-label', 'sc-disclosure-label');
     context = context.begin('span').addClass(labelClassNames).id(labelId);
     theme.labelRenderDelegate.render(dataSource, context);
     context = context.end();
@@ -40,9 +39,7 @@ SC.BaseTheme.disclosureRenderDelegate = SC.RenderDelegate.create({
     this.updateSizeClassName(dataSource, jquery);
 
     var theme = dataSource.get('theme'),
-        value = dataSource.get('value'),
-        labelClassNames = SC.A(dataSource.get('labelClassNames')),
-        $label;
+        value = dataSource.get('value');
 
     //addressing accessibility
     jquery.attr('aria-expanded', value);
@@ -55,12 +52,7 @@ SC.BaseTheme.disclosureRenderDelegate = SC.RenderDelegate.create({
       active: dataSource.get('isActive')
     });
 
-    $label = jquery.find('span.sc-disclosure-label');
-
-    labelClassNames.push('sc-button-label', 'sc-disclosure-label');
-    $label.removeClass().addClass(labelClassNames.join(' '));
-    
-    theme.labelRenderDelegate.update(dataSource, $label);
+    theme.labelRenderDelegate.update(dataSource, jquery.find('span.sc-disclosure-label'));
   }
 });
 

--- a/frameworks/desktop/tests/views/disclosure/ui.js
+++ b/frameworks/desktop/tests/views/disclosure/ui.js
@@ -34,10 +34,6 @@
     })
     .add("aria-expanded-disabled", SC.DisclosureView, {
         value: NO, isEnabled: NO
-    })
-    .add("label classes", SC.DisclosureView, {
-        value: NO, isEnabled: YES,
-        labelClassNames: 'dummyclass1 dummyclass2 dummyclass3'.w()
     });
 
 	pane.show();
@@ -101,13 +97,6 @@
       var labelled_by = document.getElementById(view.$().attr('aria-labelledby'));
       equals(view.$('span.sc-button-label')[0], labelled_by, 'aria-labelledby should be the label element even if disabled');
       equals(view.$().attr('aria-expanded'), 'false', 'aria-expanded should be false');
-    });
-
-    test("label should accept classes", function() {
-      var view = pane.view('label classes');
-      ok(view.$('span.sc-button-label').hasClass('dummyclass1'), 'label should have first custom class');
-      ok(view.$('span.sc-button-label').hasClass('dummyclass2'), 'label should have second custom class');
-      ok(view.$('span.sc-button-label').hasClass('dummyclass3'), 'label should have third custom class');
     });
 
 })();

--- a/frameworks/desktop/views/disclosure.js
+++ b/frameworks/desktop/views/disclosure.js
@@ -37,12 +37,6 @@ SC.DisclosureView = SC.ButtonView.extend(
   renderDelegateName: 'disclosureRenderDelegate',
 
   /**
-    @type Array
-    @default ['labelClassNames']
-  */
-  displayProperties: ['labelClassNames'],
-
-  /**
     @type String
     @default SC.TOGGLE_BEHAVIOR
     @see SC.ButtonView#buttonBehavior


### PR DESCRIPTION
There currently is no way to set a CSS class on the DisclosureView's label. This adds that ability.
