### PR TITLE
Calculate correctly the height of a TextFieldView's hint when the content is set to null

### DIFF
--- a/frameworks/foundation/tests/views/text_field/ui.js
+++ b/frameworks/foundation/tests/views/text_field/ui.js
@@ -712,4 +712,19 @@ test("editing a field should not change the cursor position", function() {
   ok(selection.get('start') == 2 && selection.get('end') == 3, 'cursor position should be unchanged');
 });
 
+test("the hint of a text field should have a non 0 height when the value is set to empty", function() {
+  var empty = pane.view('empty');
+  var hintEmpty = empty.$('.hint');
+  var notEmpty = pane.view('with value');
+  var hintNotEmpty = notEmpty.$('.hint');
+  var value = notEmpty.get('value');
+
+  notEmpty.set('value', null);
+
+  //compare the calculated line-height of the hint with that of a field built with an empty value
+  ok( hintEmpty.style.lineHeight === hintNotEmpty.style.lineHeight, 'the line height of the hint should be calculated correctly when the content is removed' );
+
+  notEmpty.set('value', value);
+});
+
 })();

--- a/frameworks/foundation/views/text_field.js
+++ b/frameworks/foundation/views/text_field.js
@@ -719,7 +719,11 @@ SC.TextFieldView = SC.FieldView.extend(SC.Editable,
           elem = input[0],
           val = this.get('value');
 
-      if (hintOnFocus) this.$('.hint')[0].innerHTML = hint;
+      if (hintOnFocus) {
+        this.$('.hint')[0].innerHTML = hint;
+        // Set the right size of the hint box when text field is reused or updated with an empty value
+        this._fixupTextLayout();
+      }
       else if (!hintOnFocus) elem.placeholder = hint;
 
       // IE8 has problems aligning the input text in the center


### PR DESCRIPTION
If a text field is built with a non empty value, the size of the hint is not updated correctly when the field's value is set to null or when the field is reused. This patch simply calls _fixupTextLayout() on render->update branch.

I added also a testcase but couldn't check it. For unknown reasons I no longer can run testcases on the dev branch. Anything changed here?
