### PR TITLE
Integrate the SC.AutoMixin into SC.view, using a new property: autoMixins. Deprecate SC.AutoMixin

### DIFF
--- a/frameworks/core_foundation/views/view.js
+++ b/frameworks/core_foundation/views/view.js
@@ -167,6 +167,16 @@ SC.CoreView.reopen(
   */
   childViews: SC.EMPTY_CHILD_VIEWS_ARRAY,
 
+  /**
+    Use this property to automatically mix in a collection of mixins into all
+    child views created by the view. This collection is applied during createChildView
+    @property
+
+    @type Array
+    @default null
+  */
+  autoMixins: null,
+
   // ..........................................................
   // LAYER SUPPORT
   //
@@ -1380,7 +1390,16 @@ SC.CoreView.reopen(
       // Track that we created this view.
       attrs.createdByParent = true;
 
-      view = view.create(attrs);
+      // Insert the autoMixins if defined
+      var applyMixins = this.autoMixins;
+
+      if (!!applyMixins) {
+        applyMixins = SC.clone(applyMixins);
+        applyMixins.push(attrs);
+        view = view.create.apply(view, applyMixins);
+      }
+      else
+        view = view.create(attrs);
     }
 
     return view;

--- a/frameworks/foundation/mixins/auto_mixin.js
+++ b/frameworks/foundation/mixins/auto_mixin.js
@@ -6,6 +6,7 @@
 // ==========================================================================
 
 /**
+  @deprecated SC.AutoMixin is deprecated. Please use the property autoMixins of SC.View instead
   @namespace
 
   Use this mixin to automatically mix in a list of mixins into all


### PR DESCRIPTION
This is a followup for issue https://github.com/sproutcore/sproutcore/pull/999

I consider that this auto mixins mechanism should be integrated into SC.View. After the comments done by tyler into the previous issue (#999), we have here an optimized version that should not put any extra pressure on the SC.View.createChildView. The new code is not using any get method because we really don't need them in this context.
