### PR TITLE
TextField incorrectly sets initial tab index

### DIFF
--- a/frameworks/foundation/views/text_field.js
+++ b/frameworks/foundation/views/text_field.js
@@ -647,7 +647,7 @@ SC.TextFieldView = SC.FieldView.extend(SC.StaticLayout, SC.Editable,
         autocapitalizeString = ' autocapitalize=' + (!autoCapitalize ? '"off"' : '"true"');
       }
 
-      if (isBrowserFocusable) {
+      if (!isBrowserFocusable) {
         browserFocusable = 'tabindex="-1"';
       }
         // if hint is on and we don't want it to show on focus, create one


### PR DESCRIPTION
Not sure why, but SC.TextFieldView's initial check of isBrowserFocusable was backwards and set `tabindex="-1"` when it shouldn't.  For some reason, this only caused an issue on iOS when the next/previous field buttons didn't work, and only for the initial pane.
