### PR TITLE
Fixes example code in SC.String.fmt

### DIFF
--- a/frameworks/runtime/system/string.js
+++ b/frameworks/runtime/system/string.js
@@ -45,13 +45,17 @@ SC.String = /** @scope SC.String.prototype */ {
 
     Indexed Parameters
     --------------------
-    Indexed parameters are just arguments you pass into format.
-
-    For example, if you call fmt("%@1 %3 %2", 1, 2, 3), you'll get "1 3 2" as output.
+    Indexed parameters are just arguments you pass into format. For example:
     
-    If you don't supply a number, it will use them in the order you supplied. For instance:
+        "%@1 %@3 %@2".fmt(1, 2, 3)
+        
+        // -> "1 3 2"
     
-        "abc".fmt("%@, %@", "Iskander", "Alex")  would return "Iskander, Alex".
+    If you don't supply a number, it will use them in the order you supplied. For example:
+    
+        "%@, %@".fmt("Iskander", "Alex")
+        
+        // -> "Iskander, Alex"
 
     Named Paramters
     --------------------


### PR DESCRIPTION
What I changed:
1. The example code in the docs for SC.String.fmt now actually works.
2. The examples will now be picked up as code snippets and not just plain text.

Some questions:
1. Should I be submitting pull requests against the master branch, or some other one?
2. The examples are using String.fmt, but they are in the docs for SC.String.fmt. That might not be obvious to a newbie. Is that something worth elaborating on in the docs?
