### PR TITLE
Fix SC.TextFieldView to insert a new line when the enter key is press on a text area

### DIFF
--- a/frameworks/foundation/views/inline_text_field.js
+++ b/frameworks/foundation/views/inline_text_field.js
@@ -472,18 +472,6 @@ SC.InlineTextFieldView = SC.TextFieldView.extend(SC.InlineEditor,
       if(prev && prev.beginEditing) prev.beginEditing();
     }
     return YES ;
-  },
-
-  /** @private */
-  deleteForward: function(evt) {
-    evt.allowDefault();
-    return YES;
-  },
-
-  /** @private */
-  deleteBackward: function(evt) {
-    evt.allowDefault();
-    return YES ;
   }
 });
 

--- a/frameworks/foundation/views/text_field.js
+++ b/frameworks/foundation/views/text_field.js
@@ -1190,7 +1190,55 @@ SC.TextFieldView = SC.FieldView.extend(SC.StaticLayout, SC.Editable,
     }
     return NO;
   },
+  
+  /** @private */
+  deleteForward: function(evt) { 
+    evt.allowDefault();
+    return YES;
+  },
 
+  /** @private */
+  deleteBackward: function(evt) { 
+    evt.allowDefault();
+    return YES;
+  },
+
+  /** @private */
+  moveLeft: function(evt) { 
+    evt.allowDefault();
+    return YES;
+  },
+
+  /** @private */
+  moveRight: function(evt) { 
+    evt.allowDefault();
+    return YES;
+  },
+
+  /** @private */
+  selectAll: function(evt) { 
+    evt.allowDefault();
+    return YES;
+  },
+
+  /** @private */
+  moveUp: function(evt) {
+    if (this.get('isTextArea')) {
+      evt.allowDefault();
+      return YES;
+    }
+    return NO;
+  },
+
+  /** @private */
+  moveDown: function(evt) {
+    if (this.get('isTextArea')) {
+      evt.allowDefault();
+      return YES;
+    }
+    return NO;
+  },
+  
   keyUp: function (evt) {
     if (SC.browser.isMozilla &&
         evt.keyCode === SC.Event.KEY_RETURN) { this.fieldValueDidChange(); }


### PR DESCRIPTION
A fix were already there for the SC.InlineTextFieldView class so I copy it into the TextFieldView class. I've updated the SC.InlineTextFieldView class so that it now call the super class in the case where it is a text area.

I've also removed some useless code in the SC.InlineTextFieldView class:
- A fix in the insertNewline method which is not needed anymore
- The method fieldValueDidChange which only call the super class
