### PR TITLE
Set SC.DEFAULT_CURSOR to 'default' instead of 'auto'

### DIFF
--- a/frameworks/core_foundation/system/cursor.js
+++ b/frameworks/core_foundation/system/cursor.js
@@ -6,22 +6,22 @@
 // ==========================================================================
 
 // standard browser cursor definitions
-SC.DEFAULT_CURSOR = 'default' ;
-SC.AUTO_CURSOR = 'auto' ;
-SC.CROSSHAIR_CURSOR = 'crosshair' ;
-SC.HAND_CURSOR = SC.POINTER_CURSOR = 'pointer' ;
-SC.MOVE_CURSOR = 'move' ;
-SC.E_RESIZE_CURSOR = 'e-resize' ;
-SC.NE_RESIZE_CURSOR = 'ne-resize' ;
-SC.NW_RESIZE_CURSOR = 'nw-resize' ;
-SC.N_RESIZE_CURSOR = 'n-resize' ;
-SC.SE_RESIZE_CURSOR = 'se-resize' ;
-SC.SW_RESIZE_CURSOR = 'sw-resize' ;
-SC.S_RESIZE_CURSOR = 's-resize' ;
-SC.W_RESIZE_CURSOR = 'w-resize' ;
-SC.IBEAM_CURSOR = SC.TEXT_CURSOR = 'text' ;
-SC.WAIT_CURSOR = 'wait' ;
-SC.HELP_CURSOR = 'help' ;
+SC.DEFAULT_CURSOR = 'default';
+SC.AUTO_CURSOR = 'auto';
+SC.CROSSHAIR_CURSOR = 'crosshair';
+SC.HAND_CURSOR = SC.POINTER_CURSOR = 'pointer';
+SC.MOVE_CURSOR = 'move';
+SC.E_RESIZE_CURSOR = 'e-resize';
+SC.NE_RESIZE_CURSOR = 'ne-resize';
+SC.NW_RESIZE_CURSOR = 'nw-resize';
+SC.N_RESIZE_CURSOR = 'n-resize';
+SC.SE_RESIZE_CURSOR = 'se-resize';
+SC.SW_RESIZE_CURSOR = 'sw-resize';
+SC.S_RESIZE_CURSOR = 's-resize';
+SC.W_RESIZE_CURSOR = 'w-resize';
+SC.IBEAM_CURSOR = SC.TEXT_CURSOR = 'text';
+SC.WAIT_CURSOR = 'wait';
+SC.HELP_CURSOR = 'help';
 
 /**
   @class SC.Cursor
@@ -45,26 +45,26 @@ SC.Cursor = SC.Object.extend(
 /** @scope SC.Cursor.prototype */ {
 
   /** @private */
-  init: function() {
-    sc_super() ;
+  init: function () {
+    sc_super();
 
     // create a unique style rule and add it to the shared cursor style sheet
-    var cursorStyle = this.get('cursorStyle') || SC.DEFAULT_CURSOR ,
-        ss = this.constructor.sharedStyleSheet(),
-        guid = SC.guidFor(this);
+    var cursorStyle = this.get('cursorStyle') || SC.DEFAULT_CURSOR,
+      ss = this.constructor.sharedStyleSheet(),
+      guid = SC.guidFor(this);
 
     if (ss.insertRule) { // WC3
       ss.insertRule(
-        '.'+guid+' {cursor: '+cursorStyle+';}',
+        '.' + guid + ' {cursor: ' + cursorStyle + ';}',
         ss.cssRules ? ss.cssRules.length : 0
-      ) ;
+      );
     } else if (ss.addRule) { // IE
-      ss.addRule('.'+guid, 'cursor: '+cursorStyle) ;
+      ss.addRule('.' + guid, 'cursor: ' + cursorStyle);
     }
 
-    this.cursorStyle = cursorStyle ;
-    this.className = guid ; // used by cursor clients...
-    return this ;
+    this.cursorStyle = cursorStyle;
+    this.className = guid; // used by cursor clients...
+    return this;
   },
 
   /**
@@ -83,27 +83,27 @@ SC.Cursor = SC.Object.extend(
   cursorStyle: SC.DEFAULT_CURSOR,
 
   /** @private */
-  cursorStyleDidChange: function() {
+  cursorStyleDidChange: function () {
     var cursorStyle, rule, selector, ss, rules, idx, len;
     cursorStyle = this.get('cursorStyle') || SC.DEFAULT_CURSOR;
     rule = this._rule;
     if (rule) {
-      rule.style.cursor = cursorStyle ; // fast path
-      return ;
+      rule.style.cursor = cursorStyle; // fast path
+      return;
     }
 
     // slow path, taken only once
-    selector = '.'+this.get('className') ;
-    ss = this.constructor.sharedStyleSheet() ;
-    rules = (ss.cssRules ? ss.cssRules : ss.rules) || [] ;
+    selector = '.' + this.get('className');
+    ss = this.constructor.sharedStyleSheet();
+    rules = (ss.cssRules ? ss.cssRules : ss.rules) || [];
 
     // find our rule, cache it, and update the cursor style property
-    for (idx=0, len = rules.length; idx<len; ++idx) {
-      rule = rules[idx] ;
+    for (idx = 0, len = rules.length; idx < len; ++idx) {
+      rule = rules[idx];
       if (rule.selectorText === selector) {
-        this._rule = rule ; // cache for next time
-        rule.style.cursor = cursorStyle ; // update the cursor
-        break ;
+        this._rule = rule; // cache for next time
+        rule.style.cursor = cursorStyle; // update the cursor
+        break;
       }
     }
   }.observes('cursorStyle')
@@ -115,7 +115,7 @@ SC.Cursor = SC.Object.extend(
 
 /** @private */
 SC.Cursor.sharedStyleSheet = function () {
-  var ssEl,
+  var ssEl, 
     head,
     ss = this._styleSheet;
 


### PR DESCRIPTION
Because `SC.DEFAULT_CURSOR` was set to `auto`, all the `SC.LabelView` (or any other view containing text)  inside an `SC.SplitView` (which use the `SC.Cursor` class) were having a `text` cursor. 

With this PR only the views that have isTextSelectable set to yes get a `text` cursor.

Note that I removed `SC.SYSTEM_CURSOR` which wasn't used anywhere and which is now replaced by `SC.DEFAULT_CURSOR`.
