### PR TITLE
Add support for record patching using a partial (containing only a subset of attributes) or complete data hash

### DIFF
--- a/frameworks/datastore/system/store.js
+++ b/frameworks/datastore/system/store.js
@@ -2396,6 +2396,52 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
   },
 
   /**
+    Call by the data source whenever you want to patch a record into the store
+    using a partial (containing only a subset of attributes) or complete data hash.
+
+    The attributes received are replacing the corresponding ones form the existing hash
+    by selectively merging the current data hash into the new one. In the end, the result
+    is loaded into the store using pushRetrieve.
+
+    If the record is not yet loaded into the store, or is not READY_CLEAN,
+    it behaves like a pure pushRetrieve, therefore in most of the cases it is safe
+    to replace into the data sources the calls to pushRetrieve by pushRetrievePatch.
+
+    @param {Class} recordType the SC.Record subclass
+    @param {Object} id the record id or null
+    @param {Hash} dataHash data hash used to patch the current data loaded into the store
+    @param {Number} storeKey optional store key.
+    @returns {Number|Boolean} storeKey if push was allowed, NO if not
+  */
+  pushRetrievePatch: function(recordType, id, dataHash, storeKey) {
+    var status, existingDataHash, key;
+
+    if(dataHash) {
+      if(storeKey === undefined) storeKey = recordType.storeKeyFor(id);
+      status = this.readStatus( storeKey );
+
+      // if the current record status is not READY_CLEAN, let pushRetrieve handle the new data
+      // for all other statuses handled by pushRetrieve (EMPTY, ERROR, DESTROYED_CLEAN)
+      // the new hash will just replace the existing one
+      if(status == SC.Record.READY_CLEAN) {
+        existingDataHash = this.readDataHash(storeKey);
+
+        if(existingDataHash)
+        {
+          for(key in existingDataHash) {
+            // merge only the keys that are not defined into the data hash sent by the data source
+            if(!(key in dataHash)) {
+              dataHash[key] = existingDataHash[key];
+            }
+          }
+        }
+      }
+    }
+
+    return this.pushRetrieve(recordType, id, dataHash, storeKey);
+  },
+
+  /**
     Call by the data source whenever you want to push a deletion into the
     store.
 

--- a/frameworks/datastore/tests/system/store/pushChanges.js
+++ b/frameworks/datastore/tests/system/store/pushChanges.js
@@ -34,6 +34,10 @@ module("SC.Store#pushChanges", {
 
     storeKey6 = SC.Store.generateStoreKey();
     store.writeDataHash(storeKey6, json, SC.Record.BUSY_LOADING);
+
+    storeKey7 = SC.Store.generateStoreKey();
+    store.writeDataHash(storeKey7, json, SC.Record.READY_CLEAN);
+
     SC.RunLoop.end();
   },
 
@@ -47,6 +51,13 @@ test("Do a pushRetrieve and check if there is conflicts", function () {
   var res = store.pushRetrieve(SC.Record, undefined, undefined, storeKey1);
   equals(res, storeKey1, "There is no conflict, pushRetrieve was succesful.");
   res = store.pushRetrieve(SC.Record, undefined, undefined, storeKey4);
+  ok(!res, "There is a conflict, because of the state, this is expected.");
+});
+
+test("Do a pushRetrievePatch and check if there is conflicts", function () {
+  var res = store.pushRetrievePatch(SC.Record, undefined, undefined, storeKey1);
+  equals(res, storeKey1, "There is no conflict, pushRetrievePatch was succesful.");
+  res = store.pushRetrievePatch(SC.Record, undefined, undefined, storeKey4);
   ok(!res, "There is a conflict, because of the state, this is expected.");
 });
 
@@ -79,4 +90,11 @@ test("A pushRetrieve updating the id of an existing record should update the pri
   store.pushRetrieve(SC.Record, 1, recSecond, sK);
   SC.RunLoop.end();
   equals(store.idFor(sK), 1); // id should now have been updated
+});
+
+test("A pushRetrievePatch should merge only some attributes", function () {
+  var res = store.pushRetrievePatch(SC.Record, undefined, { number: 100 }, storeKey7);
+  var ret = store.readDataHash(storeKey7);
+  equals( 100, ret.number, "The new value of a patched attribute should be found into the hash" );
+  equals( YES, ret.bool, "The value of an attribute that was not patched should be preserved" );
 });


### PR DESCRIPTION
The current version of datastore doesn't offer support for record patching via partial data hashes. A typical example is the following:
1. a new record is created
2. the record is sent to the server
3. the server saves data into the database
4. the server answers with some fields, for example an unique id that can't be calculated by the client

We have the possibility to send from the server the complete record, but this would be a waste of resources and may be even expensive in terms of computing resources.

This patching function is based on and using pushRetrieve. It mainly merges the two data hashes, the new (partial or also full) and the existing one but always the new data is preferred. Once merge done, the resulting hash is pushRetrieve-d into the store. As pushRetrieve, the merge should be done only when the record is not dirty and since pushRetrieve takes care of this, it should handle only READY_CLEAN.

Due to the logic of this function,  in most of the cases, it can be safely used in place of pushRetrieve. In fact, I'm using it exclusively (in place of pushRetrieve) for some months now and never had any undesired side effect.
