### PR TITLE
Fix SC.Record.normalize: accept record attributes based on classes extending SC.RecordAttribute

### DIFF
--- a/frameworks/datastore/models/record.js
+++ b/frameworks/datastore/models/record.js
@@ -626,8 +626,7 @@ SC.Record = SC.Object.extend(
   */
 
   normalize: function(includeNull) {
-    var primaryKey = this.primaryKey,
-        recordId   = this.get('id'),
+    var recordId   = this.get('id'),
         store      = this.get('store'),
         storeKey   = this.get('storeKey'),
         keysToKeep = {},
@@ -635,8 +634,6 @@ SC.Record = SC.Object.extend(
         isChild, defaultVal, keyForDataHash, attr;
 
     var dataHash = store.readEditableDataHash(storeKey) || {};
-    dataHash[primaryKey] = recordId;
-    keysToKeep[primaryKey] = YES;
     recHash = store.readDataHash(storeKey);
 
     for (key in this) {


### PR DESCRIPTION
When using custom types of RecordAttributes the normalize method was ignoring them (using SC.instanceOf rather than SC.kindOf ) so the transform using fromType was not executed, therefore the data into the hash was invalid (not the expected type).

Also remove a developer warning produced by the primary key being at the beginning stored into the hash and eventually removed if the record is new. Initially, in the first commit, I preserved the rowKey into the hash as it was set at the beginning of normalize, but arrived at the conclusion that storing it into the record hash is really bad practice, therefore I removed it completely.
