### PR TITLE
Call _fixupTextLayout when hint shown so the right line-height is applied.

### DIFF
--- a/frameworks/foundation/views/text_field.js
+++ b/frameworks/foundation/views/text_field.js
@@ -860,6 +860,10 @@ SC.TextFieldView = SC.FieldView.extend(SC.StaticLayout, SC.Editable,
     }
   },
 
+  didAppendToDocument: function() {
+    this._fixupTextLayout();
+  },
+
   /** @private
     Apply proper text layout to sc-hints and inputs.
    */
@@ -1027,6 +1031,7 @@ SC.TextFieldView = SC.FieldView.extend(SC.StaticLayout, SC.Editable,
     }
     else {
       this.$('.hint').removeClass('sc-hidden');
+      this._fixupTextLayout();
     }
   }.observes('value'),
 


### PR DESCRIPTION
_fixupTextLayout is called from didCreateLayer, but at that point the hint
may be hidden and have an incorrect outerHeight().
