### PR TITLE
Avoid duplicate properties in collection helper.

### DIFF
--- a/frameworks/template_view/ext/handlebars/collection.js
+++ b/frameworks/template_view/ext/handlebars/collection.js
@@ -38,6 +38,8 @@ Handlebars.registerHelper('collection', function(path, options) {
 
     extensions = SC.clone(hash);
     extensions.itemViewOptions = itemHash;
+    // don't duplicate properties in the view helper
+    options.hash = {};
   }
 
   if (fn) { extensions.itemViewTemplate = fn; }


### PR DESCRIPTION
Clear out the options hash before passing it to the view helper to avoid
duplicating the properties when the view helper does another extend.
