### PR TITLE
Fixes typo from a previous commit

### DIFF
--- a/frameworks/foundation/views/container.js
+++ b/frameworks/foundation/views/container.js
@@ -374,7 +374,7 @@ SC.ContainerContentStatechart = SC.Object.extend({
       options = container.get('transitionSwapOptions') || {},
       transitionSwap = container.get('transitionSwap');
 
-    if (transitionSwap && transitionClippingFrame) {
+    if (transitionSwap && transitionSwap.transitionClippingFrame) {
       return transitionSwap.transitionClippingFrame(container, clippingFrame, options);
     } else {
       return clippingFrame;


### PR DESCRIPTION
From this commit: https://github.com/sproutcore/sproutcore/commit/e119ca9e7c38dacc6fb2b29a1fb05073c8b3e94e
