### PR TITLE
SC.ContentValueSupport only works with one content key

### DIFF
--- a/frameworks/foundation/mixins/content_value_support.js
+++ b/frameworks/foundation/mixins/content_value_support.js
@@ -127,7 +127,10 @@ SC.ContentValueSupport = {
       var contentKey;
 
       for(contentKey in contentKeys) {
-        if(key === '*' || key === this.getDelegateProperty(contentKey, this, this.get('displayDelegate'), contentKeys)) return this.updatePropertyFromContent(contentKeys[contentKey], key, contentKey, target);
+        if(key === '*' || key === this.getDelegateProperty(contentKey, this, this.get('displayDelegate'), contentKeys)) {
+          this.updatePropertyFromContent(contentKeys[contentKey], key, contentKey, target);
+        }
+        return this;
       }
     }
 


### PR DESCRIPTION
SC.ContentValueSupport doesn't work with more than one content key, because in contentPropertyDidChange(), the code fails to loop through all of the items in contentKeys
