### PR TITLE
Adds test showing an issue when changing nowShowing during a transition

### DIFF
--- a/frameworks/foundation/tests/views/container/transition_test.js
+++ b/frameworks/foundation/tests/views/container/transition_test.js
@@ -75,6 +75,30 @@ test("Test that the isTransitioning property of container view updates according
   }, 1000);
 });
 
+test("Test changing nowShowing while the container is already transitioning.", function () {
+  // Pause the test execution.
+  window.stop(2000);
+
+  SC.run(function () {
+    containerView.set('transitionSwap', SC.ContainerView.PUSH);
+    containerView.set('nowShowing', view2);
+  });
+
+  setTimeout(function () {
+    containerView.set('nowShowing', view1);
+  }, 100);
+
+  setTimeout(function () {
+    containerView.set('nowShowing', view2);
+  }, 100);
+
+  setTimeout(function () {
+    ok(!containerView.get('isTransitioning'), "Container view should not indicate that it is transitioning.");
+
+    window.start();
+  }, 1500);
+});
+
 test("Test that the container view calls the proper transition plugin methods.", function () {
   var willBuildInToViewCalled = 0,
     buildInToViewCalled = 0,


### PR DESCRIPTION
This PR adds a test to show an issue that I'm having in my app when changing nowShowing twice while the container is still transitioning.

If you run the test with the console open, you will see this error: `Uncaught Error: SC.ContainerView:sc370.removeChild(View 1) must belong to parent` which is the same error that I have in my app.
