### PR TITLE
Improves core method performances

### DIFF
--- a/frameworks/runtime/core.js
+++ b/frameworks/runtime/core.js
@@ -697,7 +697,7 @@ SC.mixin(/** @scope window.SC.prototype */ {
   */
   tupleForPropertyPath: function (path, root) {
     // if passed nothing, return nothing.
-    if (SC.none(path)) return null;
+    if (path == null) return null;
 
     // if the passed path is itself a tuple, return it
     if (typeof path === "object" && (path instanceof Array)) return path;
@@ -729,7 +729,7 @@ SC.mixin(/** @scope window.SC.prototype */ {
     if (!root) root = window;
 
     // faster method for strings
-    if (SC.typeOf(path) === SC.T_STRING) {
+    if (typeof path === "string") {
       if (stopAt === undefined) stopAt = path.length;
       loc = 0;
       while ((root) && (loc < stopAt)) {


### PR DESCRIPTION
Theses are small changes but I find out that when I load my app and display an heavy custom collection `SC.objectForPropertyPath` is call about 174757 times.

From my benchmark, with : 
`SC.typeOf`: 174757 => 653ms
`typeof`: 175382 => 453ms

Which makes the method 1.4 times faster and make me win 200ms.

With `tupleForPropertyPath` there is a gain of 25ms when executed about 173121 times.
