### PR TITLE
Fix SC.Module loading on IE11

### DIFF
--- a/frameworks/foundation/system/module.js
+++ b/frameworks/foundation/system/module.js
@@ -337,19 +337,19 @@ SC.Module = SC.Object.create(/** @scope SC.Module */ {
       el.setAttribute('type', "text/javascript");
       el.setAttribute('src', url);
 
-      if (SC.browser.isIE) {
+      if (el.addEventListener) {
+        el.addEventListener('load', function () {
+          SC.run(function () {
+            SC.Module._moduleDidLoad(moduleName);
+          });
+        }, false);
+      } else if (el.readyState) {
         el.onreadystatechange = function () {
-          if (this.readyState == 'complete' || this.readyState == 'loaded') {
+          if (this.readyState === 'complete' || this.readyState === 'loaded') {
             SC.run(function () {
               SC.Module._moduleDidLoad(moduleName);
             });
           }
-        };
-      } else {
-        el.onload = function () {
-          SC.run(function () {
-            SC.Module._moduleDidLoad(moduleName);
-          });
         };
       }
 


### PR DESCRIPTION
IE11 removed support for onreadystatechange.
SC.Module was assuming that IE would always use onreadystatechange, so the module loaded callback would never get called on IE11.

I changed this to a feature detect to pick between using addEventListener on the load event, and onreadystatechange if supported.

Details on the recommended feature detect here: http://msdn.microsoft.com/en-us/library/ie/hh180173(v=vs.85).aspx
