### PR TITLE
Add the drag operation parameter to the computeDragOperations function

### DIFF
--- a/frameworks/desktop/protocols/drop_target.js
+++ b/frameworks/desktop/protocols/drop_target.js
@@ -137,11 +137,12 @@ SC.DropTarget = {
     @param {SC.Drag} drag The current drag object
     @param {SC.Event} evt The most recent mouse move event.  Use to get 
       location 
+    @param {DragOp} op The proposed drag operation. A drag constant
     
     @returns {DragOps} A mask of all the drag operations allowed or 
       SC.DRAG_NONE
   */
-  computeDragOperations: function(drag, evt) {
+  computeDragOperations: function(drag, evt, op) {
     return SC.DRAG_NONE;
   },
   


### PR DESCRIPTION
If a drag operation is defined by the method dragSourceOperationMaskFor, this argument will be pass to the function computeDragOperations.
