### PR TITLE
Make modal pane fill entire window, regardless of scrolling.

### DIFF
--- a/frameworks/desktop/resources/modal.css
+++ b/frameworks/desktop/resources/modal.css
@@ -7,6 +7,7 @@
   }
 
   &.for-sc-panel {
+    position: fixed;
     background: black;
     opacity: 0.3;
     -moz-opacity: 0.3;


### PR DESCRIPTION
If the browser window was sized so that it could be scrolled, the modal
pane was sized the same as the browser window, so scrolling would reveal
the content under the modal pane.
