### PR TITLE
Adds an aggregatePropertyChanges flag to SC.RecordAttribute

### DIFF
--- a/frameworks/datastore/models/record.js
+++ b/frameworks/datastore/models/record.js
@@ -517,8 +517,14 @@ SC.Record = SC.Object.extend(
       aggregates = [];
       for (key in this) {
         prop = this[key];
-        if (prop  &&  prop.isRecordAttribute  &&  prop.aggregate === YES) {
+        if (prop  &&  prop.isRecordAttribute  &&  (prop.aggregate === YES || prop.aggregatePropertyChanges === YES)) {
           aggregates.push(key);
+
+          //@if(debug)
+          if (prop.aggregatePropertyChanges && !prop.inverse) {
+            SC.warn("Developer Warning: The inverse property of the '%@' relationship needs to be set when setting aggregatePropertyChanges to true".fmt(key));
+          }
+          //@endif
         }
       }
       recordType.__sc_aggregate_keys = aggregates;
@@ -566,11 +572,29 @@ SC.Record = SC.Object.extend(
       }
     };
 
+    /**
+      @private
+
+      Notify the record that a property of its relationship has changed.
+
+      @param {SC.Record} record to notify
+    */
+    iterProp = function(recs, prop) {
+      recs.forEach(function(rec) {
+        if (rec) {
+          var inverse = prop.inverse;
+          if (inverse) rec.notifyPropertyChange(inverse);
+        }
+      }, this);
+    };
+
     for(idx=0,len=aggregates.length;idx<len;++idx) {
       key = aggregates[idx];
+      prop = this[key];
       val = this.get(key);
       recs = SC.kindOf(val, SC.ManyArray) ? val : [val];
-      recs.forEach(iter, this);
+      if (prop.aggregate) recs.forEach(iter, this);
+      if (prop.aggregatePropertyChanges) iterProp.call(this, recs, prop);
     }
   },
 

--- a/frameworks/datastore/models/record_attribute.js
+++ b/frameworks/datastore/models/record_attribute.js
@@ -134,6 +134,20 @@ SC.RecordAttribute = SC.Object.extend(
   */
   aggregate: NO,
 
+  /**
+    Can only be used for toOne or toMany relationship attributes. If YES,
+    this flag will notify any related objects when a property of this 
+    record changes.
+
+    Useful when you want a computed property observing on a toOne or toMany
+    relationship, and you want it to be recomputed when a property of
+    the relationship has changed.
+
+    @type Boolean
+    @default NO
+  */
+  aggregatePropertyChanges: NO,
+
 
   /**
     Can only be used for toOne or toMany relationship attributes. If YES,


### PR DESCRIPTION
Here is a proposal to solve a problem with computed properties depending on the property of a relationship. Here is an example :

```
MyApp.Foo = SC.Record.extend({

  bar: SC.Record.toOne("MyApp.Bar", { inverse: "foo" }),

  barBaz: function() {
    return this.getPath('bar.baz');
  }.property('bar').cacheable(), 

});
```

Currently `barBaz` will not be updated if the `baz` property of `bar`changes. After a long talk with maurits, we couldn't found a clean way to have `barBaz` updated. In fact, we can't use `property('bar.baz').cacheable()` because this is not supported and throw an error like this: `Uncaught Error: Developer Error: The record of type, GX.Invoice, with storeKey, 1029, was materialized a second time before the first call had finished. This will result in two separate instances of the same object being created and should be fixed. A likely cause is using '.observes' code in the record class, which can cause the record to be retrieved somehow while it is still being created.`
Another solution could be to make `barBaz` not cacheable, but it is needed if we want to display it in a list view. The last solution were to had observers manually, which is kind of hacky and not efficient.

So the solution we found here were to create a new property `aggregatePropertyChanges` (I think the name could be review), which, when set to true, will notify the relationship that a property has changed. In the example above, `aggregatePropertyChanges` should be had like this :

```
MyApp.Bar = SC.Record.extend({

  foo: SC.Record.toOne("MyApp.Bar", { inverse: "bar", aggregatePropertyChanges: true }),

  baz: SC.Record.attr(String), 
  qux: SC.Record.attr(String), 

});
```

The only drawback here is that if a property other `baz` is changed (like `qux`), the computed properties of the inverse relationship depending on `bar` will all be notified of a change for nothing. But I suppose this can't be avoid until we decide to support `property('bar.baz').cacheable()`.

I hope my explications are clear. I'd like to hear what you think about it. If you like the idea, I will had unit tests.
