### PR TITLE
Resolved Handlebars escaping issue with ampersands.

### DIFF
--- a/frameworks/template_view/handlebars.js
+++ b/frameworks/template_view/handlebars.js
@@ -690,6 +690,7 @@ Handlebars.SafeString.prototype.toString = function() {
 
 (function() {
   var escape = {
+    "&": "&amp;",
     "<": "&lt;",
     ">": "&gt;",
     '"': "&quot;",
@@ -697,7 +698,7 @@ Handlebars.SafeString.prototype.toString = function() {
     "`": "&#x60;"
   };
 
-  var badChars = /&(?!\w+;)|[<>"'`]/g;
+  var badChars = /[&<>"'`]/g;
   var possible = /[&<>"'`]/;
 
   var escapeChar = function(chr) {


### PR DESCRIPTION
This: "&lt;&amp;&gt; <b>This is bold</b> &&&"
was being rendered as: "<&> <b>This is bold</b> &&&".

Matches fix made in handlebars proper, see
https://github.com/wycats/handlebars.js/commit/bd9a84a0b7
