### PR TITLE
Improve touch detection logic so that unit tests can be run under phantomjs

### DIFF
--- a/frameworks/core_foundation/system/platform.js
+++ b/frameworks/core_foundation/system/platform.js
@@ -73,7 +73,7 @@ SC.platform = SC.Object.create({
 
     @type Boolean
   */
-  touch: !SC.none(window.ontouchstart) || SC.browser.name === SC.BROWSER.android || 'ontouchstart' in document.documentElement,
+  touch: SC.none(window._phantom) && ( !SC.none(window.ontouchstart) || SC.browser.name === SC.BROWSER.android || 'ontouchstart' in document.documentElement ),
 
   /**
     YES if the current browser supports bounce on scroll.


### PR DESCRIPTION
Phantomjs is uncorrectly detected as touch-enabled, see https://github.com/ariya/phantomjs/issues/10375. This way SC unit tests can be run under phantomjs, allowing easy travis-ci integration.

Tested on FF, Chrome, Phantomjs (1.9.1).
