### PR TITLE
Fixes issue with transforms on bindings being placed on parent binding.

### DIFF
--- a/frameworks/runtime/system/binding.js
+++ b/frameworks/runtime/system/binding.js
@@ -821,7 +821,7 @@ SC.Binding = /** @scope SC.Binding.prototype */{
     var t = binding._transforms;
 
     // clone the transform array if this comes from the parent
-    if (t && (t === binding.parentBinding._transform)) {
+    if (t && (t === binding.parentBinding._transforms)) {
       t = binding._transforms = t.slice();
     }
 

--- a/frameworks/runtime/tests/system/binding.js
+++ b/frameworks/runtime/tests/system/binding.js
@@ -305,6 +305,25 @@ test("Binding with transforms, function to check the type of value", function ()
   equals(jon.get("value1"), bon2.get("val1"));
 });
 
+test("Adding transform does not affect parent binding", function () {
+  var A,
+      a,
+      b;
+
+  A = SC.Object.extend({
+    isEnabledBindingDefault: SC.Binding.oneWay().bool()
+  });
+
+  b = SC.Object.create({
+    isEnabled: YES
+  });
+
+  a = A.create();
+  a.bind('isEnabled', b, 'isEnabled').not();
+
+  ok(A.prototype.isEnabledBindingDefault._transforms !== a.bindings[0]._transforms, "transforms array not shared with parent binding");
+});
+
 test("two bindings to the same value should sync in the order they are initialized", function () {
 
   SC.LOG_BINDINGS = YES;


### PR DESCRIPTION
The check that clones the parent binding's _transforms array had a typo, so any new transforms added to the binding would be shared in the parent's _transforms array.
