### PR TITLE
Declare locals in destroyObservable

### DIFF
--- a/frameworks/runtime/mixins/observable.js
+++ b/frameworks/runtime/mixins/observable.js
@@ -945,6 +945,9 @@ SC.Observable = /** @scope SC.Observable.prototype */{
       @returns {Object} this
     */
     destroyObservable: function() {
+      var keys, len, loc, key, observer, propertyPaths, propertyPathsLength,
+        ploc, path;
+
       // Destroy bindings
       this.bindings.invoke('destroy');
       delete this.bindings;


### PR DESCRIPTION
It appears that destroyObservable is using all global variables. Is that correct?
