### PR TITLE
Render icons in a span tag when using a class name

### DIFF
--- a/frameworks/desktop/panes/alert.js
+++ b/frameworks/desktop/panes/alert.js
@@ -313,7 +313,7 @@ SC.AlertPane = SC.PanelPane.extend(
         render: function(context, firstTime) {
           var pane = this.get('pane');
           if(pane.get('icon') == 'blank') context.addClass('plain');
-          context.push('<img src="'+SC.BLANK_IMAGE_URL+'" class="icon '+pane.get('icon')+'" />');
+          context.push('<span class="icon '+pane.get('icon')+'" ></span>');
           context.begin('h1').addClass('header').text(pane.get('message') || '').end();
           context.push(pane.get('displayDescription') || '');
           context.push(pane.get('displayCaption') || '');

--- a/frameworks/desktop/render_delegates/checkbox.js
+++ b/frameworks/desktop/render_delegates/checkbox.js
@@ -57,9 +57,9 @@ SC.BaseTheme.checkboxRenderDelegate = SC.RenderDelegate.create({
       'disabled': isDisabled
     });
 
-    context.push('<span class = "button"></span>');
+    context.push('<span class="button"></span>');
 
-    context = context.begin('span').addClass('label').id(labelId);
+    context = context.begin('span').addClass('sc-button-label').id(labelId);
     theme.labelRenderDelegate.render(dataSource, context);
     context = context.end();
   },
@@ -84,7 +84,7 @@ SC.BaseTheme.checkboxRenderDelegate = SC.RenderDelegate.create({
     // NOTE: the other properties were already set in render, and should not
     // need to be changed.
 
-    theme.labelRenderDelegate.update(dataSource, jquery.find('span.label'));
+    theme.labelRenderDelegate.update(dataSource, jquery.find('span.sc-button-label'));
 
     // add class names
     jquery.setClass({

--- a/frameworks/desktop/render_delegates/disclosure.js
+++ b/frameworks/desktop/render_delegates/disclosure.js
@@ -28,7 +28,7 @@ SC.BaseTheme.disclosureRenderDelegate = SC.RenderDelegate.create({
     state += dataSource.get('isSelected') ? 'open' : 'closed';
     if (dataSource.get('isActive')) state += ' active';
 
-    context.push('<img src = "' + SC.BLANK_IMAGE_URL + '" class = "disclosure button ' + state + '" />');
+    context.push('<span class="disclosure button ' + state + '"></span>');
 
     context = context.begin('span').addClass(labelClassNames).id(labelId);
     theme.labelRenderDelegate.render(dataSource, context);
@@ -46,7 +46,7 @@ SC.BaseTheme.disclosureRenderDelegate = SC.RenderDelegate.create({
 
     if (dataSource.get('isSelected')) jquery.addClass('sel');
 
-    jquery.find('img').setClass({
+    jquery.find('.disclosure').setClass({
       open: dataSource.get('isSelected'),
       closed: !dataSource.get('isSelected'),
       active: dataSource.get('isActive')

--- a/frameworks/desktop/render_delegates/slider.js
+++ b/frameworks/desktop/render_delegates/slider.js
@@ -23,8 +23,7 @@ SC.BaseTheme.sliderRenderDelegate = SC.RenderDelegate.create({
   render: function(dataSource, context) {
     this.addSizeClassName(dataSource, context);
 
-    var blankImage = SC.BLANK_IMAGE_URL,
-        valueMax    = dataSource.get('maximum'),
+    var valueMax    = dataSource.get('maximum'),
         valueMin    = dataSource.get('minimum'),
         valueNow    = dataSource.get('ariaValue');
 
@@ -37,11 +36,7 @@ SC.BaseTheme.sliderRenderDelegate = SC.RenderDelegate.create({
 
     context = context.begin('span').addClass('track');
     this.includeSlices(dataSource, context, SC.THREE_SLICE);
-    context.push(
-      '<img src="' + blankImage +
-      '" class="sc-handle" style="left: '+ dataSource.get('value') + '%" />'+
-      '</span>'
-    );
+    context.push('<span class="sc-handle" style="left: '+ dataSource.get('value') + '%"></span>');
 
     context = context.end();
 

--- a/frameworks/desktop/resources/button_view.css
+++ b/frameworks/desktop/resources/button_view.css
@@ -20,9 +20,10 @@
     line-height: 21px;
     text-align: center;
   }
-  img {
+  .sc-button-label .icon {
+    display: inline-block;
     vertical-align: middle ;
-    margin-right: 2px;
+    margin-right: 4px;
     position: relative ;
     top: -1px;
     left: -2px;

--- a/frameworks/desktop/resources/checkbox_view.css
+++ b/frameworks/desktop/resources/checkbox_view.css
@@ -1,9 +1,9 @@
-.sc-button-view.sc-checkbox-view img {
+.sc-button-view.sc-checkbox-view .sc-button-label .icon {
   margin-right: 4px;
   top: -1px;
   left: 0;
 }
 
-.sc-button-view.sc-checkbox-view.sc-small-size img {
+.sc-button-view.sc-checkbox-view.sc-small-size .sc-button-label .icon {
   top: -2px;
 }

--- a/frameworks/desktop/resources/disclosure.css
+++ b/frameworks/desktop/resources/disclosure.css
@@ -1,8 +1,9 @@
 /* SC.DisclosureView - sc-theme */
 
-.sc-button-view.sc-disclosure-view {
+.sc-disclosure-view {
   background: transparent;
-  img.disclosure.button {
+  .disclosure.button {
+    display: inline-block;
   	width: 16px;
   	height: 16px;
   	position: absolute;

--- a/frameworks/desktop/resources/list_item.css
+++ b/frameworks/desktop/resources/list_item.css
@@ -55,42 +55,42 @@
   &.has-checkbox.has-icon label {
   	left: 44px;
   }
-  img.icon,
-  img.right-icon {
+  .icon,
+  .right-icon {
   	margin-top: -9px;
   	position: absolute;
   	top: 50%;
   }
-  img.icon {
+  .icon {
     margin-top: -9px;
   	position: absolute;
   	top: 50%;
   	left: 5px;
   }
-  img.right-icon {
+  .right-icon {
     margin-top: -9px;
   	position: absolute;
   	top: 50%;
     right: 5px;
   }
-  &.has-checkbox img.icon {
+  &.has-checkbox .icon {
   	left: 25px;
   }
   
   &.has-count {
-    img.right-icon {
+    .right-icon {
       right: 32px;
     }
-    &.two-digit img.right-icon {
+    &.two-digit .right-icon {
       right: 38px;
     }
-    &.three-digit img.right-icon {
+    &.three-digit .right-icon {
       right: 44px;
     }
-    &.four-digit img.right-icon {
+    &.four-digit .right-icon {
       right: 50px;
     }
-    &.five-digit img.right-icon {
+    &.five-digit .right-icon {
       right: 56px;
     }
   }

--- a/frameworks/desktop/resources/menu_item_view.css
+++ b/frameworks/desktop/resources/menu_item_view.css
@@ -49,7 +49,7 @@
     height: 1px;
     border-bottom: 1px #cccccc solid;
   }
-  img {
+  .icon {
     left: 24px;
     top: 3px;
     display: block;

--- a/frameworks/desktop/resources/radio_view.css
+++ b/frameworks/desktop/resources/radio_view.css
@@ -1,7 +1,10 @@
-.sc-button-label {
-  vertical-align: top;
-}
+.sc-radio-view {
+  .sc-button-label {
+    vertical-align: top;
+  }
 
-.sc-button-label img {
-  margin-right: 4px;
+  .sc-button-label .icon {
+    display: inline-block;
+    margin-right: 4px;
+  }
 }

--- a/frameworks/desktop/resources/segmented.css
+++ b/frameworks/desktop/resources/segmented.css
@@ -14,9 +14,7 @@
     }
   }
 
-  img.icon {
-    position: relative;
-  }
+  
 
   /* Style for an individual segment. */
   .sc-segment-view {
@@ -25,6 +23,15 @@
     display: inline-block;
     position: relative;
     text-align: center;
+    
+    .sc-button-label {
+      vertical-align: top;
+      .icon {
+        display: inline-block;
+        position: relative;
+        margin-right: 4px;
+      }
+    }
 
     &:focus {
       outline: none;

--- a/frameworks/desktop/tests/views/checkbox/ui.js
+++ b/frameworks/desktop/tests/views/checkbox/ui.js
@@ -67,7 +67,7 @@ test("basic", function() {
   var input = view.$();
   equals(input.attr('aria-checked'), 'false',  'input should not be checked');
 
-  var label = view.$('span.label');
+  var label = view.$('span.sc-button-label');
   equals(label.text(), 'Hello World', 'should have label');
 });
 
@@ -79,7 +79,7 @@ test("selected", function() {
   var input = view.$();
   equals(input.attr('aria-checked'), 'true','input should be checked');
 
-  var label = view.$('span.label');
+  var label = view.$('span.sc-button-label');
   equals(label.text(), 'Hello World', 'should have label');
 });
 
@@ -91,7 +91,7 @@ test("disabled", function() {
   var input = view.$();
   equals(input.attr('aria-checked'), 'false','input should not be checked');
 
-  var label = view.$('span.label');
+  var label = view.$('span.sc-button-label');
   equals(label.text(), 'Hello World', 'should have label');
 });
 
@@ -103,7 +103,7 @@ test("disabled - selected", function() {
   var input = view.$();
   equals(input.attr('aria-checked'), 'true','input should be checked');
 
-  var label = view.$('span.label');
+  var label = view.$('span.sc-button-label');
   equals(label.text(), 'Hello World', 'should have label');
 });
 
@@ -114,6 +114,6 @@ test("role", function() {
 
 test("aria-labelledby", function() {
   var view = pane.view('aria-label');
-  equals(document.getElementById(view.$().attr('aria-labelledby')), view.$('span.label')[0], "aria-labelledby points at the label");
+  equals(document.getElementById(view.$().attr('aria-labelledby')), view.$('span.sc-button-label')[0], "aria-labelledby points at the label");
 });
 })();

--- a/frameworks/desktop/tests/views/list_item.js
+++ b/frameworks/desktop/tests/views/list_item.js
@@ -188,7 +188,7 @@ function label(view, labelText) {
 }
 
 function icon(view, spriteName) {
-  var cq = view.$(), iconCQ = cq.find('img.icon');
+  var cq = view.$(), iconCQ = cq.find('.icon');
   if (spriteName === null) {
     ok(!cq.hasClass('has-icon'), "should not have has-icon class");
     equals(iconCQ.size(), 0, 'should not have image');

--- a/frameworks/desktop/views/list_item.js
+++ b/frameworks/desktop/views/list_item.js
@@ -912,21 +912,13 @@ SC.ListItemView = SC.View.extend(SC.InlineEditable, SC.Control,
   */
   renderIcon: function (context, icon) {
     // get a class name and url to include if relevant
-    var url = null, className = null, classArray = [];
+    var classArray = ['icon'];
     if (icon && SC.ImageView.valueIsUrl(icon)) {
-      url = icon;
-      className = '';
+      context.begin('img').addClass(classArray).setAttr('src', icon).end();
     } else {
-      className = icon;
-      url = SC.BLANK_IMAGE_URL;
+      classArray.push(icon);
+      context.begin('span').addClass(classArray).end();
     }
-
-    // generate the img element...
-    classArray.push(className, 'icon');
-    context.begin('img')
-            .addClass(classArray)
-            .setAttr('src', url)
-            .end();
   },
 
   /** @private
@@ -952,23 +944,13 @@ SC.ListItemView = SC.View.extend(SC.InlineEditable, SC.Control,
   */
   renderRightIcon: function (context, icon) {
     // get a class name and url to include if relevant
-    var url = null,
-      className = null,
-      classArray = [];
+    var classArray = ['right-icon'];
     if (icon && SC.ImageView.valueIsUrl(icon)) {
-      url = icon;
-      className = '';
+      context.begin('img').addClass(classArray).setAttr('src', icon).end();
     } else {
-      className = icon;
-      url = SC.BLANK_IMAGE_URL;
+      classArray.push(icon);
+      context.begin('span').addClass(classArray).end();
     }
-
-    // generate the img element...
-    classArray.push('right-icon', className);
-    context.begin('img')
-      .addClass(classArray)
-      .setAttr('src', url)
-    .end();
   },
 
   /** @private
@@ -994,7 +976,7 @@ SC.ListItemView = SC.View.extend(SC.InlineEditable, SC.Control,
     @returns {void}
   */
   renderAction: function (context, actionClassName) {
-    context.push('<img src="', SC.BLANK_IMAGE_URL, '" class="action" />');
+    context.push('<span class="action"></span>');
   },
 
   /** @private

--- a/frameworks/desktop/views/menu_item.js
+++ b/frameworks/desktop/views/menu_item.js
@@ -235,17 +235,13 @@ SC.MenuItemView = SC.View.extend(SC.ContentDisplay,
   */
   renderImage: function(context, image) {
     // get a class name and url to include if relevant
-
-    var url, className ;
+    var classArray = ['icon'];
     if (image && SC.ImageView.valueIsUrl(image)) {
-      url = image ;
-      className = '' ;
+      context.begin('img').addClass(classArray).setAttr('src', image).end();
     } else {
-      className = image ;
-      url = SC.BLANK_IMAGE_URL;
+      classArray.push(image);
+      context.begin('span').addClass(classArray).end();
     }
-    // generate the img element...
-    context.begin('img').addClass('image').addClass(className).setAttr('src', url).end() ;
   },
 
   /** @private

--- a/frameworks/desktop/views/source_list_group.js
+++ b/frameworks/desktop/views/source_list_group.js
@@ -85,7 +85,7 @@ SC.SourceListGroupView = SC.View.extend(SC.Control, SC.CollectionGroup,
   /** @private */
   render: function(context, firstTime) {
     context.push('<div role="button" class="sc-source-list-label sc-disclosure-view sc-button-view button disclosure no-disclosure">',
-              '<img src="'+SC.BLANK_IMAGE_URL+'" class="button" />',
+              '<span class="button"></span>',
               '<span class="label"></span></div>') ;
   },
   

--- a/frameworks/foundation/render_delegates/label.js
+++ b/frameworks/foundation/render_delegates/label.js
@@ -131,7 +131,7 @@ SC.BaseTheme.labelRenderDelegate = SC.RenderDelegate.create({
       // to the image tag. Display a blank image so that the user can add
       // background image using CSS.
       } else {
-        icon = '<img src="'+SC.BLANK_IMAGE_URL+'" alt="" class="icon '+icon+'" />';
+        icon = '<span class="icon '+icon+'"></span>';
       }
     }
 

--- a/frameworks/foundation/resources/label.css
+++ b/frameworks/foundation/resources/label.css
@@ -4,7 +4,8 @@
   text-align: left;
   white-space: pre-line;      /* Allow strings to include '\n' characters, etc., like many other UI frameworks */
 
-  &.icon img {
+  .icon {
+    display: inline-block;
   	position: relative;
   	vertical-align: middle;
   }

--- a/frameworks/media/render_delegates/media_slider.js
+++ b/frameworks/media/render_delegates/media_slider.js
@@ -19,7 +19,6 @@ SC.BaseTheme.mediaSliderRenderDelegate = SC.RenderDelegate.create({
   render: function(dataSource, context) {
     this.addSizeClassName(dataSource, context);
 
-    var blankImage = SC.BLANK_IMAGE_URL;
     var valueMax = dataSource.get('maximum');
     var valueMin = dataSource.get('minimum');
     var valueNow = dataSource.get('ariaValue');
@@ -38,7 +37,7 @@ SC.BaseTheme.mediaSliderRenderDelegate = SC.RenderDelegate.create({
     context = context.begin('span').addClass('track');
     this.includeSlices(dataSource, context, SC.THREE_SLICE);
     context.push('<span class="sc-loaded-ranges"></span>');
-    context.push('<img src="' + blankImage + '" class="sc-handle" style="left: ' + dataSource.get('value') + '%" />' + '</span>');
+    context.push('<span class="sc-handle" style="left: ' + dataSource.get('value') + '%"></span>');
 
     context = context.end();
 

--- a/themes/ace/resources/button/ace/18px/button.css
+++ b/themes/ace/resources/button/ace/18px/button.css
@@ -9,9 +9,7 @@
       padding-top:2px;
     }
 
-    img {
-      top: -2px;
-    }
+    
 
     @include slices("normal_button.png", $left: 3, $right: 3);
 

--- a/themes/ace/resources/checkbox/ace/14px/checkbox.css
+++ b/themes/ace/resources/checkbox/ace/14px/checkbox.css
@@ -9,7 +9,7 @@ $theme.checkbox {
     @include slice("checkbox_unchecked.png");
   }
   
-  .label {
+  .sc-button-label {
     position: absolute;
     left: 20px;
   }

--- a/themes/ace/resources/checkbox/ace/16px/checkbox.css
+++ b/themes/ace/resources/checkbox/ace/16px/checkbox.css
@@ -9,7 +9,7 @@ $theme.checkbox {
     @include slice("checkbox_unchecked.png");
   }
   
-  .label {
+  .sc-button-label {
     position: absolute;
     left: 22px;
   }

--- a/themes/ace/resources/disclosure/ace/disclosure.css
+++ b/themes/ace/resources/disclosure/ace/disclosure.css
@@ -9,7 +9,7 @@ $theme.disclosure {
     left: 18px;
   }
   
-  img.disclosure.button {
+  .disclosure.button {
     width: 14px;
     height: 14px;
     &.open    { @include slice("disclosure_open.png"); }

--- a/themes/ace/resources/segmented/18px/segmented.css
+++ b/themes/ace/resources/segmented/18px/segmented.css
@@ -27,12 +27,12 @@ $theme.sc-segment-view {
     line-height: 18px;
     margin-left: 9px;
     margin-right: 10px;
-  }
 
-  img.icon {
-    height: 12px;
-    top: 2px;
-    width: 12px;
+    .icon {
+      height: 12px;
+      top: 2px;
+      width: 12px;
+    }
   }
 
   &.sc-first-segment .left {

--- a/themes/ace/resources/segmented/24px/segmented.css
+++ b/themes/ace/resources/segmented/24px/segmented.css
@@ -33,12 +33,12 @@ $theme.sc-segment-view {
     line-height: 24px;
     margin-left: 9px;
     margin-right: 10px;
-  }
 
-  img.icon {
-    height: 14px;
-    top: 5px;
-    width: 14px;
+    .icon {
+      height: 14px;
+      top: 5px;
+      width: 14px;
+    }
   }
 
   &.sc-first-segment .left {

--- a/themes/ace/resources/segmented/30px/segmented.css
+++ b/themes/ace/resources/segmented/30px/segmented.css
@@ -33,12 +33,12 @@ $theme.sc-segment-view {
     line-height: 30px;
     margin-left: 9px;
     margin-right: 10px;
-  }
 
-  img.icon {
-    height: 16px;
-    top: 7px;
-    width: 16px;
+    .icon {
+      height: 16px;
+      top: 7px;
+      width: 16px;
+    }
   }
 
   &.sc-first-segment .left {

--- a/themes/ace/resources/segmented/44px/segmented.css
+++ b/themes/ace/resources/segmented/44px/segmented.css
@@ -31,12 +31,12 @@ $theme.sc-segment-view {
     text-shadow: 0px 1px 1px white;
     margin-left: 9px;
     margin-right: 10px;
-  }
-
-  img.icon {
-    height: 24px;
-    top: 9px;
-    width: 24px;
+    
+    .icon {
+      height: 24px;
+      top: 9px;
+      width: 24px;
+    }
   }
 
   &.sc-first-segment .left {

--- a/themes/legacy_theme/english.lproj/button.css
+++ b/themes/legacy_theme/english.lproj/button.css
@@ -8,7 +8,7 @@
   padding: 0;
 }
 
-.sc-theme .sc-button-view.icon img.icon {
+.sc-theme .sc-button-view.icon .icon {
   position: relative;
   vertical-align: middle;
   top: -2px;

--- a/themes/legacy_theme/english.lproj/checkbox.css
+++ b/themes/legacy_theme/english.lproj/checkbox.css
@@ -5,7 +5,7 @@
 	vertical-align: middle;
 }
 
-.sc-theme .sc-checkbox-view .label {
+.sc-theme .sc-checkbox-view .sc-button-label {
 	position: absolute ;
 	left: 20px;
 	top: 0;
@@ -14,7 +14,7 @@
 	line-height: 18px;
 }
  
-.sc-theme .sc-checkbox-view.icon img.icon {
+.sc-theme .sc-checkbox-view.icon .icon {
 	position: relative;
 	vertical-align: middle;
 	top: -2px;

--- a/themes/legacy_theme/english.lproj/disclosure.css
+++ b/themes/legacy_theme/english.lproj/disclosure.css
@@ -4,7 +4,7 @@
 
 /* @group basic */
 
-.sc-theme .sc-button-view.sc-disclosure-view img.button {
+.sc-theme .sc-button-view.sc-disclosure-view > .button {
 	width: 12px;
 	height: 12px;
 	left: 0;
@@ -13,11 +13,11 @@
 } 
 
 
-.sc-theme .sc-button-view.sc-disclosure-view.sel img.button {
+.sc-theme .sc-button-view.sc-disclosure-view.sel > .button {
 	background-position: 0px -1597px ;
 }
 
-.sc-theme .sc-button-view.sc-disclosure-view img.button {
+.sc-theme .sc-button-view.sc-disclosure-view > .button {
 	background-position: -16px -1614px ;
 }
 
@@ -29,11 +29,11 @@
 
 /* @group disabled */
 
-.sc-theme .sc-button-view.sc-disclosure-view.sel.disabled img.button {
+.sc-theme .sc-button-view.sc-disclosure-view.sel.disabled > .button {
 	background-position: 0px -1613px ;
 }
 
-.sc-theme .sc-button-view.sc-disclosure-view.disabled img.button {
+.sc-theme .sc-button-view.sc-disclosure-view.disabled > .button {
 	background-position: -16px -1630px ;
 }
 
@@ -41,11 +41,11 @@
 
 /* @group active */
 
-.sc-theme .sc-button-view.sc-disclosure-view.sel.active img.button {
+.sc-theme .sc-button-view.sc-disclosure-view.sel.active > .button {
 	background-position: -16px -1597px ;
 }
 
-.sc-theme .sc-button-view.sc-disclosure-view.active img.button {
+.sc-theme .sc-button-view.sc-disclosure-view.active > .button {
 	background-position: -0px -1630px ;
 }
 

--- a/themes/legacy_theme/english.lproj/label.css
+++ b/themes/legacy_theme/english.lproj/label.css
@@ -2,7 +2,7 @@
 
 /* SC.LabelView - sc-theme support */
 
-.sc-theme .sc-label-view img.icon {
+.sc-theme .sc-label-view .icon {
 	top: -2px;
 	margin-left: 2px;
 	margin-right: 4px;

--- a/themes/legacy_theme/english.lproj/list_item.css
+++ b/themes/legacy_theme/english.lproj/list_item.css
@@ -31,7 +31,7 @@
 
 /* @group Disclosure */
 
-.sc-list-item-view img.disclosure {
+.sc-list-item-view .disclosure {
 	position: absolute ;
 	left: -11px;
 	top: 50%;
@@ -42,25 +42,25 @@
 	background-position: -16px -1614px ;
 }
 
-.sc-list-item-view img.disclosure.open {
+.sc-list-item-view .disclosure.open {
 	background-position: 0px -1597px ;
 }
 
-.sc-list-item-view img.disclosure.active {
+.sc-list-item-view .disclosure.active {
 	background-position: -0px -1630px ;
 }
 
-.sc-list-item-view img.disclosure.open.active {
+.sc-list-item-view .disclosure.open.active {
 	background-position: -16px -1597px ;
 }
 
-.sc-list-item-view.disabled img.disclosure,
-.sc-list-item-view.disabled img.disclosure.active {
+.sc-list-item-view.disabled .disclosure,
+.sc-list-item-view.disabled .disclosure.active {
 	background-position: -16px -1630px ;
 }
 
-.sc-list-item-view.disabled img.disclosure.open,
-.sc-list-item-view.disabled img.disclosure.open.active {
+.sc-list-item-view.disabled .disclosure.open,
+.sc-list-item-view.disabled .disclosure.open.active {
 	background-position: 0px -1613px ;
 }
 

--- a/themes/legacy_theme/english.lproj/radio.css
+++ b/themes/legacy_theme/english.lproj/radio.css
@@ -53,7 +53,8 @@
 	color: rgba(0,0,0,0.5);
 }
 
-.sc-theme .sc-radio-view img.icon {
+.sc-theme .sc-radio-view .sc-button-label .icon {
+	display: inline-block;
 	position: relative;
 	vertical-align: middle;
 	top: -2px;
@@ -63,8 +64,8 @@
 	width: 16px;
 }
 
-.sc-theme .sc-radio-view.disabled img.icon,
-.sc-theme .sc-radio-view .sc-radio-button.disabled img.icon {
+.sc-theme .sc-radio-view.disabled .sc-button-label .icon,
+.sc-theme .sc-radio-view .sc-radio-button.disabled .sc-button-label .icon {
 	opacity: 0.5;
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)"; 
   filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=50);

--- a/themes/legacy_theme/english.lproj/segmented.css
+++ b/themes/legacy_theme/english.lproj/segmented.css
@@ -6,7 +6,7 @@
 	outline: none;
 }
 
-.sc-theme .sc-segment-view img.icon {
+.sc-theme .sc-segment-view .sc-button-label .icon {
 	position: relative;
 	vertical-align: middle;
 	top: -2px;
@@ -15,7 +15,7 @@
 	width: 16px;
 }
 
-.sc-theme .sc-segmented-view.disabled .sc-segment-view img.icon {
+.sc-theme .sc-segmented-view.disabled .sc-segment-view .sc-button-label .icon {
 	opacity: 0.5;
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)"; 
   filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=50);

--- a/themes/legacy_theme/render_delegates/slider.js
+++ b/themes/legacy_theme/render_delegates/slider.js
@@ -23,8 +23,7 @@ SC.LegacyTheme.sliderRenderDelegate = SC.RenderDelegate.create({
   render: function(dataSource, context) {
     this.addSizeClassName(dataSource, context);
 
-    var blankImage  = SC.BLANK_IMAGE_URL,
-        valueMax    = dataSource.get('maximum'),
+    var valueMax    = dataSource.get('maximum'),
         valueMin    = dataSource.get('minimum'),
         valueNow    = dataSource.get('ariaValue');
 
@@ -38,16 +37,14 @@ SC.LegacyTheme.sliderRenderDelegate = SC.RenderDelegate.create({
     context.push('<span class="sc-inner">',
                   '<span class="sc-leftcap"></span>',
                   '<span class="sc-rightcap"></span>',
-                  '<img src="', blankImage,
-                  '" class="sc-handle" style="left: ', dataSource.get('value'), '%" />',
+                  '<span class="sc-handle" style="left: ', dataSource.get('value'), '%"></span>',
                   '</span>');
   },
 
   update: function(dataSource, jquery) {
     this.updateSizeClassName(dataSource, jquery);
 
-    var blankImage  = SC.BLANK_IMAGE_URL,
-        valueMax    = dataSource.get('maximum'),
+    var valueMax    = dataSource.get('maximum'),
         valueMin    = dataSource.get('minimum'),
         valueNow    = dataSource.get('ariaValue');
 


### PR DESCRIPTION
More information about why this change: https://github.com/sproutcore/sproutcore/issues/963

This pull request include:
- replacement of icons `img` tags by `span` tags when using a class name
- update of the CSS rules to match that change
- wrapping of the CSS rules of the radio view into `sc-radio-view`
- icon `margin-right` fix for the button views
- icon positioning fix of 18px button views
- rename of the label classname of the checkbox view from `label` to `sc-button-label` for consistency.
