### PR TITLE
Allow SC.State's to disallow a state transition.

### DIFF
--- a/frameworks/statechart/system/state.js
+++ b/frameworks/statechart/system/state.js
@@ -1239,6 +1239,20 @@ SC.State = SC.Object.extend(
     this._isExitingState = NO;
   },
 
+  /**
+    Allows the state to indicate to the statechart that it cannot currently be exited.
+
+    @see SC.StatechartManager#gotoState
+    @param {SC.State} state gotoState parameter
+    @param {SC.State} fromCurrentState gotoState parameter
+    @param {SC.State} useHistory gotoState parameter
+    @param {SC.State} context gotoState parameter
+    @return {Boolean} YES if state can be exited; otherwise NO
+  */
+  stateCanBecomeExited: function(state, fromCurrentState, useHistory, context) {
+    return YES;
+  },
+
   /** @private
 
     Used to setup all the state observer handlers. Should be done when

--- a/frameworks/statechart/tests/state_transitioning/standard/without_concurrent_states/core.js
+++ b/frameworks/statechart/tests/state_transitioning/standard/without_concurrent_states/core.js
@@ -287,3 +287,17 @@ test("from state g, go to state h using 'parentState' syntax", function() {
   equals(monitor.matchSequence().begin().exited('g').entered('h').end(), 
     true, 'sequence should be exited[g], entered[h]');
 });
+
+test("cancel state transition", function() {
+  stateG.stateCanBecomeExited = function() { return NO; };
+  equals(statechart.gotoState('h'), SC.GOTOSTATE_CANCELED, 'state g should cancel state transition');
+  equals(statechart.stateIsCurrentState('g'), true, 'state g should be current state');
+
+  stateG.stateCanBecomeExited = function() { return YES; };
+  stateC.stateCanBecomeExited = function() { return NO; };
+  equals(statechart.gotoState('h'), SC.GOTOSTATE_COMPLETE, 'state c should not cancel state transition');
+  equals(statechart.stateIsCurrentState('h'), true, 'state h should be current state');
+
+  equals(statechart.gotoState('i'), SC.GOTOSTATE_CANCELED, 'state c should cancel state transition');
+  equals(statechart.stateIsCurrentState('h'), true, 'state h should be current state');
+});


### PR DESCRIPTION
Added a stateCanBecomeExited function to SC.State. During
SC.StatechartManager#gotoState, all states that will be exited will have
this function called. If any of them return NO, the state transition will
be canceled.
