### PR TITLE
Fix caching issue with SC.routes.informLocation.

### DIFF
--- a/frameworks/routing/system/routes.js
+++ b/frameworks/routing/system/routes.js
@@ -198,7 +198,18 @@ SC.routes = SC.Object.create(
     @type {String}
   */
   location: function(key, value) {
+    var lsk;
     this._skipRoute = NO;
+    if (value !== undefined) {
+      // The 'location' and 'informLocation' properties essentially
+      // represent a single property, but with different behavior
+      // when setting the value. Because of this, we manually
+      // update the cached value for the opposite property to
+      // ensure they remain in sync. You shouldn't do this in
+      // your own code unless you REALLY know what you are doing.
+      lsk = this.informLocation.lastSetValueKey;
+      if (lsk && this._kvo_cache) this._kvo_cache[lsk] = value;
+    }
     return this._extractLocation(key, value);
   }.property(),
 
@@ -207,17 +218,18 @@ SC.routes = SC.Object.create(
     you want to just change the location w/out triggering the routes
   */
   informLocation: function(key, value){
+    var lsk;
     this._skipRoute = YES;
-    // This is a very special case where this property
-    // has a very heavy influence on the 'location' property
-    // this is a case where you might want to use idempotent
-    // but you would take a performance hit because it is possible
-    // call set() multiple time and we don't want to take the extra
-    // cost, so we just invalidate the cached set() value ourselves
-    // you shouldn't do this in your own code unless you REALLY
-    // know what you are doing.
-    var lsk = this.location.lastSetValueKey;
-    if (lsk && this._kvo_cache) this._kvo_cache[lsk] = value;
+    if (value !== undefined) {
+      // The 'location' and 'informLocation' properties essentially
+      // represent a single property, but with different behavior
+      // when setting the value. Because of this, we manually
+      // update the cached value for the opposite property to
+      // ensure they remain in sync. You shouldn't do this in
+      // your own code unless you REALLY know what you are doing.
+      lsk = this.location.lastSetValueKey;
+      if (lsk && this._kvo_cache) this._kvo_cache[lsk] = value;
+    }
     return this._extractLocation(key, value);
   }.property(),
 

--- a/frameworks/routing/tests/system/routes.js
+++ b/frameworks/routing/tests/system/routes.js
@@ -148,6 +148,49 @@ test('Already escaped route', function() {
   routeWorks('%C3%A9%C3%A0%20%C3%A7%C3%B9%20%C3%9F%E2%82%AC', 'already escaped');
 });
 
+module('SC.routes informLocation', {
+
+  teardown: function() {
+    SC.routes.set('informLocation', null);
+  }
+
+});
+
+test('informLocation updates location', function() {
+  SC.routes.set('informLocation', 'simple');
+  stop();
+
+  setTimeout(function() {
+    equals(SC.routes.get('location'), 'simple');
+    start();
+  }, 300);
+});
+
+test('informLocation and location invalidate each others caches', function() {
+  SC.routes.set('location', '');
+  stop();
+
+  setTimeout(function() {
+    equals(SC.routes.get('location'), '');
+    SC.routes.set('informLocation', 'simple');
+
+    setTimeout(function() {
+      equals(SC.routes.get('location'), 'simple');
+      SC.routes.set('location', '');
+
+      setTimeout(function() {
+        equals(SC.routes.get('location'), '');
+        SC.routes.set('informLocation', 'simple');
+
+        setTimeout(function() {
+          equals(SC.routes.get('location'), 'simple');
+          start();
+        }, 300);
+      }, 300);
+    }, 300);
+  }, 300);
+});
+
 module('SC.routes defined routes', {
 
   setup: function() {


### PR DESCRIPTION
Since location and informLocation really just represent a single property,
they both need to update the cached value for the opposite property.
