### PR TITLE
Adds some SC.RunLoop begin & end to avoid developer warnings

### DIFF
--- a/frameworks/desktop/tests/panes/menu/ui.js
+++ b/frameworks/desktop/tests/panes/menu/ui.js
@@ -30,6 +30,7 @@ var menu;
 
 module('SC.MenuPane UI', {
   setup: function () {
+    SC.RunLoop.begin();
     menu = SC.MenuPane.create({
       layout: { width: 206 },
 
@@ -50,10 +51,13 @@ module('SC.MenuPane UI', {
     };
 
     menu.set('items', items);
+    SC.RunLoop.end();
   },
 
   teardown: function () {
+    SC.RunLoop.begin();
     menu.destroy();
+    SC.RunLoop.end();
     menu = null;
   }
 });
@@ -118,7 +122,9 @@ function keyPressOn(view, keyCode, isKeyPress, shiftKey, ctrlKey) {
 }
 
 test('Basic UI', function () {
+  SC.RunLoop.begin();
   menu.popup();
+  SC.RunLoop.end();
   ok(menu.$().hasClass('sc-menu'), 'pane should have "sc-menu" class');
   ok(menu.$().hasClass('sc-regular-size'), 'pane should have default control size class');
   ok(!menu.get('isSubMenu'), 'isSubMenu should be NO on menus that are not submenus');
@@ -133,7 +139,9 @@ test('Basic UI', function () {
     equals(selectedItem ? selectedItem.title : null, menuItem.get('content').title, 'selectedItem should be set to the content item that was clicked');
     equals(1, menu._selectedItemCount, 'selectedItem should only change once when a menu item is clicked');
     equals(1, menu._actionCount, 'action is fired once when menu item is clicked');
+    SC.RunLoop.begin();
     menu.remove();
+    SC.RunLoop.end();
     ok(!menu.get('isVisibleInWindow'), 'menu should not be visible after being removed');
     equals(menu.get('currentMenuItem'), null, 'currentMenuItem should be null after being removed');
     start();
@@ -141,6 +149,7 @@ test('Basic UI', function () {
 });
 
 test('Control size', function () {
+  SC.RunLoop.begin();
   var smallPane, largePane, views, items = [
     { title: 'Can I get get get' },
     { title: 'To know know know know', isSeparator: YES },
@@ -172,24 +181,30 @@ test('Control size', function () {
   equals(views[1].get('frame').height, large_constants.itemSeparatorHeight, 'should change itemSeparatorHeight');
   equals(views[0].get('frame').y, large_constants.menuHeightPadding/2, 'should change menuHeightPadding');
   largePane.remove();
+  SC.RunLoop.end();
 });
 
 test('Legacy Function Support', function (){
+  SC.RunLoop.begin();
   menu.popup();
   var menuItem = menu.get('menuItemViews')[1], selectedItem;
   menuItem.mouseEntered();
+  SC.RunLoop.end();
   clickOn(menuItem, NO, NO);
   stop();
 
   setTimeout(function () {
     selectedItem = menu.get('selectedItem');
     equals(1, menu._functionActionCount, 'Function should be called if it is set as the action and the menu item is clicked');
+    SC.RunLoop.begin();
     menu.remove();
+    SC.RunLoop.end();
     start();
   }, 250);
 });
 
 test('Custom MenuItemView Class', function () {
+  SC.RunLoop.begin();
   equals(menu.get('exampleView'), SC.MenuItemView, 'SC.MenuPane should generate SC.MenuItemViews by default');
   var menu2 = SC.MenuPane.create({
     exampleView: SC.MenuItemView.extend({
@@ -201,18 +216,22 @@ test('Custom MenuItemView Class', function () {
   menu2.popup();
   ok(menu2.$('.custom-menu-item').length > 0, 'SC.MenuPane should generate instances of custom classes if exampleView is changed');
   menu2.remove();
+  SC.RunLoop.end();
 });
 
 
 test('Custom MenuItemView Class on an item using itemExampleViewKey', function () {
+  SC.RunLoop.begin();
   equals(menu.get('exampleView'), SC.MenuItemView, 'SC.MenuPane should generate SC.MenuItemViews by default');
   menu.popup();
   ok(menu.$('.custom-menu-item').length === 1, 'SC.MenuPane should generate one instance of a custom class if the item has an exampleView property');
   ok($($('.sc-menu-item')[11]).hasClass('custom-menu-item'), 'The last menu item should have a custom class');
   menu.remove();
+  SC.RunLoop.end();
 });
 
 test('Basic Submenus', function () {
+  SC.RunLoop.begin();
   var smallMenu = SC.MenuPane.create({
     controlSize: SC.SMALL_CONTROL_SIZE,
     items: items
@@ -220,7 +239,7 @@ test('Basic Submenus', function () {
   var menuItem = smallMenu.get('menuItemViews')[8], subMenu;
   smallMenu.popup();
   menuItem.mouseEntered();
-  SC.RunLoop.begin().end();
+  SC.RunLoop.end();
   ok(menuItem.get('hasSubMenu'), 'precond - menu item has a submenu');
   subMenu = menuItem.get('subMenu');
   ok(!subMenu.get('isVisibleInWindow'), 'submenus should not open immediately');
@@ -229,13 +248,16 @@ test('Basic Submenus', function () {
     ok(subMenu.get('isVisibleInWindow'), 'submenu should open after 100ms delay');
     ok(subMenu.get('isSubMenu'), 'isSubMenu should be YES on submenus');
     ok(subMenu.get('controlSize'), SC.SMALL_CONTROL_SIZE, "submenu should inherit parent's controlSize");
+    SC.RunLoop.begin();
     smallMenu.remove();
+    SC.RunLoop.end();
     ok(!subMenu.get('isVisibleInWindow'), 'submenus should close if their parent menu is closed');
     start();
   }, 150);
 });
 
 test('Menu Item Localization', function () {
+  SC.RunLoop.begin();
   ok(menu.get('localize'), 'menu panes should be localized by default');
   var locMenu, items;
 
@@ -258,15 +280,18 @@ test('Menu Item Localization', function () {
   locMenu.popup();
   equals('LOCALIZED TEXT', locMenu.$('.sc-menu-item .value').text(), 'Menu item titles should be localized if localize is YES');
   locMenu.remove();
+  SC.RunLoop.end();
 });
 
 test('Automatic Closing', function () {
+  SC.RunLoop.begin();
   menu.popup();
   ok(menu.get('isVisibleInWindow'), 'precond - window should be visible');
   menu.windowSizeDidChange();
   ok(!menu.get('isVisibleInWindow'), 'menu should close if window resizes');
 
   menu.popup();
+  SC.RunLoop.end();
   clickOn(menu);
   ok(!menu.get('isVisibleInWindow'), 'menu should close if anywhere other than a menu item is clicked');
 });
@@ -294,7 +319,10 @@ test('keyEquivalents', function () {
 test('scrolling', function () {
   var currentMenuItem;
 
+  SC.RunLoop.begin();
   menu.popup();
+  SC.RunLoop.end();
+
   menu.set('currentMenuItem', menu.get('menuItemViews')[0]);
   currentMenuItem = menu.get('currentMenuItem');
   equals(currentMenuItem.get('title'), 'Menu Item', 'menu should begin at first item');
@@ -325,12 +353,14 @@ test('scrolling', function () {
 });
 
 test('aria-role attribute', function () {
+  SC.RunLoop.begin();
   var menuPane = SC.MenuPane.create({
     layout: { width: 200 },
     items: items,
     itemCheckboxKey: 'isChecked'
   }), menuItems,normalItem, itemWithCheckBox, separatorItem;
   menuPane.popup();
+  SC.RunLoop.end();
 
   equals(menuPane.$().attr('role'), 'menu', "menu pane should have role set");
 
@@ -346,12 +376,14 @@ test('aria-role attribute', function () {
 });
 
 test('aria-checked attribute', function () {
+  SC.RunLoop.begin();
   var menuPane = SC.MenuPane.create({
     layout: { width: 200 },
     items: items,
     itemCheckboxKey: 'isChecked'
   }),itemWithCheckBox;
   menuPane.popup();
+  SC.RunLoop.end();
 
   itemWithCheckBox = menuPane.get('menuItemViews')[1];
 


### PR DESCRIPTION
I was going to publish some unit tests to show an issue with SC.MenuPane but the issue was actually related to SC.AutoResizeMenuPane. 
While I was adding tests, I've also added some SC.RunLoop.begin(); & SC.RunLoop.end(); because the console was full of warning. So I just publish this changes here.
