### PR TITLE
Fix the SelectView to render correctly when the items collection is replaced or the content changes

### DIFF
--- a/frameworks/desktop/tests/views/select/methods.js
+++ b/frameworks/desktop/tests/views/select/methods.js
@@ -121,7 +121,11 @@ test("Check if setting a value actually changes the selection value", function()
 
 //test10
 test('Setting the view\'s items should not result in an error.', function() {
-  try { view1.set('items', null); }
+  try {
+    SC.RunLoop.begin() ;
+    view1.set('items', null);
+    SC.RunLoop.end() ;
+  }
   catch (e) {
     ok(false, 'Nulling out items should not throw an error.');
   }
@@ -142,3 +146,13 @@ test("The properties for select button should take the specified values", functi
   equals(prop1,'custom-menu-item','Custom view class name should be custom-menu-item');
   equals(prop2,46,'Custom view menu off set width should be 46');
 });
+
+test("The content of the popup should be recalculated correctly when the list of items changes", function() {
+  equals(view3.get("_itemList")[2].title, "World", "The list should have on the 3rd position the title World");
+  SC.RunLoop.begin() ;
+  view4.get('items').insertAt( 0, { title: "Moving", pos: 0 } ) ;
+  view3.set('items', ["It", "Works", "Again"] );
+  SC.RunLoop.end() ;
+  equals(view4.get("_itemList")[0].title, "Moving", "The list should start with new item Moving");
+  equals(view3.get("_itemList")[2].title, "Again", "The list should have on the 3rd position the title Again");
+})

--- a/frameworks/desktop/views/select.js
+++ b/frameworks/desktop/views/select.js
@@ -334,6 +334,16 @@ SC.SelectView = SC.ButtonView.extend(
   supportFocusRing: YES,
 
   /**
+  * @private
+  * Overwritten to calculate the content corresponding to items configured at creation
+  */
+  init: function() {
+    sc_super();
+
+    this.itemsDidChange();
+  },
+
+  /**
     Left Alignment based on the size of the button
 
     @private
@@ -376,11 +386,11 @@ SC.SelectView = SC.ButtonView.extend(
   },
 
   /**
-    render method
+    Observer called whenever the items collection or an element of this collection changes
 
     @private
   */
-  render: function (context,firstTime) {
+  itemsDidChange: function() {
 
     var escapeHTML, items, len, nameKey, iconKey, valueKey, separatorKey, showCheckbox,
         currentSelectedVal, shouldLocalize, isSeparator, itemList, isChecked,
@@ -544,27 +554,19 @@ SC.SelectView = SC.ButtonView.extend(
       this.set('_itemList', itemList);
     }, this );
 
-    if (firstTime) {
-      this.invokeLast(function () {
-        var value = this.get('value');
-        if (SC.none(value)) {
-          if (SC.none(emptyName)) {
-            this.set('value', this._defaultVal);
-            this.set('title', this._defaultTitle);
-            this.set('icon', this._defaultIcon);
-          }
-          else this.set('title', emptyName);
-        }
-      });
+    var value = this.get('value');
+    if (SC.none(value)) {
+      if (SC.none(emptyName)) {
+        this.set('value', this._defaultVal);
+        this.set('title', this._defaultTitle);
+        this.set('icon', this._defaultIcon);
+      }
+      else this.set('title', emptyName);
     }
 
     //Set the preference matrix for the menu pane
-    this.changeSelectPreferMatrix(this.get("_itemIdx"));
-
-    // If we're going to do such a stupid render function where we set properties
-    // on ourself, then we should use those properties in this pass.
-    sc_super();
-  },
+    this.changeSelectPreferMatrix();
+  }.observes( '*items.[]' ),
 
   /**
     @private


### PR DESCRIPTION
The SC.SelectView was not rendered correctly when the items collection was replaced or had the content changed (for example bound to a query result). This simple pull request adds an observer on the "items" collection to calculate correctly the content of the menu pane.
Pull request includes a test cases. Fixed also a developer warning into another test case.
