### PR TITLE
Add support for text field autocompletion

### DIFF
--- a/frameworks/foundation/tests/views/text_field/methods.js
+++ b/frameworks/foundation/tests/views/text_field/methods.js
@@ -197,6 +197,30 @@ test("autoCorrect=null should not add autocorrect", function() {
   ok(!view.$input().attr('autocorrect'), 'should not have an autocorrect attribute set');
 });
 
+test("autoComplete=YES should add autocomplete='on'", function() {
+  SC.RunLoop.begin();
+  view.set('autoComplete', YES);
+  view.displayDidChange();
+  SC.RunLoop.end();
+  ok(view.$input().attr('autocomplete') === "on", 'should have an autocomplete attribute set to "on"');
+});
+
+test("autoComplete=NO should add autocomplete='off'", function() {
+  SC.RunLoop.begin();
+  view.set('autoComplete', NO);
+  view.displayDidChange();
+  SC.RunLoop.end();
+  ok(view.$input().attr('autocomplete') === "off", 'should have an autocomplete attribute set to "off"');
+});
+
+test("autoComplete=null should not add autocomplete", function() {
+  SC.RunLoop.begin();
+  view.set('autoComplete', null);
+  view.displayDidChange();
+  SC.RunLoop.end();
+  ok(!view.$input().attr('autocomplete'), 'should not have an autocomplete attribute set');
+});
+
 /**
  SC.TextFieldView was extended to make use of interpretKeyEvents, which
  allows easy actions to be implemented based off of several key "keys".  This

--- a/frameworks/foundation/views/text_field.js
+++ b/frameworks/foundation/views/text_field.js
@@ -152,6 +152,17 @@ SC.TextFieldView = SC.FieldView.extend(SC.Editable,
   autoCapitalize: SC.CAPITALIZE_SENTENCES,
 
   /**
+    Whether the browser should automatically complete the input.
+
+    When `autoComplete` is set to `null`, the browser will use
+    the system defaults.
+
+    @type Boolean
+    @default null
+   */
+  autoComplete: null,
+
+  /**
     Localizes the hint if necessary.
 
     @field
@@ -621,8 +632,10 @@ SC.TextFieldView = SC.FieldView.extend(SC.Editable,
         isEditable = this.get('isEditable'),
         autoCorrect = this.get('autoCorrect'),
         autoCapitalize = this.get('autoCapitalize'),
+        autoComplete = this.get('autoComplete'),
         isBrowserFocusable = this.get('isBrowserFocusable'),
         spellCheckString='', autocapitalizeString='', autocorrectString='',
+        autocompleteString='',
         name, adjustmentStyle, type, hintElements, element, paddingElementStyle,
         fieldClassNames, isOldSafari, activeState, browserFocusable;
 
@@ -652,6 +665,10 @@ SC.TextFieldView = SC.FieldView.extend(SC.Editable,
         } else {
           autocapitalizeString = ' autocapitalize=' + autoCapitalize;
         }
+      }
+
+      if (!SC.none(autoComplete)) {
+        autocompleteString = ' autocomplete=' + (!autoComplete ? '"off"' : '"on"');
       }
 
       if (!isBrowserFocusable) {
@@ -714,8 +731,9 @@ SC.TextFieldView = SC.FieldView.extend(SC.Editable,
         context.push('<input aria-label="' + hint + '" class="'+fieldClassNames+'" type="'+ type+
                       '" name="'+ name + '" '+ activeState + ' value="'+ value + '"' +
                       hintString + spellCheckString+ browserFocusable +
-                      ' maxlength="'+ maxLength+ '" '+autocorrectString+' ' +
-                      autocapitalizeString+'/></div>') ;
+                      ' maxlength="'+ maxLength+ '" ' + autocorrectString+' ' +
+                      autocapitalizeString+ ' ' + autocompleteString +
+                      '/></div>') ;
       }
     }
     else {
@@ -765,6 +783,12 @@ SC.TextFieldView = SC.FieldView.extend(SC.Editable,
         }
       } else {
         input.attr('autocapitalize', null);
+      }
+
+      if (!SC.none(autoComplete)) {
+        input.attr('autoComplete', !autoComplete ? 'off' : 'on');
+      } else {
+        input.attr('autoComplete', null);
       }
 
       if (!hintOnFocus && SC.platform.input.placeholder) input.attr('placeholder', hint);


### PR DESCRIPTION
Adds an 'autoComplete' attribute to TextFieldView. Set to YES or NO to
enable or disable autocompletion. If set to 'null', the browser uses system
defaults. The default value is 'null' so that backward compatibility is
maintained.
