### PR TITLE
Fix phantomjs files being included in builds.

### DIFF
--- a/Buildfile
+++ b/Buildfile
@@ -48,7 +48,9 @@ config :designer,        :required => [:runtime, :foundation, :desktop, :templat
 config :"experimental/split_view", :test_required => [:desktop]
 
 # WRAPPER FRAMEWORKS
-config :sproutcore, :required => [:desktop, :datastore, :statechart]
+config :sproutcore,
+  :required => [:desktop, :datastore, :statechart],
+  :exclude => ['phantomjs']
 
 config :qunit, :required => []
 config :testing, :required => [:jquery], :test_required => [], :debug_required => []

--- a/phantomjs/minimist.js
+++ b/phantomjs/minimist.js
@@ -1,8 +1,3 @@
-// Mark this file as a resource so that it is not included in the built framework code.
-if (typeof sc_resource === 'function') {
-    sc_resource('phantomjs/minimist.js');
-}
-
 module.exports = function (args, opts) {
     if (!opts) opts = {};
 

--- a/phantomjs/q.js
+++ b/phantomjs/q.js
@@ -1,8 +1,3 @@
-// Mark this file as a resource so that it is not included in the built framework code.
-if (typeof sc_resource === 'function') {
-    sc_resource('phantomjs/q.js');
-}
-
 // vim:ts=4:sts=4:sw=4:
 /*!
  *

--- a/phantomjs/test_runner.js
+++ b/phantomjs/test_runner.js
@@ -1,8 +1,3 @@
-// Mark this file as a resource so that it is not included in the built framework code.
-if (typeof sc_resource === 'function') {
-  sc_resource('phantomjs/test_runner.js');
-}
-
  /**
   PhantomJS Unit Test Runner
 


### PR DESCRIPTION
Uses the new :exclude option in Abbot to exclude the phantomjs test runner
files from any builds.

This requires https://github.com/sproutcore/abbot/pull/101 to be pulled in before it will work.
