### PR TITLE
Fix SC.GridView insertionPoint position

### DIFF
--- a/frameworks/desktop/views/grid.js
+++ b/frameworks/desktop/views/grid.js
@@ -177,27 +177,21 @@ SC.GridView = SC.ListView.extend(
         this._lastDropOnView = null;
       }
 
-      if (!this._insertionPointView) {
-        this._insertionPointView = this.insertionPointClass.create();
+      var insertionPoint = this._insertionPointView,
+          layout = SC.clone(itemView.get('layout'));
+
+      if (!insertionPoint) {
+        insertionPoint = this._insertionPointView = this.insertionPointClass.create();
       }
 
-      var insertionPoint = this._insertionPointView;
-      var itemViewFrame = itemView.get('frame');
-      var f = { height: itemViewFrame.height - 6,
-            x: itemViewFrame.x,
-            y: itemViewFrame.y + 6,
-            width: 0
-          };
+      layout.top += 6;
+      layout.height -= 6;
+      layout.left -= 1;
+      layout.width = 2;
 
-      if (!SC.rectsEqual(insertionPoint.get('frame'), f)) {
-        insertionPoint.set('frame', f);
-      }
-
-      if (insertionPoint.parentNode !== itemView.parentNode) {
-        itemView.parentNode.appendChild(insertionPoint);
-      }
+      insertionPoint.set('layout', layout);
+      this.appendChild(insertionPoint);
     }
-
   },
 
   /** @see SC.CollectionView#hideInsertionPoint */


### PR DESCRIPTION
Don't if it was working for someone but in my case, the insertionPoint was not appended.
While I was fixing it, I find out that there is no style for it and that the style for sc-list-insertion-point is only set in the legacy_theme. 

I'd love to add theme for it but I don't know where is the best place to do so: legacy_theme, ace or directly in the ressource directory by creating a grid.css.
Maybe it could also be great to move the theme for sc-list-insertion-point.

I'm waiting for work feedback before going any further.
