### PR TITLE
fix a test suite in which null was used in place of undefined. Replaced check with SC.none

### DIFF
--- a/frameworks/foundation/tests/views/text_field/ui.js
+++ b/frameworks/foundation/tests/views/text_field/ui.js
@@ -473,7 +473,7 @@ test("Adding right accessory view", function() {
   view.set('rightAccessoryView', accessoryView);
   SC.RunLoop.end();
 
-  ok(view.get('rightAccessoryView').get('layout').left === null, "right accessory view created with 'left' rather than 'right' in layout should have layout.left set to null");
+  ok( SC.none(view.get('rightAccessoryView').get('layout').left), "right accessory view created with 'left' rather than 'right' in layout should not have a value for layout.left");
   ok(view.get('rightAccessoryView').get('layout').right === 0, "right accessory view created with 'left' rather than 'right' in layout should have layout.right set to 0");
 
 


### PR DESCRIPTION
This is the same edit reviewed by @dcporter [here](https://github.com/unicolet/sproutcore/commit/d25d5efab1af19c195aa83d3010009b2dcd20dac).
