### PR TITLE
Fix failing unit test: sproutcore/ajax/en/current/tests/system/request.html

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rvm:
   - 1.9.3
 
 env:
-  - IP=127.0.0.1 PORT=4020 VERBOSE=false PASTEBIN=true
+  - IP=127.0.0.1 PORT=4020 VERBOSE=false PASTEBIN=
 
 install: true
 
@@ -12,7 +12,7 @@ before_script:
   - ./scripts/run_sc_server_master.sh
   - sleep 5 # give sc-server some time to start
 
-script: phantomjs tests/phantomjs_runner.phantomjs request
+script: phantomjs tests/phantomjs_runner.phantomjs
 
 after_script:
   - "test -z \"${PASTEBIN}\" || echo \"Sharing failures summaries on pastebin for 1 hour...\""

--- a/frameworks/ajax/tests/system/request.js
+++ b/frameworks/ajax/tests/system/request.js
@@ -388,6 +388,7 @@ test("Test Multiple listeners per single status response", function() {
     if (numResponses === 2) { window.start(); }
   }, ((test_timeout*5) - 500) );
 
+  // phantomjs (used in integration tests) needs a veeeery long timeout, just for this test
   stop(test_timeout*5); // stops the test runner - wait for response
 
   response = request.send();

--- a/tests/phantomjs_runner.phantomjs
+++ b/tests/phantomjs_runner.phantomjs
@@ -30,16 +30,6 @@ var travis=env['TRAVIS_JOB_ID']?env['TRAVIS_JOB_ID']:false,
     host=env['IP']?env['IP']:"127.0.0.1",
     filter=(args.length === 2 ? new RegExp(args[1]) : false);
 
-if(!travis && verbose) {
-  page.onError = function(err, stack) {
-    console.log("CONSOLE ERROR: "+err);
-  };
-
-  page.onConsoleMessage = function(msg, lineNum, sourceId) {
-    console.log('CONSOLE: ' + msg);
-  };
-}
-
 var urls=[
     {url:'sproutcore/core_foundation/en/current/tests/views/pane/layout.html'},
     {url:'sproutcore/core_foundation/en/current/tests/views/pane/sendEvent.html'},
@@ -513,6 +503,19 @@ var outcome=0;
 var failed=0;
 var webpage = require('webpage');
 
+function configure(page) {
+    if(!travis && verbose) {
+      page.onError = function(err, stack) {
+        console.log("CONSOLE ERROR: "+err);
+      };
+    
+      page.onConsoleMessage = function(msg, lineNum, sourceId) {
+        console.log('CONSOLE: ' + msg);
+      };
+    }
+    return page;
+}
+
 function logResult(r,i) {
     // output coloring
     var red, blue, reset;
@@ -534,7 +537,7 @@ function runTest(idx, cb) {
     if (!filter || url.match(filter)) {
         run++;
         var page = webpage.create();
-        page.viewportSize = { width: 1024, height: 768 };
+        configure(page).viewportSize = { width: 1024, height: 768 };
         // Chrome/Linux
         //page.settings.userAgent = "Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.71 Safari/537.36";
         page.open('http://'+host+':'+port+'/'+url, function (status) {


### PR DESCRIPTION
This pr includes the fix for the above unit test (which basically boils down to allowing a longer timeout for the test that was failing: Test Multiple listeners per single status response) and an improvement to the travis-ci script which implements a functionality by which the html of failed tests is pushed to pastebin for post-mortem inspection.

To turn pastebin upload on set the PASTEBIN env var to any not blank value.
Note: there is a limit on the number of pastes that may be created in 24h by the same ip address. Be a good netizen and turn this this functionality on only when enecessary!
