### PR TITLE
correct unit test asserts on SC.Pane where behavior changed after introduction of statecharts for views

### DIFF
--- a/frameworks/desktop/tests/panes/pane_page.js
+++ b/frameworks/desktop/tests/panes/pane_page.js
@@ -25,18 +25,34 @@ test("isVisible changes should update views that are instantiated in a page", fu
     })
   }) ;
 
-
+  /*
+    The behavior for isVisible has changed since in 1.10 view statecharts were introduced
+    and now setting isVisible on a detached view has no effect, while it
+    previously effectively attempted to hide the view by adding the sc-hidden class.
+    
+    bottom line: setting isVisible now only works on attached views.
+  */
   var pp = page.get('inspector');
+  pp.childViews[0].childViews[0].set('isVisible', NO);
   pp.append();
   SC.RunLoop.begin().end();
+  var res = pp.childViews[0].childViews[0].$().hasClass('sc-hidden');
+  ok(res, "isVisible works when a view is attached");
+  
+  pp.childViews[0].childViews[0].set('isVisible', YES);
+  pp.append();
+  SC.RunLoop.begin().end();
+  res = pp.childViews[0].childViews[0].$().hasClass('sc-hidden');
+  ok(!res, "isVisible (reverse) works when a view is attached");
+  
   pp.remove();
   SC.RunLoop.begin().end();
   pp.childViews[0].childViews[0].set('isVisible', NO);
   SC.RunLoop.begin().end();
   pp.append();
   SC.RunLoop.begin().end();
-  var res = pp.childViews[0].childViews[0].$().hasClass('sc-hidden');
-  ok(res, "The view (isVisible) has been properly rerendered even though it was part of a page, the pane was detached and the visibility was changed while detached");
+  res = pp.childViews[0].childViews[0].$().hasClass('sc-hidden');
+  ok(!res, "isVisible has no effect while a view is detached");
 
   pp.remove();
 });


### PR DESCRIPTION
After digging through the source code the change in behavior seems to be related to the new statecharts.
Someone from the core team should be able to confirm.
