### PR TITLE
Withdraw body overflow request when panes are detached.

### DIFF
--- a/frameworks/core_foundation/panes/main.js
+++ b/frameworks/core_foundation/panes/main.js
@@ -63,6 +63,18 @@ SC.MainPane = SC.Pane.extend({
     if (!responder.get('keyRootView')) responder.makeKeyPane(this);
     return ret ;
   },
+
+  /**
+    @private
+
+    Withdraw body overflow request when the pane is detached.
+  */
+  paneAttachedDidChange: function() {
+    if (!this.get('isPaneAttached')) {
+      SC.bodyOverflowArbitrator.requestVisible(this);
+      SC.bodyOverflowArbitrator.withdrawRequest(this);
+    }
+  }.observes('isPaneAttached'),
   
   /** @private */
   acceptsKeyPane: YES,


### PR DESCRIPTION
SC.MainPane makes a body overflow request on init. That request needs to
be withdrawn when the pane is detached.
