### PR TITLE
Stacked child layout views + resizeToFit: don't add padding or margins if none of the children is visible

### DIFF
--- a/frameworks/core_foundation/child_view_layouts/horizontal_stack_layout.js
+++ b/frameworks/core_foundation/child_view_layouts/horizontal_stack_layout.js
@@ -272,7 +272,9 @@ SC.mixin(SC.View,
       }
 
       // Adjust our frame to fit as well, this ensures that scrolling works.
-      position += Math.max(lastMargin, paddingAfter);
+      // If the current size is 0 (all children are hidden), it doesn't make sense to add the padding
+      if (position !== 0)
+        position += Math.max(lastMargin, paddingAfter);
       if (resizeToFit && view.getPath('layout.width') !== position) {
         view.adjust('width', position);
       }

--- a/frameworks/core_foundation/child_view_layouts/vertical_stack_layout.js
+++ b/frameworks/core_foundation/child_view_layouts/vertical_stack_layout.js
@@ -273,7 +273,9 @@ SC.mixin(SC.View,
       }
 
       // Adjust our frame to fit as well, this ensures that scrolling works.
-      position += Math.max(lastMargin, paddingAfter);
+      // If the current size is 0 (all children are hidden), it doesn't make sense to add the padding
+      if (position !== 0)
+        position += Math.max(lastMargin, paddingAfter);
       if (resizeToFit && view.getPath('layout.height') !== position) {
         view.adjust('height', position);
       }


### PR DESCRIPTION
If we have a view using one of the stacked layouts, it may happen that for various reasons, all children are hidden. In this case and if the view has the flag resizeToFit = YES, we should not add any padding/margin at the end of the calculation. The view should remain effectively with width/height 0.
