### PR TITLE
Added fix for incorrect loop in SC.Request.manager.cancelAll

### DIFF
--- a/frameworks/ajax/system/request.js
+++ b/frameworks/ajax/system/request.js
@@ -669,13 +669,27 @@ SC.Request.manager = SC.Object.create(
     @returns {Boolean} YES if any items were cancelled.
   */
   cancelAll: function() {
-    if (this.get('pending').length || this.get('inflight').length) {
-      this.set('pending', []);
-      this.get('inflight').forEach(function(r) { r.cancel(); });
-      this.set('inflight', []);
-      return YES;
-    }
+    var pendingLen = this.getPath('pending.length'),
+      inflightLen = this.getPath('inflight.length'),
+      inflight = this.get('inflight'),
+      pending = this.get('pending');
 
+    if(pendingLen || inflightLen) {
+      // Iterate backwards.
+      for( var i = inflightLen - 1; i >= 0; i--) {
+        // This will 'eventually' try to remove the request from
+        // inflight, but it's not fast enough for us.
+        var r = inflight.objectAt(i);
+        r.cancel();
+      }
+      
+      // Manually scrub the arrays without screwing up memory pointers.
+      pending.replace(0, pendingLen);
+      inflight.replace(0, inflightLen);
+      
+      return YES;
+      
+    }
     return NO;
   },
 

--- a/frameworks/ajax/tests/system/request.js
+++ b/frameworks/ajax/tests/system/request.js
@@ -552,3 +552,36 @@ test("Test upload event listeners on successful request.", function() {
 
   stop() ; // stops the test runner - wait for response
 });
+
+
+test("Test manager.cancelAll.", function() {
+  var manager = SC.Request.manager, max = manager.get('maxRequests');
+  // Make sure we're clear.
+  SC.Request.manager.cancelAll();
+  
+  // Get a copy of the previous arrays, since they're overwritten on clear.
+  var inflight = manager.get('inflight');
+  var pending = manager.get('pending');
+  
+  // Generate > 6 requests
+  for( var i = 0; i < max * 2; i++) {
+    SC.Request.getUrl('/').send();
+  }
+  
+  equals(inflight.get('length'), max, "There must be %@ inflight requests".fmt(max));
+  equals(pending.get('length'), max, "There must be %@ pending requests".fmt(max));
+  
+  SC.Request.manager.cancelAll();
+
+  // Demonstrates memory pointer matches
+  equals(inflight, manager.getPath('inflight'), "Arrays must be identical");
+  equals(pending, manager.getPath('pending'), "Arrays must be identical");
+  
+  // Demonstrates that all previous requests have been cleared.
+  equals(inflight.get('length'), 0, "There must be 0 inflight requests in the old array".fmt(max));
+  equals(pending.get('length'), 0, "There must be 0 pending requests in the old array".fmt(max));
+  
+  // Demonstrates that the manager doesn't know about any requests.
+  equals(manager.getPath('inflight.length'), 0, "There must be 0 inflight requests".fmt(max));
+  equals(manager.getPath('pending.length'), 0, "There must be 0 pending requests".fmt(max));
+});


### PR DESCRIPTION
SC.Request.manager.cancelAll was using javascript's internal forEach loop in combination with a method that modified the array over which the loop is operating. The result of this is that every other request was being skipped and not cancelled.

This issue was partially concealed by the fact that the inflight and pending arrays were being overwritten whenever cancelAll was being invoked. This has also been corrected.
