### PR TITLE
Added support for localized number ordinals / ordinals in DateTime#toFormattedString

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .gitattributes
 *.swp
 *.swo
+*.iml
 themes/sc_ace/resources/slices/
 tmp/
 bin

--- a/frameworks/core_foundation/system/locale.js
+++ b/frameworks/core_foundation/system/locale.js
@@ -233,10 +233,10 @@ SC.Locale.mixin(/** @scope SC.Locale */ {
     var autodetect = (String.useAutodetectedLanguage !== undefined) ? String.useAutodetectedLanguage : this.useAutodetectedLanguage;
     var preferred = (String.preferredLanguage !== undefined) ? String.preferredLanguage : this.preferredLanguage ;
 
+
     // determine the language
     var lang = ((autodetect) ? SC.browser.language : null) || preferred || SC.browser.language || 'en';
     lang = SC.Locale.normalizeLanguage(lang) ;
-
     // get the locale class.  If a class cannot be found, fall back to generic
     // language then to english.
     var klass = this.localeClassFor(lang) ;

--- a/frameworks/core_foundation/tests/ext/number_test.js
+++ b/frameworks/core_foundation/tests/ext/number_test.js
@@ -1,0 +1,88 @@
+// ==========================================================================
+// Project:   SproutCore - JavaScript Application Framework
+// Copyright: ©2006-2011 Strobe Inc. and contributors.
+//            Portions ©2008-2011 Apple Inc. All rights reserved.
+// License:   Licensed under MIT license (see license.js)
+// ==========================================================================
+/*globals module, test, start, stop, expect, ok, equals*/
+
+module("Number#ordinal");
+
+/**
+ * Admitedly not exhaustive, but tests the numbers from 1-100
+ */
+test("Properly Computes the Ordinal in english", function () {
+
+  equals(SC.Locale.currentLocale.language, 'en');
+
+  var sts = [1, 21, 31, 41, 51, 61, 71, 81, 91, 101],
+    nds = [2, 22, 32, 42, 52, 62, 72, 82, 92, 102],
+    rds = [3, 23, 33, 43, 53, 63, 73, 83, 93, 103];
+  sts.forEach(function (number) {
+    equals(number.ordinal(), 'st');
+  });
+
+  nds.forEach(function (number) {
+    equals(number.ordinal(), 'nd');
+  });
+
+  rds.forEach(function (number) {
+    equals(number.ordinal(), 'rd');
+  });
+
+  var ths = [];
+  for (var i = 0; i < 100; i++) {
+    ths.push(i);
+  }
+
+  ths.removeObjects(sts);
+  ths.removeObjects(nds);
+  ths.removeObjects(rds);
+
+  ths.forEach(function (number) {
+    equals(number.ordinal(), 'th');
+  });
+
+});
+
+/**
+ * Admitedly not exhaustive, but tests the numbers from 1-100
+ */
+test("Properly Computes the Ordinal in a language without an ordinal function using english", function () {
+
+  // force it to japanese
+  String.preferredLanguage = 'jp';
+
+  SC.Locale.currentLocale = SC.Locale.createCurrentLocale();
+
+  equals(SC.Locale.currentLocale.language, 'ja');
+
+  var sts = [1, 21, 31, 41, 51, 61, 71, 81, 91, 101],
+    nds = [2, 22, 32, 42, 52, 62, 72, 82, 92, 102],
+    rds = [3, 23, 33, 43, 53, 63, 73, 83, 93, 103];
+  sts.forEach(function (number) {
+    equals(number.ordinal(), 'st');
+  });
+
+  nds.forEach(function (number) {
+    equals(number.ordinal(), 'nd');
+  });
+
+  rds.forEach(function (number) {
+    equals(number.ordinal(), 'rd');
+  });
+
+  var ths = [];
+  for (var i = 0; i < 100; i++) {
+    ths.push(i);
+  }
+
+  ths.removeObjects(sts);
+  ths.removeObjects(nds);
+  ths.removeObjects(rds);
+
+  ths.forEach(function (number) {
+    equals(number.ordinal(), 'th');
+  });
+
+});

--- a/frameworks/datetime/frameworks/core/system/datetime.js
+++ b/frameworks/datetime/frameworks/core/system/datetime.js
@@ -427,10 +427,8 @@ SC.DateTime = SC.Object.extend(SC.Freezable, SC.Copyable,
 
     @return {String}
    */
-  suffix: function(){
-
-
-     return '';
+  dayOrdinal: function(){
+     return this.get('day').ordinal();
    }.property(),
 
   /**
@@ -1132,6 +1130,7 @@ SC.DateTime.mixin(SC.Comparable,
       case 'j': return this._pad(this._get('dayOfYear'), 3);
       case 'm': return this._pad(this._get('month'));
       case 'M': return this._pad(this._get('minute'));
+      case 'o': return this._get('day').ordinal();
       case 'p': return this._get('hour') > 11 ? this.AMPMNames[1] : this.AMPMNames[0];
       case 'S': return this._pad(this._get('second'));
       case 's': return this._pad(this._get('millisecond'), 3);
@@ -1164,7 +1163,7 @@ SC.DateTime.mixin(SC.Comparable,
     // need to move into local time zone for these calculations
     this._setCalcState(start - (timezone * 60000), 0); // so simulate a shifted 'UTC' time
 
-    return format.replace(/\%([aAbBcdeEDhHiIjmMpsSUWwxXyYZ\%])/g, function() {
+    return format.replace(/\%([aAbBcdeEDhHiIjmMopsSUWwxXyYZ\%])/g, function() {
       var v = that.__toFormattedString.call(that, arguments, start, timezone);
       return v;
     });

--- a/frameworks/datetime/frameworks/core/tests/system/datetime.js
+++ b/frameworks/datetime/frameworks/core/tests/system/datetime.js
@@ -238,40 +238,25 @@ test('Format', function() {
   equals(dt.adjust({ timezone:  420 }).toFormattedString('%Y-%m-%d %H:%M:%S %Z'), '1985-06-07 22:00:22 -07:00'); // the previous day
 });
 
+/**
+ * This test only tests english (the default) because Locale is not loaded as
+ * part of this test (bummer)
+ */
+test('Properly Computes day ordinal in toFormattedString', function(){
+  [1, 21, 31].forEach(function(day){
+    equals(SC.DateTime.create({month: 3, day: day}).toFormattedString('%o'), 'st');
+  });
+  [2, 22].forEach(function(day){
+    equals(SC.DateTime.create({month: 3, day: day}).toFormattedString('%o'), 'nd');
+  });
+  [3, 23].forEach(function(day){
+    equals(SC.DateTime.create({month: 3, day: day}).toFormattedString('%o'), 'rd');
+  });
 
-//test('Properly Computes Suffix in toFormattedString', function(){
-//  equals(SC.DateTime.create({day: 1}).get('suffix'), 'st');
-//  equals(SC.DateTime.create({day: 2}).get('suffix'), 'nd');
-//  equals(SC.DateTime.create({day: 3}).get('suffix'), 'rd');
-//  equals(SC.DateTime.create({day: 4}).get('suffix'), 'th');
-//  equals(SC.DateTime.create({day: 5}).get('suffix'), 'th');
-//  equals(SC.DateTime.create({day: 6}).get('suffix'), 'th');
-//  equals(SC.DateTime.create({day: 7}).get('suffix'), 'th');
-//  equals(SC.DateTime.create({day: 8}).get('suffix'), 'th');
-//  equals(SC.DateTime.create({day: 9}).get('suffix'), 'th');
-//  equals(SC.DateTime.create({day: 10}).get('suffix'), 'th');
-//  equals(SC.DateTime.create({day: 11}).get('suffix'), 'th');
-//  equals(SC.DateTime.create({day: 12}).get('suffix'), 'th');
-//  equals(SC.DateTime.create({day: 13}).get('suffix'), 'th');
-//  equals(SC.DateTime.create({day: 14}).get('suffix'), 'th');
-//  equals(SC.DateTime.create({day: 15}).get('suffix'), 'th');
-//  equals(SC.DateTime.create({day: 16}).get('suffix'), 'th');
-//  equals(SC.DateTime.create({day: 17}).get('suffix'), 'th');
-//  equals(SC.DateTime.create({day: 18}).get('suffix'), 'th');
-//  equals(SC.DateTime.create({day: 19}).get('suffix'), 'th');
-//  equals(SC.DateTime.create({day: 20}).get('suffix'), 'th');
-//  equals(SC.DateTime.create({day: 21}).get('suffix'), 'st');
-//  equals(SC.DateTime.create({day: 22}).get('suffix'), 'nd');
-//  equals(SC.DateTime.create({day: 23}).get('suffix'), 'rd');
-//  equals(SC.DateTime.create({day: 24}).get('suffix'), 'th');
-//  equals(SC.DateTime.create({day: 25}).get('suffix'), 'th');
-//  equals(SC.DateTime.create({day: 26}).get('suffix'), 'th');
-//  equals(SC.DateTime.create({day: 27}).get('suffix'), 'th');
-//  equals(SC.DateTime.create({day: 28}).get('suffix'), 'th');
-//  equals(SC.DateTime.create({day: 29}).get('suffix'), 'th');
-//  equals(SC.DateTime.create({day: 30}).get('suffix'), 'th');
-//  equals(SC.DateTime.create({day: 31}).get('suffix'), 'th');
-//});
+  [4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,24,25,26,27,28,29,30].forEach(function(day){
+    equals(SC.DateTime.create({month: 3, day: day}).toFormattedString('%o'), 'th');
+  });
+});
 
 test('fancy getters', function() {
   equals(dt.get('isLeapYear'), NO);

--- a/frameworks/runtime/ext/number.js
+++ b/frameworks/runtime/ext/number.js
@@ -5,8 +5,6 @@
 // License:   Licensed under MIT license (see license.js)
 // ==========================================================================
 
-sc_require('system/Number');
-
 SC.supplement(Number.prototype, {
 
   /**
@@ -14,10 +12,23 @@ SC.supplement(Number.prototype, {
    *
    * eg: 1 => st, 2 => 2nd
    *
-   * Delegates to the current locale to try and localize it, otherwise uses
-   * english.
+   *
+   * If the current Locale exists (which it almost always does except for in
+   * testing) we try and delegate to it. Otherwise we use this inner anonymous
+   * function (to prevent further mucking with the prototype)
+   *
    */
   ordinal: function () {
-    return SC.Locale.currentLocale.ordinalForNumber(this);
+
+    var _ordinal = function (number) {
+      var d = number % 10;
+      return (~~(number % 100 / 10) === 1) ? 'th' :
+        (d === 1) ? 'st' :
+          (d === 2) ? 'nd' :
+            (d === 3) ? 'rd' : 'th';
+    };
+
+    return SC.Local ? SC.Locale.currentLocale.ordinalForNumber(this) : _ordinal(this);
   }
+
 });

--- a/frameworks/runtime/tests/ext/number_test.js
+++ b/frameworks/runtime/tests/ext/number_test.js
@@ -1,0 +1,44 @@
+/*-------------------------------------------------------------------------------------------------
+ - Project:   sproutcore                                                                          -
+ - Copyright: ©2013 Matygo Educational Incorporated operating as Learndot                         -
+ - Author:    Joe Gaudet (joe@learndot.com) and contributors (see contributors.txt)               -
+ - License:   Licensed under MIT license (see license.js)                                         -
+ -------------------------------------------------------------------------------------------------*/
+/*globals module, test, start, stop, expect, ok, equals*/
+
+module("Number#ordinal");
+
+/**
+ * Admitedly not exhaustive, but tests the numbers from 1-100
+ */
+test("Properly Computes the Ordinal in english", function () {
+  var sts = [1, 21, 31, 41, 51, 61, 71, 81, 91, 101],
+    nds = [2, 22, 32, 42, 52, 62, 72, 82, 92, 102],
+    rds = [3, 23, 33, 43, 53, 63, 73, 83, 93, 103];
+  sts.forEach(function (number) {
+    equals(number.ordinal(), 'st');
+  });
+
+  nds.forEach(function (number) {
+    equals(number.ordinal(), 'nd');
+  });
+
+  rds.forEach(function (number) {
+    equals(number.ordinal(), 'rd');
+  });
+
+  var ths = [];
+  for (var i = 0; i < 100; i++) {
+    ths.push(i);
+  }
+
+  ths.removeObjects(sts);
+  ths.removeObjects(nds);
+  ths.removeObjects(rds);
+
+  ths.forEach(function (number) {
+    equals(number.ordinal(), 'th');
+  });
+
+});
+


### PR DESCRIPTION
Added support for taking any number and calling ordinal on it (5 => 5th, 3=>3rd). It Looks first in Locale for a i8n version of the ordinal function (stored in a map on the Locale mixin) which by default will fall through to english. If the Locale doesn't yet exist (in testing) it uses an onboard version.

Additionally added support to SC.DateTime to hand %o to the ordinal function.

Also with tests!
