### PR TITLE
When reading a SC.DateTime record attribute, the convertion of a null value, should produce null in all cases, not only for non unix time attributes.

### DIFF
--- a/frameworks/datastore/models/record_attribute.js
+++ b/frameworks/datastore/models/record_attribute.js
@@ -592,13 +592,13 @@ if (SC.DateTime && !SC.RecordAttribute.transforms[SC.guidFor(SC.DateTime)]) {
       Convert a String to a DateTime
     */
     to: function(str, attr) {
+      if (SC.none(str) || SC.instanceOf(str, SC.DateTime)) return str;
       if(attr.get('useUnixTime')) {
         if(SC.typeOf(str) === SC.T_STRING) { str = parseInt(str); }
         if(isNaN(str) || SC.typeOf(str) !== SC.T_NUMBER) { str = 0; }
         return SC.DateTime.create({ milliseconds: str*1000, timezone: 0 });
       }
-      if (SC.none(str) || SC.instanceOf(str, SC.DateTime)) return str;
-      if (SC.none(str) || SC.instanceOf(str, Date)) return SC.DateTime.create(str.getTime());
+      if (SC.instanceOf(str, Date)) return SC.DateTime.create(str.getTime());
       var format = attr.get('format');
       return SC.DateTime.parse(str, format ? format : SC.DateTime.recordFormat);
     },

--- a/frameworks/datastore/tests/models/datetime_recordattribute.js
+++ b/frameworks/datastore/tests/models/datetime_recordattribute.js
@@ -10,45 +10,52 @@
 // framework might not be the best place for it but it works because the
 // desktop framework requires both datestore and foundation frameworks.
 
-var sprocket, nullSprocket, d1, d2, d3;
+var sprocket, nullSprocket, nullUnixTime, d1, d2, d3;
 
 module('SC.DateTime transform', {
 
   setup: function() {
-    
+
     d1 = SC.DateTime.create({ year: 2009, month: 3, day: 1, hour: 20, minute: 30, timezone: 480 });
     d2 = SC.DateTime.create({ year: 2009, month: 3, day: 1, hour: 20, minute: 30, timezone: SC.DateTime.timezone });
     d3 = SC.DateTime.create({ year: 2009, month: 3, day: 1, hour: 20, minute: 30, timezone: 0 });
-    
+
     var MyApp = SC.Object.create({
       store: SC.Store.create()
     });
-    
+
     MyApp.Sprocket = SC.Record.extend({
       createdAt: SC.Record.attr(SC.DateTime),
       frenchCreatedAt: SC.Record.attr(SC.DateTime, { format: '%d/%m/%Y %H:%M:%S' }),
       unixTimeCreatedAt: SC.Record.attr(SC.DateTime, { useUnixTime: YES })
     });
-        
+
     SC.RunLoop.begin();
     MyApp.store.loadRecords(MyApp.Sprocket, [
-      { 
-        guid: '1', 
+      {
+        guid: '1',
         createdAt: '2009-03-01T20:30:00-08:00',
         frenchCreatedAt: '01/03/2009 20:30:00',
         unixTimeCreatedAt: 1235939400
       },
-      { 
-        guid: '2', 
+      {
+        guid: '2',
         createdAt: null,
         frenchCreatedAt: null,
         unixTimeCreatedAt: 'invalidValue'
+      },
+      {
+        guid: '3',
+        createdAt: null,
+        frenchCreatedAt: null,
+        unixTimeCreatedAt: null
       }
     ]);
     SC.RunLoop.end();
-    
+
     sprocket = MyApp.store.find(MyApp.Sprocket, '1');
     nullSprocket = MyApp.store.find(MyApp.Sprocket, '2');
+    nullUnixTime = MyApp.store.find(MyApp.Sprocket, '3');
   }
 
 });
@@ -61,10 +68,10 @@ test("reading a DateTime should successfully parse the underlying string value",
 test("writing a DateTime should successfully format the value into a string", function() {
   d1 = d1.advance({ year: 1, hour: 2, minute: 28 });
   d2 = d2.advance({ month: -2, minute: 16 });
-  
+
   sprocket.set('createdAt', d1);
   sprocket.set('frenchCreatedAt', d2);
-  
+
   equals(sprocket.readAttribute('createdAt'), '2010-03-01T22:58:00-08:00', 'writing a DateTime should successfully format the value into the a string');
   equals(sprocket.readAttribute('frenchCreatedAt'), '01/01/2009 20:46:00', 'writing a DateTime with a custom format should successfully format the value into the a string');
 });
@@ -72,14 +79,15 @@ test("writing a DateTime should successfully format the value into a string", fu
 test("reading or writing null values should work", function() {
   sprocket.set('createdAt', null);
   equals(sprocket.readAttribute('createdAt'), null);
-  
+
   equals(nullSprocket.get('createdAt'), null);
+  equals(nullUnixTime.get('unixTimeCreatedAt'), null, 'reading a DateTime store in unix time should default to null when a null value is provided');
 });
 
 test("reading and writing a DateTime should successfully convert to/from unix time", function() {
   // Reading test
   equals(sprocket.get('unixTimeCreatedAt'), d3, 'reading a DateTime stored in unix time format should return the correct SC.DateTime object');
-  
+
   // Writing test
   d3 = d3.advance({ year: 2, month: 7, day: 14, hour: -3 });
   sprocket.set('unixTimeCreatedAt', d3);


### PR DESCRIPTION
A null value should never be converted to 0 milliseconds because null should remain null in all cases. The alternative (unacceptable) would be to handle this special case (milliseconds=0 i.e. 1.1.1970) into the from method of the same transformer. The previous version was properly handling null only on non useUnixTime attributes.
