### PR TITLE
Add more options for automatic capitalization

### DIFF
--- a/frameworks/foundation/tests/views/text_field/methods.js
+++ b/frameworks/foundation/tests/views/text_field/methods.js
@@ -116,6 +116,39 @@ test("isBrowserFocusable should set tab index", function() {
   ok(view.$input().attr('tabindex') === "-1", 'unfocusable field should have unfocusable tab index');
 });
 
+test("autoCapitalize=SC.AUTOCAPITALIZE_NONE should add autocapitalize='none'", function() {
+  SC.RunLoop.begin();
+  view.set('autoCapitalize', SC.AUTOCAPITALIZE_NONE);
+  view.displayDidChange();
+  SC.RunLoop.end();
+  console.log(view.$input().attr('autocapitalize'))
+  ok(view.$input().attr('autocapitalize') === "none", 'should have an autocapitalize attribute set to "none"');
+});
+
+test("autoCapitalize=SC.AUTOCAPITALIZE_SENTENCES should add autocapitalize='sentences'", function() {
+  SC.RunLoop.begin();
+  view.set('autoCapitalize', SC.AUTOCAPITALIZE_SENTENCES);
+  view.displayDidChange();
+  SC.RunLoop.end();
+  ok(view.$input().attr('autocapitalize') === "sentences", 'should have an autocapitalize attribute set to "sentences"');
+});
+
+test("autoCapitalize=SC.AUTOCAPITALIZE_WORDS should add autocapitalize='words'", function() {
+  SC.RunLoop.begin();
+  view.set('autoCapitalize', SC.AUTOCAPITALIZE_WORDS);
+  view.displayDidChange();
+  SC.RunLoop.end();
+  ok(view.$input().attr('autocapitalize') === "words", 'should have an autocapitalize attribute set to "words"');
+});
+
+test("autoCapitalize=SC.AUTOCAPITALIZE_CHARACTERS should add autocapitalize='characters'", function() {
+  SC.RunLoop.begin();
+  view.set('autoCapitalize', SC.AUTOCAPITALIZE_CHARACTERS);
+  view.displayDidChange();
+  SC.RunLoop.end();
+  ok(view.$input().attr('autocapitalize') === "characters", 'should have an autocapitalize attribute set to "characters"');
+});
+
 test("autoCapitalize=YES should add autocapitalize='sentences'", function() {
   SC.RunLoop.begin();
   view.set('autoCapitalize', YES);

--- a/frameworks/foundation/views/text_field.js
+++ b/frameworks/foundation/views/text_field.js
@@ -10,6 +10,11 @@ sc_require('system/text_selection') ;
 sc_require('mixins/static_layout') ;
 sc_require('mixins/editable');
 
+SC.AUTOCAPITALIZE_NONE = 'none';
+SC.AUTOCAPITALIZE_SENTENCES = 'sentences';
+SC.AUTOCAPITALIZE_WORDS = 'words';
+SC.AUTOCAPITALIZE_CHARACTERS = 'characters';
+
 /**
   @class
 
@@ -125,15 +130,26 @@ SC.TextFieldView = SC.FieldView.extend(SC.Editable,
   autoCorrect: YES,
 
   /**
-    Whether the browser should automatically capitalize the input.
+    Specifies the autocapitalization behavior.
+
+    Possible values are:
+
+     - `SC.AUTOCAPITALIZE_NONE` -- Do not autocapitalize.
+     - `SC.AUTOCAPITALIZE_SENTENCES` -- Autocapitalize the first letter of each
+       sentence.
+     - `SC.AUTOCAPITALIZE_WORDS` -- Autocapitalize the first letter of each word.
+     - `SC.AUTOCAPITALIZE_CHARACTERS` -- Autocapitalize all characters.
+
+    Boolean values are also supported, with YES interpreted as
+    `SC.AUTOCAPITALIZE_NONE` and NO as `SC.AUTOCAPITALIZE_SENTENCES`.
 
     When `autoCapitalize` is set to `null`, the browser will use
     the system defaults.
 
-    @type Boolean
-    @default YES
+    @type String SC.AUTOCAPITALIZE_NONE|SC.AUTOCAPITALIZE_SENTENCES|SC.AUTOCAPITALIZE_WORDS|SC.AUTOCAPITALIZE_CHARACTERS
+    @default SC.CAPITALIZE_SENTENCES
    */
-  autoCapitalize: YES,
+  autoCapitalize: SC.CAPITALIZE_SENTENCES,
 
   /**
     Localizes the hint if necessary.
@@ -631,7 +647,11 @@ SC.TextFieldView = SC.FieldView.extend(SC.Editable,
       }
 
       if (!SC.none(autoCapitalize)) {
-        autocapitalizeString = ' autocapitalize=' + (!autoCapitalize ? '"none"' : '"sentences"');
+        if (SC.typeOf(autoCapitalize) === 'boolean') {
+          autocapitalizeString = ' autocapitalize=' + (!autoCapitalize ? '"none"' : '"sentences"');
+        } else {
+          autocapitalizeString = ' autocapitalize=' + autoCapitalize;
+        }
       }
 
       if (!isBrowserFocusable) {
@@ -738,7 +758,11 @@ SC.TextFieldView = SC.FieldView.extend(SC.Editable,
       }
 
       if (!SC.none(autoCapitalize)) {
-        input.attr('autocapitalize', !autoCapitalize ? 'none' : 'sentences');
+        if (SC.typeOf(autoCapitalize) == 'boolean') {
+          input.attr('autocapitalize', !autoCapitalize ? 'none' : 'sentences');
+        } else {
+          input.attr('autocapitalize', autoCapitalize);
+        }
       } else {
         input.attr('autocapitalize', null);
       }


### PR DESCRIPTION
Change 'autoCapitalize' property of TextFieldView to accept a variety of
constants instead of a boolean, so that autocapitalization of words and
characters can be used. Backwards-compatibility with boolean values is
retained.

This was originally part of #1021 and adapted from comments there by @dcporter.
