### PR TITLE
Moves SC.View#animate's adjust-on-zero-duration call to the next runloop

### DIFF
--- a/frameworks/core_foundation/views/view/animation.js
+++ b/frameworks/core_foundation/views/view/animation.js
@@ -291,8 +291,10 @@ SC.View.reopen(
 
     // In the case of zero duration, just adjust and call the callback.
     if (options.duration === 0) {
-      this.adjust(hash);
-      this.runAnimationCallback(options, null, NO);
+      this.invokeNext(function() {
+        this.adjust(hash);
+        this.runAnimationCallback(options, null, NO);
+      });
       return this;
     }
 


### PR DESCRIPTION
All animations begin after the end of the current runloop; zero-duration animations should be no different, even if we're using the underlying adjust code instead.
