### PR TITLE
Fix implicitly defined globals in SC.MenuPane

### DIFF
--- a/frameworks/desktop/panes/menu.js
+++ b/frameworks/desktop/panes/menu.js
@@ -650,6 +650,7 @@ SC.MenuPane = SC.PickerPane.extend(
   createMenuItemViews: function() {
     var views = [], items = this.get('displayItems'),
         exampleView = this.get('exampleView'), item, itemView, view,
+        exampleViewKey, itemExampleView,
         height, heightKey, separatorKey, defaultHeight, separatorHeight,
         menuHeight, menuHeightPadding, keyEquivalentKey, keyEquivalent,
         keyArray, idx, layerIdKey, propertiesHash,


### PR DESCRIPTION
I'm not sure if these were causing problems or what problems they would have been causing, but its not good to go around implicitly defining globals.
