### PR TITLE
Fixes #1087 issue with triggering & canceling animation in same runloop.

### DIFF
--- a/frameworks/core_foundation/views/view/animation.js
+++ b/frameworks/core_foundation/views/view/animation.js
@@ -466,6 +466,7 @@ SC.View.reopen(
       layout = this.get('liveAdjustments');
       break;
     default:
+      layout = this._animateLayout;
     }
 
     // Immediately remove the pending animations while calling the callbacks.
@@ -504,6 +505,7 @@ SC.View.reopen(
     delete this._prevLayout;
     delete this._activeAnimations;
     delete this._pendingAnimations;
+    delete this._animateLayout;
 
     return this;
   },


### PR DESCRIPTION
The problem was that cancelAnimation relies on the invokeLast'd _animate to set the view to its planned final layout. This means that if any further changes are made in the same runloop, before the invokeLast(_animate) call runs, the planned final layout will override them.

This fix moves the pertinent adjustment from _animate up in time to run within cancelAnimation rather than later.
