### PR TITLE
correct media audio/video detection code

### DIFF
--- a/frameworks/media/media_capabilities.js
+++ b/frameworks/media/media_capabilities.js
@@ -41,9 +41,9 @@ SC.mediaCapabilities = SC.Object.create({});
     }
     
     var doc = document.createElement('audio');
-    isAudioSupported = !!doc.canPlayType;
+    var isAudioSupported = !!doc.canPlayType;
     delete doc;
-    SC.mediaCapabilities.isHTML5AudioSupported = YES;
+    SC.mediaCapabilities.isHTML5AudioSupported = isAudioSupported;
     
   } catch(e) {
   }
@@ -62,9 +62,9 @@ SC.mediaCapabilities = SC.Object.create({});
     }
     
     var doc = document.createElement('video');
-    isVideoSupported = !!doc.canPlayType;
+    var isVideoSupported = !!doc.canPlayType;
     delete doc;
-    SC.mediaCapabilities.isHTML5VideoSupported = YES;
+    SC.mediaCapabilities.isHTML5VideoSupported = isVideoSupported;
   } catch(e) {
   }
   


### PR DESCRIPTION
The audio video detection code was missing an assignment of the actual result from the browser sniffing code.

The test fails on Phantomjs and not on other browsers because Phantomjs is in the quite unique situation that it does not support audio and video at this time.
