### PR TITLE
Ensure text field hint line-height gets set correctly.

### DIFF
--- a/frameworks/foundation/views/text_field.js
+++ b/frameworks/foundation/views/text_field.js
@@ -867,6 +867,10 @@ SC.TextFieldView = SC.FieldView.extend(SC.Editable,
     }
   },
 
+  didAppendToDocument: function() {
+    this._fixupTextLayout();
+  },
+
   /** @private
     Apply proper text layout to sc-hints and inputs.
    */
@@ -1033,6 +1037,7 @@ SC.TextFieldView = SC.FieldView.extend(SC.Editable,
       this.$('.hint').addClass('sc-hidden');
     } else {
       this.$('.hint').removeClass('sc-hidden');
+      this._fixupTextLayout();
     }
   }.observes('value'),
 


### PR DESCRIPTION
Call _fixupTextLayout when appending to the document and when hint is shown so the right line-height is applied.

_fixupTextLayout is called from didCreateLayer, but at that point the hint may be hidden and have an incorrect outerHeight().

Replaces #886. Rebased on top of master and pushed for convenient unit test run. Everything passes. Planned on merging it on in but decided to hold off pending a glance-over by @publickeating.
