### PR TITLE
Fixes SC.SegmentedView overflow.

### DIFF
--- a/frameworks/desktop/views/segmented.js
+++ b/frameworks/desktop/views/segmented.js
@@ -599,7 +599,7 @@ SC.SegmentedView = SC.View.extend(SC.Control,
       // check for an overflow (leave room for the overflow segment except for with the last segment)
       dimToFit = (i === length - 1) ? curElementsDim : curElementsDim + this.cachedOverflowDim;
 
-      if (dimToFit > visibleDim) {
+      if (dimToFit > visibleDim || this.isOverflowing) {
         // Add the localItem to the overflowItems
         this.overflowItems.pushObject(childView.get('localItem'));
 


### PR DESCRIPTION
Since each segment is checked individually for overflow, and the last
segment is checked without the size of the overflow view, it is possible
for the last segment to be shown while the previous segment is hidden.

Instead, always hide all segments after we determine we are overflowing.
