### PR TITLE
Refactors SC.SceneView to match the new SC.ContainerView

### DIFF
--- a/frameworks/desktop/views/scene.js
+++ b/frameworks/desktop/views/scene.js
@@ -7,201 +7,99 @@
 
 /** @class
 
-  This view was significantly more limited than what can be achieved
-  using the new transition plugins in SproutCore 1.10.  Please use the
-  `transition` property in SC.ContainerView for animating between
-  views.
-
+  Displays several views as scenes that can slide on and off the screen.  The
+  scene view is a nice way to provide a simple effect of moving from a 
+  higher level screen to a more detailed level screen.  You will be able to
+  optionally choose the kind of animation used to transition the two scenes 
+  as well if supported on the web browser.
+  
+  # Using SC.SceneView
+  
+  To setup the scene view, you should define the 'scenes' property with an 
+  array of scene names.  These will be the properties on the scene view that
+  you can shift in an out of view as needed.  You can edit the scenes property
+  at any time.  It will only be used when you start to transition from one
+  scene to another.
+  
+  Next you should set your nowShowing property to the name of the scene you 
+  would like to display.  This will cause the view to transition scenes if it
+  is visible on screen.  Otherwise, it will simply make the new scene view 
+  the current content view and that's it.
+  
   @extends SC.ContainerView
-  @deprecated Version 1.10
-  @see SC.ContainerView#transition
   @since Version 1.0
 */
 SC.SceneView = SC.ContainerView.extend(
 /** @scope SC.SceneView.prototype */ {
 
-  //@if(debug)
-  init: function () {
-    sc_super();
-
-    SC.warn("Developer Warning: SC.SceneView has been deprecated.  Please use the transition property of SC.ContainerView for animated view swapping.");
-  },
-  //@endif
-
   /**
     Array of scene names.  Scenes will slide on and off screen in the order
     that you specify them here.  That is, if you shift from a scene at index
-    2 to a scene at index 1, the scenes will animation backwards.  If you
+    2 to a scene at index 1, the scenes will animate backwards.  If you
     shift to a scene at index 3, the scenes will animate forwards.
 
     @type Array
-    @default ['master', 'detail']
-  */
-  scenes: ['master', 'detail'],
-
-  /**
-    The currently showing scene.  Changing this property will cause the
-    scene view to transition to the new scene.  If you set this property to
-    null, an empty string, or a non-existent scene, then the scene will appear
-    empty.
-
-    @type String
     @default null
   */
-  nowShowing: null,
+  scenes: null,
 
   /**
-    Speed of transition.  Should be expressed in msec.
+    The transitionSwap plugin to use when animating backwards.
 
-    @type Number
-    @default 200
+    @type Object (SC.SwapTransitionProtocol)
+    @default null
+    @see SC.ContainerView#transitionSwap
   */
-  transitionDuration: 200,
+  transitionBackward: SC.ContainerView.PUSH,
 
-  /** @private */
-  _state: 'NO_VIEW', // no view
+  /**
+    The options for the given transitionSwap plugin when animating backwards.
+
+    @type Object
+    @default { duration: .25, direction: 'left' }
+    @see SC.ContainerView#transitionBackwardOptions
+  */
+  transitionBackwardOptions: { duration: .25, direction: 'left' },
+
+  /**
+    The transitionSwap plugin to use when animating forwards.
+
+    @type Object (SC.SwapTransitionProtocol)
+    @default null
+    @see SC.ContainerView#transitionSwap
+  */
+  transitionForward: SC.ContainerView.PUSH,
+
+  /**
+    The options for the given transitionSwap plugin when animating forwards.
+
+    @type Object
+    @default { duration: .25, direction: 'right' }
+    @see SC.ContainerView#transitionBackwardOptions
+  */
+  transitionForwardOptions: { duration: .25, direction: 'right' },
 
   /** @private
-    Whenever called to change the content, save the nowShowing state and
-    then animate in by adjusting the layout.
+    @param {SC.View} newContent the new content view or null.
+    @see SC.ContainerView#replaceContent
   */
-  replaceContent: function(content) {
-    if (content && this._state===this.READY) this.animateScene(content);
-    else this.replaceScene(content);
-    return this ;
-  },
+  replaceContent: function(newContent) {
+    var scenes = this.get('scenes'),
+        nowShowing = this.get('nowShowing'),
+        outIdx = scenes ? scenes.indexOf(this._lastNowShowingView) : -1,
+        inIdx = scenes ? scenes.indexOf(nowShowing) : -1;
 
-  /** @private
-    Invoked whenever we just need to swap the scenes without playing an
-    animation.
-  */
-  replaceScene: function(newContent) {
-    var oldContent = this._targetView,
-        layout     = this.STANDARD_LAYOUT,
-        scenes     = this.get('scenes'),
-        idx        = scenes ? scenes.indexOf(this.get('nowShowing')) : -1;
+    this._lastNowShowingView = nowShowing;
 
-    // cleanup animation here too..
-    this._targetView = newContent ;
-    this._targetIndex  = idx;
-
-    if (this._timer) this._timer.invalidate();
-    this._leftView = this._rightView = this._start = this._end = null;
-    this._timer = null;
-
-
-    this.removeAllChildren();
-
-    if (oldContent) oldContent.set('layout', layout);
-    if (newContent) newContent.set('layout', layout);
-
-    if (newContent) this.appendChild(newContent);
-    this._state = newContent ? this.READY : this.NO_VIEW ;
-  },
-
-  /** @private
-    Invoked whenever we need to animate in the new scene.
-  */
-  animateScene: function(newContent) {
-    var oldContent = this._targetView,
-        outIdx     = this._targetIndex,
-        scenes     = this.get('scenes'),
-        inIdx      = scenes ? scenes.indexOf(this.get('nowShowing')) : -1,
-        layout;
-
-    if (outIdx<0 || inIdx<0 || outIdx===inIdx) {
-      return this.replaceScene(newContent);
-    }
-
-    this._targetView = newContent ;
-    this._targetIndex = inIdx;
-
-    // save some info needed for animation
-    if (inIdx > outIdx) {
-      this._leftView  = oldContent;
-      this._rightView = newContent;
-      this._target    = -1;
+    if (outIdx < inIdx) {
+      this.transitionSwap = this.transitionForward;
+      this.transitionSwapOptions = this.transitionForwardOptions;
     } else {
-      this._leftView  = newContent ;
-      this._rightView = oldContent ;
-      this._target    = 1 ;
+      this.transitionSwap = this.transitionBackward;
+      this.transitionSwapOptions = this.transitionBackwardOptions;
     }
 
-    // setup views
-    this.removeAllChildren();
-
-    if (oldContent) this.appendChild(oldContent)
-    if (newContent) this.appendChild(newContent);
-
-    // setup other general state
-    this._start   = Date.now();
-    this._end     = this._start + this.get('transitionDuration');
-    this._state   = this.ANIMATING;
-    this.tick();
+    sc_super();
   },
-
-  /** @private
-    Called while the animation runs.  Compute the new layout for
-    the left and right views based on the portion completed.  When we finish
-    call replaceScene().
-  */
-  tick: function() {
-    this._timer = null ; // clear out
-
-    var now    = Date.now(),
-        pct    = (now-this._start)/(this._end-this._start),
-        target = this._target,
-        left   = this._leftView,
-        right  = this._rightView,
-        layout, adjust;
-
-    if (pct<0) pct = 0;
-
-    // if we're done or the view is no longer visible, just replace the
-    // scene.
-    if (!this.get('isVisibleInWindow') || (pct>=1)) {
-      return this.replaceScene(this._targetView);
-    }
-
-    // ok, now let's compute the new layouts for the two views and set them
-    layout = SC.clone(this.get('frame'));
-    adjust = Math.floor(layout.width * pct);
-
-    // set the layout for the views, depending on the direction
-    if (target>0) {
-      layout.left = 0-(layout.width-adjust);
-      left.set('layout', layout);
-
-      layout = SC.clone(layout);
-      layout.left = adjust ;
-      right.set('layout', layout);
-
-    } else {
-      layout.left = 0-adjust ;
-      left.set('layout', layout);
-
-      layout = SC.clone(layout);
-      layout.left = layout.width-adjust;
-      right.set('layout', layout);
-    }
-
-    this._timer = this.invokeLater(this.tick, 20);
-    return this;
-  },
-
-
-  /** @private */
-  NO_VIEW: 'NO_VIEW',
-
-  /** @private */
-  ANIMATING: 'ANIMATING',
-
-  /** @private */
-  READY: 'READY',
-
-  /** @private
-    Standard layout assigned to views at rest
-  */
-  STANDARD_LAYOUT: { top: 0, left: 0, bottom: 0, right: 0 }
 
 });


### PR DESCRIPTION
See this issue https://github.com/sproutcore/sproutcore/issues/1078 for more details about this.

Basically you can define two different transition plugins and transition options depending on if the animation is backwards or forwards.

I've took back the description of `SC.SceneView` before it were deprecated but I think it needs an update. If a native english speaker could do it, it would be better.

Note that it works like expected when using 'right' and 'left' directions but it doesn't when using 'top' and 'bottom'. I guess this is because of an issue with `SC.ContainerView` or something else.
