### PR TITLE
Fix for SegmentedView bound to Array property

### DIFF
--- a/frameworks/desktop/views/segmented.js
+++ b/frameworks/desktop/views/segmented.js
@@ -295,6 +295,7 @@ SC.SegmentedView = SC.View.extend(SC.Control,
   */
   segmentViewClass: SC.SegmentView,
 
+  valueAlwaysMultiple: NO,
 
   /** @private
     The following properties are used to map items to child views. Item keys
@@ -1085,15 +1086,17 @@ SC.SegmentedView = SC.View.extend(SC.Control,
     }
 
     // normalize back to non-array form
-    switch(value.get('length')) {
-      case 0:
-        value = null;
-        break;
-      case 1:
-        value = value.objectAt(0);
-        break;
-      default:
-        break;
+    if (!this.get('valueAlwaysMultiple')) {
+      switch(value.get('length')) {
+        case 0:
+          value = null;
+          break;
+        case 1:
+          value = value.objectAt(0);
+          break;
+        default:
+          break;
+      }
     }
 
     // also, trigger target if needed.


### PR DESCRIPTION
If you bind a SC.SegmentedView to a record attribute declared as SC.Record.attr(Array), you will never be able to select an item in the Segmented view.  This is because the SegmentedView coerces its value to a string if only one item is selected, and the RecordAttribute rejects the change as the value is not an array.

This PR adds an option to disable the coercion so the value of a SegmentedView is always an array, regardless of having 0, 1, or more items selected.  If this is desired, I will add docs.
