### PR TITLE
Fix indexing problem in SC.CollectionView.

### DIFF
--- a/frameworks/desktop/views/collection.js
+++ b/frameworks/desktop/views/collection.js
@@ -973,7 +973,7 @@ SC.CollectionView = SC.View.extend(SC.CollectionViewDelegate, SC.CollectionConte
         existing.destroy();
 
         // Insert the replacement view before the following view.
-        existing = (idx === len - 1) ? null : itemViews[idx + 1];
+        existing = itemViews[idx + 1]; // may result in undefined, but insertBefore treats this the same as null
         view = this.itemViewForContentIndex(idx, YES);
 
         containerView.insertBefore(view, existing);


### PR DESCRIPTION
The index check here was comparing idx, an index into itemViews, to len,
the length of viewsToRedraw.

I removed the index check since if the index is out of bounds, the result
will be undefined, which insertBefore treats the same as null.
