### PR TITLE
Added platform detection for the Apache Cordova (formerly phonegap)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ Gemfile*
 *.orig
 .sass-cache/
 .strobe/
+.project
+.settings/

--- a/frameworks/core_foundation/system/platform.js
+++ b/frameworks/core_foundation/system/platform.js
@@ -381,7 +381,26 @@ SC.platform = SC.Object.create({
     @property {Boolean}
     @default NO
   */
-  windowSizeDeterminesOrientation: SC.browser.os === SC.OS.ios || !('onorientationchange' in window)
+  windowSizeDeterminesOrientation: SC.browser.os === SC.OS.ios || !('onorientationchange' in window),
+
+  /**
+    Does this browser support the Apache Cordova (formerly phonegap) runtime?
+    
+    This requires that you (the engineer) manually include the cordova 
+    javascript library for the appropriate platform (Android, iOS, etc)
+    in your code. There are various methods of doing this; creating your own
+    platform-specific index.rhtml is probably the easiest option. 
+    
+    WARNING: Using the javascript_libs Buildfile option for the cordova include
+    will NOT work. The library will be included after your application code,
+    by which time this property will already have been evaluated.
+
+    @property {Boolean}
+    @see http://incubator.apache.org/cordova/
+    @default NO
+  */
+  // Check for the global cordova property. 
+  cordova: (typeof window.cordova !== "undefined")
 
 });
 

--- a/frameworks/core_foundation/tests/system/platform.js
+++ b/frameworks/core_foundation/tests/system/platform.js
@@ -1,0 +1,18 @@
+// ==========================================================================
+// Project: SproutCore - JavaScript Application Framework
+// Copyright: ©2012 Michael Krotscheck and contributors. All rights reserved.
+// License: Licensed under MIT license (see license.js)
+// ==========================================================================
+
+/**
+ * Test for correct cordova detection.
+ */
+test("SC.platform.cordova", function() {
+  
+  ok(typeof SC.platform.cordova == 'boolean', "Cordova check must have been executed.");
+  
+  // Is there a chance we're in a cordova runtime?
+  var isCordova = typeof window.cordova !== "undefined";
+  equals(isCordova, SC.platform.cordova, "Cordova detection must match what we've been able to determine for ourselves");
+  
+});


### PR DESCRIPTION
This pull request adds autodetection of the Apache Cordova browser-to-mobile-runtime bridge. It's fairly simple detection: Does the cordova object exist or not.

I opted not to build this out into a full framework because cordova needs additional configuration independent of sproutcore to work properly. There are different library versions for different platforms, which need to be included independently for each build target. For example, an android build needs to include the android cordova lib, etc etc.

There's a small unrelated part of this pull request, in that I've added .project and .settings to the .gitignore file. These are eclipse-specific files/folders used for the IDE to save its settings, and should be ignored (much like .DS_Store, etc).
