### PR TITLE
Add support for touch events to SC.PopupButtonView

### DIFF
--- a/frameworks/desktop/views/popup_button.js
+++ b/frameworks/desktop/views/popup_button.js
@@ -294,6 +294,16 @@ SC.PopupButtonView = SC.ButtonView.extend(
     var menu = this.get('instantiatedMenu') ;
 
     return (!!menu && menu.performKeyEquivalent(charCode, evt, YES)) ;
+  },
+
+  /** @private */
+  touchStart: function(evt) {
+    return this.mouseDown(evt);
+  },
+
+  /** @private */
+  touchEnd: function(evt) {
+    return this.mouseUp(evt);
   }
 
 });

--- a/frameworks/experimental/frameworks/select_view/views/popup_button.js
+++ b/frameworks/experimental/frameworks/select_view/views/popup_button.js
@@ -259,6 +259,16 @@ SC.PopupButtonView = SC.ButtonView.extend({
     }
 
     return sc_super();
+  },
+
+  /** @private */
+  touchStart: function(evt) {
+    return this.mouseDown(evt);
+  },
+
+  /** @private */
+  touchEnd: function(evt) {
+    return this.mouseUp(evt);
   }
 });
 


### PR DESCRIPTION
This simply map the touchStart and touchEnd events to the mouseDown and
mouseUp methods.
I'm not sure this is testable.
