### PR TITLE
Adds minimal-ui flag to viewport meta tag in index.rhtml.

### DIFF
--- a/lib/index.rhtml
+++ b/lib/index.rhtml
@@ -26,7 +26,7 @@
     <meta http-equiv="Content-Script-Type" content="text/javascript"  >
     <meta name="apple-mobile-web-app-capable" content="yes"  >
     <meta name="apple-mobile-web-app-status-bar-style" content="<%= config.status_bar_style || 'default' %>"  >
-    <meta name="viewport" content="initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no"  >
+    <meta name="viewport" content="initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no, minimal-ui"  >
 
     <% if config.touch_enabled %>
     <% if config.precomposed_icon %>


### PR DESCRIPTION
I'm posting this pull req to get it on the Issues list, but currently there's a harmless-but-annoying chrome bug that barfs a console error when it sees this. The bug is fixed in Chromium, so let's hold off on integrating this until the fix makes it into Chrome.
