### PR TITLE
Resets the click count if another button is pressed

### DIFF
--- a/frameworks/core_foundation/system/root_responder.js
+++ b/frameworks/core_foundation/system/root_responder.js
@@ -1780,9 +1780,9 @@ SC.RootResponder = SC.Object.extend(
 
     // First, save the click count. The click count resets if the mouse down
     // event occurs more than 250 ms later than the mouse up event or more
-    // than 8 pixels away from the mouse down event.
+    // than 8 pixels away from the mouse down event or if the button used is different.
     this._clickCount += 1;
-    if (!this._lastMouseUpAt || ((Date.now() - this._lastMouseUpAt) > 250)) {
+    if (!this._lastMouseUpAt || this._lastClickWhich !== evt.which || ((Date.now() - this._lastMouseUpAt) > 250)) {
       this._clickCount = 1;
     } else {
       var deltaX = this._lastMouseDownX - evt.clientX,
@@ -1793,6 +1793,7 @@ SC.RootResponder = SC.Object.extend(
     }
     evt.clickCount = this._clickCount;
 
+    this._lastClickWhich = evt.which;
     this._lastMouseDownX = evt.clientX;
     this._lastMouseDownY = evt.clientY;
 


### PR DESCRIPTION
I have a use case in my app where a right click open a contextual menu and a double click open a pane. If I do a click to select the item and quickly after a right click to open the contextual menu, the pane is also open.

I could have fix this in my app, but it seems to me that it's rather an SC issue. So this fix simply reset the click count if we click with a different button.
