### PR TITLE
Add null check in recomputeIsVisibleInWindow.

### DIFF
--- a/frameworks/core_foundation/views/view/visibility.js
+++ b/frameworks/core_foundation/views/view/visibility.js
@@ -61,10 +61,14 @@ SC.View.reopen(
     if (previous !== current) {
       this.set('isVisibleInWindow', current);
 
-      var childViews = this.get('childViews'), idx, view;
-      for(idx=0;idx<childViews.length;idx++) {
+      var childViews = this.get('childViews'), len, idx, view;
+      childViews = childViews ? SC.clone(childViews) : [];
+      len = childViews.length;
+      for(idx=0;idx<len;idx++) {
         view = childViews[idx];
-        if(view && view.recomputeIsVisibleInWindow) { view.recomputeIsVisibleInWindow(current); }
+        if(view && view.get('parentView') === this && view.recomputeIsVisibleInWindow) {
+          view.recomputeIsVisibleInWindow(current);
+        }
       }
 
       // For historical reasons, we'll also layout the child views if


### PR DESCRIPTION
There are some circumstances where a view could get destroyed while
recomputeIsVisibleInWindow is happening, which could lead to childViews
going away in the middle of this loop.
