### PR TITLE
Adds a new child layout plugin: SC.View.FLEX_GRID

### DIFF
--- a/frameworks/core_foundation/child_view_layouts/flex_grid_layout.js
+++ b/frameworks/core_foundation/child_view_layouts/flex_grid_layout.js
@@ -12,9 +12,9 @@ SC.mixin(SC.View,
   /**
     This child layout plugin automatically positions the view's child views in a
     grid and optionally adjusts the parent view's height and width to fit.  It
-    does this by checking the column and row index of each child view and 
-    positioning them in the grid accordingly.  By default any time that a child 
-    view's height or width changes, the view will use this plugin to re-adjust all 
+    does this by checking the column and row index of each child view and
+    positioning them in the grid accordingly.  By default any time that a child
+    view's height or width changes, the view will use this plugin to re-adjust all
     other child views and its own height and width appropriately.
 
     ## Set the position of the child views in the grid with `gridProperties`
@@ -23,6 +23,8 @@ SC.mixin(SC.View,
       - row - The index of the row where the child view will be.  Default: 0
       - columnSpan - The number of columns the view will to take up.  Default: 1
       - rowSpan - The number of rows the view will to take up.  Default: 1
+      - rowFillRatio - when the parent view is configured with a fixed dimension, children not specifying a height but specifying fillRatio will be resized to fill the unclaimed space proportionally to this ratio.
+      - columnFillRatio - when the parent view is configured with a fixed dimension, children not specifying a width but specifying fillRatio will be resized to fill the unclaimed space proportionally to this ratio.
 
     For example,
 
@@ -39,25 +41,25 @@ SC.mixin(SC.View,
           cellA: SC.View.design({
             // Actual layout will become { left: 0, width: 100, top: 0, height: 24 }
             layout: { width: 100, height: 24 },
-            gridProperties: { row: 0, column: 0 }, 
+            gridProperties: { row: 0, column: 0 },
           }),
 
           cellB: SC.View.design({
             // Actual layout will become { left: 100, width: 200, top: 0, height: 24 }
             layout: { width: 200 }, // Don't need to specify layout.height, since it is already defined in cellA
-            gridProperties: { row: 0, column: 1 },  
+            gridProperties: { row: 0, column: 1 },
           }),
 
           cellC: SC.View.design({
             // Actual layout will become { left: 0, width: 300, top: 24, height: 30 }
             layout: { height: 30 } // Don't need to specify layout.width, this is automatic when columnSpan is greater than 1.
-            gridProperties: { row: 1, column: 0, columnSpan: 2 }, 
+            gridProperties: { row: 1, column: 0, columnSpan: 2 },
           }),
 
           cellD: SC.View.design({
             // Actual layout will become { left: 300, width: 120, top: 0, height: 54 }
             layout: { width: 120 } // Don't need to specify layout.height, this is automatic when rowSpan is greater than 1.
-            gridProperties: { column: 2, rowSpan: 2, }, 
+            gridProperties: { column: 2, rowSpan: 2, },
           })
 
         });
@@ -69,7 +71,14 @@ SC.mixin(SC.View,
 
       - rowSpace - Spaces between each row.  Default: 0
       - columnSpace - Spaces between each column.  Default: 0
+      - columnCount - The maximum number of column.
+      - rowCount - The maximum number of row.
+      - defaultRowHeight - The default height of the rows.
+      - defaultColumnWidth- The default width of the columns.
       - resizeToFit - Whether to resize the view to fit the child views.  Default: true
+      - resizeWidthToFit - Whether to resize the view width to fit the child views.  Default: true
+      - resizeHeightToFit - Whether to resize the view height to fit the child views.  Default: true
+      - layoutDirection: SC.LAYOUT_VERTICAL
 
     For example,
 
@@ -91,32 +100,32 @@ SC.mixin(SC.View,
           cellA: SC.View.design({
             // Actual layout will become { left: 0, width: 100, top: 0, height: 24 }
             layout: { width: 100, height: 24 },
-            gridProperties: { row: 0, column: 0 }, 
+            gridProperties: { row: 0, column: 0 },
           }),
 
           cellB: SC.View.design({
             // Actual layout will become { left: 110, width: 200, top: 0, height: 24 }
             layout: { width: 200 }, // Don't need to specify layout.height, since it is already defined in cellA
-            gridProperties: { row: 0, column: 1 },  
+            gridProperties: { row: 0, column: 1 },
           }),
 
           cellC: SC.View.design({
             // Actual layout will become { left: 0, width: 300, top: 29, height: 30 }
             layout: { height: 30 } // Don't need to specify layout.width, this is automatic when columnSpan is greater than 1.
-            gridProperties: { row: 1, column: 0, columnSpan: 2 }, 
+            gridProperties: { row: 1, column: 0, columnSpan: 2 },
           }),
 
           cellD: SC.View.design({
             // Actual layout will become { left: 320, width: 120, top: 0, height: 54 }
             layout: { width: 120 } // Don't need to specify layout.height, this is automatic when rowSpan is greater than 1.
-            gridProperties: { column: 2, rowSpan: 2, }, 
+            gridProperties: { column: 2, rowSpan: 2, },
           })
 
         });
 
     If `resizeToFit` is set to `false`, the view will not adjust itself to fit
     its child views.  This means that when `resizeToFit` is false, the view should
-    specify its height and width component in its layout.  
+    specify its height and width component in its layout.
 
     ## Modify specific child view layouts
 
@@ -136,121 +145,321 @@ SC.mixin(SC.View,
     /** @private Properties to observe on child views that affect the overall child view layout. */
     childLayoutProperties: ['gridProperties', 'isVisible'],
 
+    /** @private When resizeToFit is false, then we need to know when the view's frame changes. */
+    layoutDependsOnSize: function (view) {
+      var options = view.get('childViewLayoutOptions');
+      if (options) {
+        var resizeToFit = resizeToFit !== false && (options.resizeHeightToFit !== false || options.resizeWidthToFit !== false);
+        if (!resizeToFit) return true;
+      }
+      return false;
+    },
+
     /** @private */
     layoutChildViews: function (view) {
       var childViews = view.get('childViews'),
         options = view.get('childViewLayoutOptions') || {},
-        resizeToFit = SC.none(options.resizeToFit) ? true : options.resizeToFit,
         rowSpace = options.rowSpace || 0,
         columnSpace = options.columnSpace || 0,
-        len = childViews.get('length'),
+        layoutDirection = options.layoutDirection || SC.LAYOUT_VERTICAL,
+        isVertical = layoutDirection === SC.LAYOUT_VERTICAL,
+        rowCount = 0,
+        columnCount = 0,
+        defaultRowHeight = options.defaultRowHeight,
+        defaultColumnWidth = options.defaultColumnWidth,
+        remainingWidth = 0,
+        remainingHeight = 0,
+        childLen = childViews.get('length'),
         columnSizes = {},
         rowSizes = {},
-        width = height = 0,
-        top = left = 0,
-        childView, i, j, index;
+        top = 0,
+        left = 0,
+        childView, i, j, k, index,
+        vFrame = view.frame(),
+        totalHeight = vFrame.height,
+        totalWidth = vFrame.width,
+        verticalFilledSpace = 0,
+        horizontalFilledSpace = 0,
 
-      for (i = 0; i < len; i++) {
+        gridProperties = view._gridProperties = {
+          options: options,
+          isVertical: isVertical,
+          cells: {}
+        },
+
+        layout,
+        chilGridProperties,
+        columnFillRatio, rowFillRatio,
+        columnSpan, rowSpan,
+        columnWidth, rowHeight,
+        columnIndex, rowIndex,
+        cij, rij;
+
+      for (i = 0; i < childLen; i++) {
         childView = childViews.objectAt(i);
 
         // Ignore child views with useAbsoluteLayout true, useStaticLayout true or that are not visible.
         if (!this._needsLayoutAdjustment(childView)) continue;
 
-        var layout = childView.get('layout'),
-          gridProperties = childView.get('gridProperties') || {},
-          column = gridProperties.column || 0,
-          row = gridProperties.row || 0,
-          columnSpan = gridProperties.columnSpan || 1,
-          rowSpan = gridProperties.rowSpan || 1;
+        layout = childView.get('layout');
+        chilGridProperties = childView.get('gridProperties') || {};
+        rowFillRatio = chilGridProperties.rowFillRatio;
+        columnFillRatio = chilGridProperties.columnFillRatio;
+        columnSpan = chilGridProperties.columnSpan || 1;
+        rowSpan = chilGridProperties.rowSpan || 1;
+        columnWidth = 0;
+        rowHeight = 0;
 
-        if (layout.width && columnSpan === 1) {
-          if (!columnSizes[column]) columnSizes[column] = {};
-          columnSizes[column].width = Math.max(columnSizes[column].width || 0, layout.width || 0);
+        rowIndex = chilGridProperties.row || 0;
+        columnIndex = chilGridProperties.column || 0;
+        var nextPos = this._computeNextAvailablePosition(view, childView, rowIndex, columnIndex);
+        rowIndex = nextPos[0];
+        columnIndex = nextPos[1];
+
+        //@if(debug)
+        if (!SC.none(gridProperties.row) && chilGridProperties.row !== rowIndex) {
+          SC.warn("Developer Warning: The SC.View.FLEX_GRID plugin could not use the specified row '%@'.".fmt(gridProperties.row));
+          return;
+        }
+        if (!SC.none(gridProperties.column) && chilGridProperties.column !== columnIndex) {
+          SC.warn("Developer Warning: The SC.View.FLEX_GRID plugin could not use the specified column '%@'.".fmt(gridProperties.column));
+          return;
+        }
+        //@endif
+
+        childView._sc_computedGridProperties = {
+          column: columnIndex,
+          row: rowIndex,
+          columnSpan: columnSpan,
+          rowSpan: rowSpan,
         }
 
-        if (layout.height && rowSpan === 1) {
-          if (!rowSizes[row]) rowSizes[row] = {};
-          rowSizes[row].height = Math.max(rowSizes[row].height || 0, layout.height || 0);
+        // Save the initial hardcoded layout
+        if (!('_sc_width' in childView)) childView._sc_width = layout.width;
+        if (!('_sc_height' in childView)) childView._sc_height = layout.height;
+
+        if (childView._sc_width) columnWidth = (childView._sc_width - ((columnSpan-1)*columnSpace)) / columnSpan;
+        for (j = 0; j < columnSpan; j++) {
+          cij = columnIndex+j;
+          if (!columnSizes[cij]) columnSizes[cij] = {};
+          columnSizes[cij].layoutWidth = Math.max(columnSizes[cij].layoutWidth || 0, columnWidth);
+          columnSizes[cij].fillRatio = Math.max(columnSizes[cij].fillRatio || 0, columnFillRatio || 0);
         }
+
+        if (childView._sc_height) rowHeight = (childView._sc_height - ((rowSpan-1)*rowSpace)) / rowSpan;
+        for (j = 0; j < rowSpan; j++) {
+          rij = rowIndex+j;
+          if (!rowSizes[rij]) rowSizes[rij] = {};
+
+          rowSizes[rij].layoutHeight = Math.max(rowSizes[rij].layoutHeight || 0, rowHeight);
+          rowSizes[rij].fillRatio = Math.max(rowSizes[rij].fillRatio || 0, rowFillRatio || 0);
+        }
+
+        for (j = 0; j < columnSpan; j++) {
+          for (k = 0; k < rowSpan; k++) {
+            gridProperties.cells[(columnIndex+j)+'x'+(rowIndex+k)] = 1;
+          }
+        }
+
+        gridProperties.columnSizes = columnSizes;
+        gridProperties.rowSizes = rowSizes;
+
+        columnCount = Math.max(columnCount, columnIndex+columnSpan);
+        rowCount = Math.max(rowCount, rowIndex+rowSpan);
       }
 
+
+      if (!defaultColumnWidth) {
+        defaultColumnWidth = Math.trunc((totalWidth-((columnCount-1)*columnSpace)) / columnCount);
+        remainingWidth = totalWidth - ((defaultColumnWidth * columnCount) + ((columnCount-1)*columnSpace));
+      }
+
+      // compute the width of column and the space remaining to fill
       for (index in columnSizes) {
+        if (!columnSizes[index].fillRatio) {
+          if (SC.none(columnSizes[index].width)) {
+            if (columnSizes[index].layoutWidth) columnSizes[index].width = columnSizes[index].layoutWidth;
+            else if (defaultColumnWidth) {
+              columnSizes[index].width = defaultColumnWidth + (index > 0 ? 0 : remainingWidth);
+            }
+          }
+          else {
+            //@if(debug)
+            SC.warn("Developer Warning: The SC.View.FLEX_GRID plugin got an unexpected width '%@'".fmt(columnSizes[index].width));
+            //@endif
+          }
+          horizontalFilledSpace += columnSizes[index].width || 0;
+        }
+      };
+
+      i = 0;
+      for (index in columnSizes) {
+        i++;
         columnSizes[index].left = left;
 
-        //@if(debug)
-        if (!columnSizes[index].width) {
-          SC.warn("Developer Warning: The SC.View.FLEX_GRID plugin requires that you set a width to one of the views in the column '%@'".fmt(index));
-          return;
+        if (columnSizes[index].fillRatio) {
+          columnSizes[index].width = (totalWidth - horizontalFilledSpace) * columnSizes[index].fillRatio;
         }
-        //@endif
 
-        left += columnSizes[index].width+columnSpace;
+        if (columnSizes[index].width) left += columnSizes[index].width+(i < columnCount ? columnSpace : 0);
       };
+
+
+      if (!defaultRowHeight) {
+        defaultRowHeight = Math.trunc((totalHeight-((rowCount-1)*rowSpace)) / rowCount);
+        remainingHeight = totalHeight - ((defaultRowHeight * rowCount) + ((rowCount-1)*rowSpace));
+      }
 
       for (index in rowSizes) {
-        rowSizes[index].top = top;
-
-        //@if(debug)
-        if (!rowSizes[index].height) {
-          SC.warn("Developer Warning: The SC.View.FLEX_GRID plugin requires that you set a width to one of the views in the row '%@'".fmt(index));
-          return;
+        if (!rowSizes[index].fillRatio) {
+          if (SC.none(rowSizes[index].height)) {
+            if (rowSizes[index].layoutHeight) rowSizes[index].height = rowSizes[index].layoutHeight;
+            else if (defaultRowHeight) rowSizes[index].height = defaultRowHeight + (index > 0 ? 0 : remainingHeight);
+          }
+          else {
+            //@if(debug)
+            SC.warn("Developer Warning: The SC.View.FLEX_GRID plugin got an unexpected height '%@'".fmt(rowSizes[index].height));
+            //@endif
+          }
+          verticalFilledSpace += rowSizes[index].height+rowSpace;
         }
-        //@endif
-
-        top += rowSizes[index].height+rowSpace;
       };
 
-      for (i = 0; i < len; i++) {
+      i = 0;
+      for (index in rowSizes) {
+        i++;
+        rowSizes[index].top = top;
+
+        if (rowSizes[index].fillRatio) {
+          rowSizes[index].height = (totalHeight - verticalFilledSpace) / rowSizes[index].fillRatio;
+        }
+        if (rowSizes[index].height) top += rowSizes[index].height+(i < rowCount ? rowSpace : 0);
+      };
+
+      for (i = 0; i < childLen; i++) {
         childView = childViews.objectAt(i);
 
         // Ignore child views with useAbsoluteLayout true, useStaticLayout true or that are not visible.
         if (!this._needsLayoutAdjustment(childView)) continue;
 
-        var gridProperties = childView.get('gridProperties') || {},
-          column = gridProperties.column || 0,
-          row = gridProperties.row || 0,
-          columnSpan = gridProperties.columnSpan || 1,
-          rowSpan = gridProperties.rowSpan || 1,
+        var chilGridProperties = childView._sc_computedGridProperties,
+          column = chilGridProperties.column,
+          row = chilGridProperties.row,
+          columnSpan = chilGridProperties.columnSpan,
+          rowSpan = chilGridProperties.rowSpan,
           columnData = columnSizes[column],
-          rowData = rowSizes[row];
-
-        width = height = 0;
-
-        //@if(debug)
-        if (!columnData) {
-          SC.warn("Developer Warning: The SC.View.FLEX_GRID plugin requires that you set a width to one of the views in the column '%@'.".fmt(column));
-          return;
-        }
-        if (!rowData) {
-          SC.warn("Developer Warning: The SC.View.FLEX_GRID plugin requires that you set a width to one of the views in the row '%@'.".fmt(row));
-          return;
-        }
-        //@endif
+          rowData = rowSizes[row],
+          width = 0,
+          height = 0;
 
         for (j = 0; j < columnSpan; j++) {
           var columnSpanData = columnSizes[column+j];
-          if (columnSpanData) width += columnSpanData.width;
+          if (columnSpanData && columnSpanData.width) width += columnSpanData.width + (j > 0 ? columnSpace : 0);
         };
 
         for (j = 0; j < rowSpan; j++) {
           var rowSpanData = rowSizes[row+j];
-          if (rowSpanData) height += rowSizes[row+j].height;
+          if (rowSpanData && rowSpanData.height) height += rowSpanData.height + (j > 0 ? rowSpace : 0);
         };
 
-        childView.adjust({ 
-          top: rowData.top, 
-          left: columnData.left, 
-          width: width, 
-          height: height 
+
+        childView.adjust({
+          top: rowData ? rowData.top : 0,
+          left: columnData ? columnData.left : 0,
+          width: width,
+          height: height
         });
       }
 
-      // Adjust our frame to fit as well, this ensures that scrolling works.
-      if (resizeToFit) {
-        width = left - columnSpace;
-        height = top - rowSpace;
-        view.adjust({ width: width, height: height });
+      if (options.resizeToFit !== false) {
+        var newLayout = {};
+        if (options.resizeWidthToFit !== false) {
+          newLayout.width = left;
+          delete view._sc_width;
+        }
+        if (options.resizeHeightToFit !== false) {
+          newLayout.height = top;
+          delete view._sc_height;
+        }
+        view.adjust(newLayout);
       }
+
+      view.viewDidResize = function() {
+        this.layoutChildViews();
+        this._sc_viewFrameDidChange();
+      };
+    },
+
+    /** @private */
+    _computeNextAvailablePosition: function(view, childView, rowIndex, columnIndex) {
+      var gridProperties = view._gridProperties,
+        cells = gridProperties.cells,
+        columnSizes = gridProperties.columnSizes,
+        rowSizes = gridProperties.rowSizes,
+        initialRowIndex = rowIndex,
+        initialColumnIndex = columnIndex;
+
+      if (columnSizes && rowSizes) {
+        var isVertical = gridProperties.isVertical,
+          options = gridProperties.options,
+          maxRowCount = options.rowCount || 0,
+          maxColumnCount = options.columnCount || 0,
+          chilGridProperties = childView.get('gridProperties') || {},
+          columnSpan = chilGridProperties.columnSpan || 1,
+          rowSpan = chilGridProperties.rowSpan || 1,
+          isTaken, i, j;
+
+        //@if(debug)
+        if (maxRowCount && maxColumnCount) {
+          SC.error("Developer Error: SC.View.FLEX_GRID plugin doesn't not support rowCount and columnCount being both defined.");
+          return;
+        }
+        //@endif
+
+        for (i = columnIndex; (i < (columnIndex+columnSpan)) && !isTaken; i++) {
+          for (j = rowIndex; (j < (rowIndex+rowSpan)) && !isTaken; j++) {
+            if (cells[i+'x'+j]) isTaken = true;
+          }
+        }
+
+        if (isTaken) {
+          if (isVertical) columnIndex++;
+          else rowIndex++;
+        }
+
+        if (maxColumnCount) {
+          //@if(debug)
+          if (columnSpan > maxColumnCount) {
+            SC.error("Developer Error: columnSpan '%@' is greater than maxColumnCount '%@'.".fmt(columnSpan, maxColumnCount));
+            return;
+          }
+          //@endif
+
+          if ((columnSpan + columnIndex) > maxColumnCount) {
+            rowIndex += 1;
+            columnIndex = 0;
+          }
+        }
+        if (maxRowCount) {
+          //@if(debug)
+          if (rowSpan > maxRowCount) {
+            SC.error("Developer Error: rowSpan '%@' is greater than maxRowCount '%@'.".fmt(rowSpan, maxRowCount));
+            return;
+          }
+          //@endif
+
+          if ((rowSpan + rowIndex) > maxRowCount) {
+            columnIndex += 1;
+            rowIndex = 0;
+          }
+        }
+      }
+
+      if (initialRowIndex !== rowIndex || initialColumnIndex !== columnIndex) {
+        return this._computeNextAvailablePosition(view, childView, rowIndex, columnIndex);
+      }
+
+      return [rowIndex, columnIndex];
     },
 
     /** @private */

--- a/frameworks/core_foundation/tests/views/view/childViewLayout_test.js
+++ b/frameworks/core_foundation/tests/views/view/childViewLayout_test.js
@@ -35,15 +35,15 @@ test("basic VERTICAL_STACK", function () {
       },
       childViews: ['sectionA', 'sectionB', 'sectionC'],
       layout: { left: 10, right: 10, top: 20 },
-      sectionA: SC.View.design({
+      sectionA: SC.View.extend({
         layout: { height: 100 }
       }),
 
-      sectionB: SC.View.design({
+      sectionB: SC.View.extend({
         layout: { border: 1, height: 50 }
       }),
 
-      sectionC: SC.View.design({
+      sectionC: SC.View.extend({
         layout: { left: 10, right: 10, height: 120 }
       })
 
@@ -69,15 +69,15 @@ test("basic HORIZONTAL_STACK", function () {
       childViews: ['sectionA', 'sectionB', 'sectionC'],
       layout: { left: 10, bottom: 20, top: 20 },
 
-      sectionA: SC.View.design({
+      sectionA: SC.View.extend({
         layout: { width: 100 }
       }),
 
-      sectionB: SC.View.design({
+      sectionB: SC.View.extend({
         layout: { border: 1, width: 50 }
       }),
 
-      sectionC: SC.View.design({
+      sectionC: SC.View.extend({
         layout: { top: 10, bottom: 10, width: 120 }
       })
     });
@@ -99,58 +99,473 @@ test("basic FLEX_GRID", function () {
         columnSpace: 10,
       },
 
-      childViews: ['cellA', 'cellB', 'cellC', 'cellD'],
-
       layout: { left: 10, top: 20 },
 
-      cellA: SC.View.design({
+      childViews: ['cellA', 'cellB', 'cellC', 'cellD'],
+
+      cellA: SC.View.extend({
         layout: { width: 100, height: 24 },
         gridProperties: { row: 0, column: 0 },
       }),
 
-      cellB: SC.View.design({
-        // Actual layout will become { left: 110, width: 200, top: 0, height: 24 }
+      cellB: SC.View.extend({
         layout: { width: 200 },
         gridProperties: { row: 0, column: 1 },
       }),
 
-      cellC: SC.View.design({
-        // Actual layout will become { left: 0, width: 300, top: 29, height: 30 }
-        layout: { height: 30 } ,
+      cellC: SC.View.extend({
+        layout: { height: 30 },
         gridProperties: { row: 1, column: 0, columnSpan: 2 },
       }),
 
-      cellD: SC.View.design({
-        // Actual layout will become { left: 320, width: 120, top: 0, height: 54 }
+      cellD: SC.View.extend({
         layout: { width: 120 },
-        gridProperties: { column: 2, rowSpan: 2, },
+        gridProperties: { row: 0, column: 2, rowSpan: 2, },
       })
 
     });
   });
 
-  equals(view.cellA.layout.left, 0, "cellA left should be 0");
-  equals(view.cellA.layout.top, 0, "cellA top should be 0");
-  equals(view.cellA.layout.width, 100, "cellA width should be 100");
-  equals(view.cellA.layout.height, 24, "cellA height should be 24");
+  equals(view.cellA.layout.left, 0, "cellA left");
+  equals(view.cellA.layout.top, 0, "cellA top");
+  equals(view.cellA.layout.width, 100, "cellA width");
+  equals(view.cellA.layout.height, 24, "cellA height");
 
-  equals(view.cellB.layout.left, 110, "cellB left should be 110");
-  equals(view.cellB.layout.top, 0, "cellB top should be 0");
-  equals(view.cellB.layout.width, 200, "cellB width should be 200");
-  equals(view.cellB.layout.height, 24, "cellB height should be 24");
+  equals(view.cellB.layout.left, 110, "cellB left");
+  equals(view.cellB.layout.top, 0, "cellB top");
+  equals(view.cellB.layout.width, 200, "cellB width");
+  equals(view.cellB.layout.height, 24, "cellB height");
 
-  equals(view.cellC.layout.left, 0, "cellC left should be 0");
-  equals(view.cellC.layout.top, 29, "cellC top should be 29");
-  equals(view.cellC.layout.width, 300, "cellC width should be 300");
-  equals(view.cellC.layout.height, 30, "cellC height should be 30");
+  equals(view.cellC.layout.left, 0, "cellC left");
+  equals(view.cellC.layout.top, 29, "cellC top");
+  equals(view.cellC.layout.width, 310, "cellC width");
+  equals(view.cellC.layout.height, 30, "cellC height");
 
-  equals(view.cellD.layout.left, 320, "cellD left should be 320");
-  equals(view.cellD.layout.top, 0, "cellD top should be 0");
-  equals(view.cellD.layout.width, 120, "cellD width should be 120");
-  equals(view.cellD.layout.height, 54, "cellD height should be 54");
+  equals(view.cellD.layout.left, 320, "cellD left");
+  equals(view.cellD.layout.top, 0, "cellD top");
+  equals(view.cellD.layout.width, 120, "cellD width");
+  equals(view.cellD.layout.height, 59, "cellD height");
 
   equals(view.layout.height, 59, "view height should be 59");
   equals(view.layout.width, 440, "view width should be 440");
+});
+
+test("FLEX_GRID - with columnCount", function () {
+  SC.run(function() {
+    view = SC.View.create({
+      childViewLayout: SC.View.FLEX_GRID,
+
+      childViewLayoutOptions: {
+        columnCount: 1,
+        rowSpace: 5
+      },
+      childViews: ['sectionA', 'sectionB', 'sectionC'],
+      layout: { left: 10, right: 10, top: 20 },
+      sectionA: SC.View.extend({
+        layout: { height: 100 }
+      }),
+
+      sectionB: SC.View.extend({
+        layout: { border: 1, height: 50 }
+      }),
+
+      sectionC: SC.View.extend({
+        layout: { left: 10, right: 10, height: 120 }
+      })
+
+    });
+  });
+
+  equals(view.sectionA.layout.top, 0, "sectionA top");
+  equals(view.sectionB.layout.top, 105, "sectionB top");
+  equals(view.sectionC.layout.top, 160, "sectionC");
+  equals(view.layout.height, 280, "view height");
+
+});
+
+test("FLEX_GRID - with span", function () {
+  SC.run(function() {
+    view = SC.View.create({
+      layout: { width: 100, height: 200 },
+      childViewLayout: SC.View.FLEX_GRID,
+
+      childViewLayoutOptions: {
+        columnCount: 3,
+        rowSpace: 10,
+        columnSpace: 5,
+        resizeToFit: false
+      },
+      childViews: ['spanTop', 'spanRight', 'spanLeft', 'cellCenter', 'spanBottom'],
+
+      spanTop: SC.View.extend({
+        gridProperties: { columnSpan: 2 }
+      }),
+
+      spanRight: SC.View.extend({
+        gridProperties: { rowSpan: 2 }
+      }),
+
+      cellCenter: SC.View,
+
+      spanLeft: SC.View.extend({
+        gridProperties: { rowSpan: 2 }
+      }),
+
+      spanBottom: SC.View.extend({
+        gridProperties: { columnSpan: 2 }
+      }),
+    });
+  });
+
+  equals(view.spanTop.layout.top, 0, "spanTop top");
+  equals(view.spanTop.layout.left, 0, "spanTop left");
+  equals(view.spanTop.layout.height, 60, "spanTop height");
+  equals(view.spanTop.layout.width, 65, "spanTop width");
+  equals(view.spanRight.layout.top, 0, "spanRight top");
+  equals(view.spanRight.layout.left, 70, "spanRight left");
+  equals(view.spanRight.layout.height, 130, "spanRight height");
+  equals(view.spanRight.layout.width, 30, "spanRight width");
+  equals(view.spanLeft.layout.top, 70, "spanLeft top");
+  equals(view.spanLeft.layout.left, 0, "spanLeft left");
+  equals(view.spanLeft.layout.height, 130, "spanLeft height");
+  equals(view.spanLeft.layout.width, 30, "spanLeft width");
+  equals(view.cellCenter.layout.top, 70, "cellCenter top");
+  equals(view.cellCenter.layout.left, 35, "cellCenter left");
+  equals(view.cellCenter.layout.height, 60, "cellCenter height");
+  equals(view.cellCenter.layout.width, 30, "cellCenter width");
+  equals(view.spanBottom.layout.top, 140, "spanBottom top");
+  equals(view.spanBottom.layout.left, 35, "spanBottom left");
+  equals(view.spanBottom.layout.height, 60, "spanBottom height");
+  equals(view.spanBottom.layout.width, 65, "spanBottom width");
+  equals(view.layout.width, 100, "view width");
+  equals(view.layout.height, 200, "view height");
+});
+
+
+
+test("FLEX_GRID - with span layout horizontal", function () {
+  SC.run(function() {
+    view = SC.View.create({
+      layout: { width: 100, height: 200 },
+      childViewLayout: SC.View.FLEX_GRID,
+
+      childViewLayoutOptions: {
+        rowCount: 3,
+        rowSpace: 10,
+        columnSpace: 5,
+        resizeToFit: false,
+        layoutDirection: SC.LAYOUT_HORIZONTAL
+      },
+      childViews: ['spanTop', 'spanLeft', 'cellCenter', 'spanRight', 'spanBottom'],
+
+      spanTop: SC.View.extend({
+        gridProperties: { columnSpan: 2 }
+      }),
+
+      spanLeft: SC.View.extend({
+        gridProperties: { rowSpan: 2 }
+      }),
+
+      cellCenter: SC.View,
+
+      spanRight: SC.View.extend({
+        gridProperties: { rowSpan: 2 }
+      }),
+
+      spanBottom: SC.View.extend({
+        gridProperties: { columnSpan: 2 }
+      }),
+    });
+  });
+
+  equals(view.spanTop.layout.top, 0, "spanTop top");
+  equals(view.spanTop.layout.left, 0, "spanTop left");
+  equals(view.spanTop.layout.height, 60, "spanTop height");
+  equals(view.spanTop.layout.width, 65, "spanTop width");
+  equals(view.spanRight.layout.top, 0, "spanRight top");
+  equals(view.spanRight.layout.left, 70, "spanRight left");
+  equals(view.spanRight.layout.height, 130, "spanRight height");
+  equals(view.spanRight.layout.width, 30, "spanRight width");
+  equals(view.spanLeft.layout.top, 70, "spanLeft top");
+  equals(view.spanLeft.layout.left, 0, "spanLeft left");
+  equals(view.spanLeft.layout.height, 130, "spanLeft height");
+  equals(view.spanLeft.layout.width, 30, "spanLeft width");
+  equals(view.cellCenter.layout.top, 70, "cellCenter top");
+  equals(view.cellCenter.layout.left, 35, "cellCenter left");
+  equals(view.cellCenter.layout.height, 60, "cellCenter height");
+  equals(view.cellCenter.layout.width, 30, "cellCenter width");
+  equals(view.spanBottom.layout.top, 140, "spanBottom top");
+  equals(view.spanBottom.layout.left, 35, "spanBottom left");
+  equals(view.spanBottom.layout.height, 60, "spanBottom height");
+  equals(view.spanBottom.layout.width, 65, "spanBottom width");
+  equals(view.layout.width, 100, "view width");
+  equals(view.layout.height, 200, "view height");
+});
+
+test("FLEX_GRID - resizeToFit and defaultRowHeight", function () {
+  SC.run(function() {
+    view = SC.View.create({
+      layout: { width: 100 },
+      childViewLayout: SC.View.FLEX_GRID,
+
+      childViewLayoutOptions: {
+        columnCount: 2,
+        rowSpace: 8,
+        columnSpace: 4,
+        defaultRowHeight: 50
+      },
+      childViews: ['c1', 'c2', 'c3'],
+
+      c1: SC.View.extend({
+        gridProperties: { rowSpan: 2 },
+        layout: { height: 100 }
+      }),
+
+      c2: SC.View.extend({
+      }),
+
+      c3: SC.View.extend({
+        gridProperties: { columnSpan: 2 }
+      }),
+    });
+  });
+
+  equals(view.c1.layout.top, 0, "c1 top");
+  equals(view.c1.layout.left, 0, "c1 left");
+  equals(view.c1.layout.height, 100, "c1 height");
+  equals(view.c1.layout.width, 48, "c1 width");
+  equals(view.c2.layout.top, 0, "c2 top");
+  equals(view.c2.layout.left, 52, "c2 left");
+  equals(view.c2.layout.height, 46, "c2 height");
+  equals(view.c2.layout.width, 48, "c2 width");
+  equals(view.c3.layout.top, 108, "c3 top");
+  equals(view.c3.layout.left, 0, "c3 left");
+  equals(view.c3.layout.height, 50, "c3 height");
+  equals(view.c3.layout.width, 100, "c3 width");
+  equals(view.layout.width, 100, "view width");
+  equals(view.layout.height, 158, "view height");
+});
+
+
+test("FLEX_GRID - resizeToFit and defaultRowHeight layout horizontal", function () {
+  SC.run(function() {
+    view = SC.View.create({
+      layout: { height: 100 },
+      childViewLayout: SC.View.FLEX_GRID,
+
+      childViewLayoutOptions: {
+        rowCount: 2,
+        columnSpace: 8,
+        rowSpace: 4,
+        defaultColumnWidth: 50,
+        layoutDirection: SC.LAYOUT_HORIZONTAL
+      },
+      childViews: ['c1', 'c2', 'c3'],
+
+      c1: SC.View.extend({
+        gridProperties: { columnSpan: 2 },
+        layout: { width: 100 }
+      }),
+
+      c2: SC.View.extend({
+      }),
+
+      c3: SC.View.extend({
+        gridProperties: { rowSpan: 2 }
+      }),
+    });
+  });
+
+  equals(view.c1.layout.top, 0, "c1 top");
+  equals(view.c1.layout.left, 0, "c1 left");
+  equals(view.c1.layout.height, 48, "c1 height");
+  equals(view.c1.layout.width, 100, "c1 width");
+  equals(view.c2.layout.top, 52, "c2 top");
+  equals(view.c2.layout.left, 0, "c2 left");
+  equals(view.c2.layout.height, 48, "c2 height");
+  equals(view.c2.layout.width, 46, "c2 width");
+  equals(view.c3.layout.top, 0, "c3 top");
+  equals(view.c3.layout.left, 108, "c3 left");
+  equals(view.c3.layout.height, 100, "c3 height");
+  equals(view.c3.layout.width, 50, "c3 width");
+  equals(view.layout.width, 158, "view width");
+  equals(view.layout.height, 100, "view height");
+});
+
+
+test("FLEX_GRID - isVisible", function () {
+  SC.run(function() {
+    view = SC.View.create({
+      childViewLayout: SC.View.FLEX_GRID,
+
+      childViewLayoutOptions: {
+        rowCount: 2,
+        columnSpace: 8,
+        rowSpace: 4,
+        defaultRowHeight: 25,
+        defaultColumnWidth: 50,
+      },
+      childViews: ['c1', 'c2', 'c3'],
+
+      c1: SC.View,
+
+      c2: SC.View.extend({
+        isVisible: false
+      }),
+
+      c3: SC.View,
+    });
+  });
+
+  equals(view.c1.layout.top, 0, "c1 top");
+  equals(view.c1.layout.left, 0, "c1 left");
+  equals(view.c1.layout.height, 25, "c1 height");
+  equals(view.c1.layout.width, 50, "c1 width");
+  equals(view.c3.layout.top, 0, "c3 top");
+  equals(view.c3.layout.left, 58, "c3 left");
+  equals(view.c3.layout.height, 25, "c3 height");
+  equals(view.c3.layout.width, 50, "c3 width");
+  equals(view.layout.width, 108, "view width");
+  equals(view.layout.height, 25, "view height");
+});
+
+test("basic HORIZONTAL_STACK", function () {
+  SC.run(function() {
+    view = SC.View.create({
+      childViewLayout: SC.View.HORIZONTAL_STACK,
+      childViewLayoutOptions: {
+        paddingBefore: 10,
+        paddingAfter: 20,
+        spacing: 5
+      },
+      childViews: ['sectionA', 'sectionB', 'sectionC'],
+      layout: { left: 10, bottom: 20, top: 20 },
+
+      sectionA: SC.View.extend({
+        layout: { width: 100 }
+      }),
+
+      sectionB: SC.View.extend({
+        layout: { border: 1, width: 50 }
+      }),
+
+      sectionC: SC.View.extend({
+        layout: { top: 10, bottom: 10, width: 120 }
+      })
+    });
+  });
+
+  equals(view.sectionA.layout.left, 10, "sectionA left should be 10");
+  equals(view.sectionB.layout.left, 115, "sectionB left should be 115");
+  equals(view.sectionC.layout.left, 170, "sectionC left should be 170");
+  equals(view.layout.width, 310, "view width should be 310");
+
+});
+
+test("HORIZONTAL_STACK - with fillRatio", function () {
+  var view = null;
+  SC.run(function() {
+    view = SC.View.create({
+      layout: { height: 10, width: 200 },
+      childViewLayout: SC.View.HORIZONTAL_STACK,
+      childViewLayoutOptions: {
+        resizeToFit: NO,
+        paddingBefore: 10,
+        paddingAfter: 20,
+        spacing: 10
+      },
+      childViews: [ "c1", "c2", "c3", "c4", "c5" ],
+
+      c1: SC.View.extend({
+        layout: { height: 10, width: 10 },
+      }),
+      c2: SC.View.extend({
+        layout: { height: 10 },
+        fillRatio: 1
+      }),
+      c3: SC.View.extend({
+        layout: { height: 10, width: 10 },
+      }),
+      c4: SC.View.extend({
+        layout: { height: 10 },
+        fillRatio: 2
+      }),
+      c5: SC.View.extend({
+        layout: { height: 10 },
+        border: 1,
+        isVisible: NO
+      }),
+    });
+  });
+
+  equals(view.c1.layout.left, 10, "c1 left should be 10");
+  equals(view.c2.layout.left, 30, "c2 left should be 10");
+  equals(view.c2.get( "borderFrame" ).width, 40, "c2 width should be 40");
+  equals(view.c3.layout.left, 80, "c3 left should be 10");
+  equals(view.c4.layout.left, 100, "c4 left should be 10");
+  equals(view.c4.get( "borderFrame" ).width, 80, "c4 width should be 80");
+
+  SC.run(function() {
+    view.c2.set( "isVisible", NO );
+    view.c4.set( "isVisible", NO );
+    view.c5.set( "isVisible", YES );
+  });
+
+  equals(view.c1.layout.left, 10, "c1 left should be 10");
+  equals(view.c3.layout.left, 30, "c3 left should be 30");
+  equals(view.c5.layout.left, 50, "c5 left should be 50");
+  equals(view.c5.get( "borderFrame" ).width, 130, "being the last child, c5 will extend to fill the available space, width should be 130");
+});
+
+
+test("VERTICAL_STACK - with fillRatio", function () {
+  var view = null;
+  SC.run(function() {
+    view = SC.View.create({
+      layout: { width: 10, height: 200 },
+      childViewLayout: SC.View.VERTICAL_STACK,
+      childViewLayoutOptions: {
+        resizeToFit: NO,
+        paddingBefore: 10,
+        paddingAfter: 20,
+        spacing: 10
+      },
+      childViews: [ "c1", "c2", "c3", "c4", "c5" ],
+
+      c1: SC.View.extend({
+        layout: { width: 10, height: 10 },
+      }),
+      c2: SC.View.extend({
+        layout: { width: 10 },
+        fillRatio: 1
+      }),
+      c3: SC.View.extend({
+        layout: { width: 10, height: 10 },
+      }),
+      c4: SC.View.extend({
+        layout: { width: 10 },
+        fillRatio: 2
+      }),
+      c5: SC.View.extend({
+        layout: { width: 10 },
+        border: 1,
+        isVisible: NO
+      }),
+    });
+  });
+
+  equals(view.c1.layout.top, 10, "c1 top should be 10");
+  equals(view.c2.layout.top, 30, "c2 top should be 10");
+  equals(view.c2.get( "borderFrame" ).height, 40, "c2 height should be 40");
+  equals(view.c3.layout.top, 80, "c3 top should be 10");
+  equals(view.c4.layout.top, 100, "c4 top should be 10");
+  equals(view.c4.get( "borderFrame" ).height, 80, "c4 height should be 80");
+
+  SC.run(function() {
+    view.c2.set( "isVisible", NO );
+    view.c4.set( "isVisible", NO );
+    view.c5.set( "isVisible", YES );
+  });
 
       childViewLayout: SC.View.VERTICAL_STACK,
 


### PR DESCRIPTION
Here is a new child layout plugin called FLEX_GRID which allows child views to be positioned in a grid by setting a `column` and `row` index and optionals `columnSpan` and `rowSpan` values to them.

This plugin also support `rowSpace` and `colSpace` properties to define the space between the rows and columns.
