### PR TITLE
SC.NestedStore use the callback argument on retrieveRecords

### DIFF
--- a/frameworks/datastore/system/nested_store.js
+++ b/frameworks/datastore/system/nested_store.js
@@ -482,7 +482,7 @@ SC.NestedStore = SC.Store.extend(
     an error if the record is dirty.  We'll otherwise avoid setting our status
     because that can disconnect us from upper and/or lower stores.
   */
-  retrieveRecords: function(recordTypes, ids, storeKeys, isRefresh) {
+  retrieveRecords: function(recordTypes, ids, storeKeys, isRefresh, callbacks) {
     var pstore = this.get('parentStore'), idx, storeKey, newStatus,
       len = (!storeKeys) ? ids.length : storeKeys.length,
       K = SC.Record, status;
@@ -536,7 +536,7 @@ SC.NestedStore = SC.Store.extend(
       }
     }
 
-    return pstore.retrieveRecords(recordTypes, ids, storeKeys, isRefresh);
+    return pstore.retrieveRecords(recordTypes, ids, storeKeys, isRefresh, callbacks);
   },
 
   /** @private - adapt for nested store */


### PR DESCRIPTION
When retrieving records, the nested store should call the callbacks when data source answers.
The change just forwards the callbacks argument to the corresponding method of the parent store.
