### PR TITLE
Throw an exception if we try to find an itemView with a negative contentIndex

### DIFF
--- a/frameworks/desktop/views/collection.js
+++ b/frameworks/desktop/views/collection.js
@@ -1066,6 +1066,10 @@ SC.CollectionView = SC.View.extend(SC.CollectionViewDelegate, SC.CollectionConte
     @returns {SC.View} instantiated view
   */
   itemViewForContentIndex: function (idx, rebuild) {
+    if (idx < 0) {
+      throw new Error("Cannot find an itemView with a contentIndex of "+idx);
+    }
+
     var ret;
 
     // Use an existing view for this index if we have it.


### PR DESCRIPTION
This can happen when trying to get the itemView of an object that is not in the collection.

If we don't throw an exception, an empty view with an id like sc123--1 is created which lead to an exception saying that an item view (sc123--1) was found while the item view does not exist. 
See that issue for more details:  https://github.com/sproutcore/sproutcore/issues/943
