### PR TITLE
Fixes a bug in IndexSet causing an infinite loop.

### DIFF
--- a/frameworks/runtime/system/index_set.js
+++ b/frameworks/runtime/system/index_set.js
@@ -448,7 +448,7 @@ SC.IndexSet = SC.mixin({},
 
       cur = 0;
       next = content[0];
-      while(next !== 0) {
+      while(next && next !== 0) {
         if (next>0) this.add(cur, next-cur);
         cur = next<0 ? 0-next : next;
         next = content[cur];
@@ -886,7 +886,7 @@ SC.IndexSet = SC.mixin({},
         source  = this.source;
 
     if (target === undefined) target = null;
-    while (next !== 0) {
+    while (next && next !== 0) {
       if (next > 0) callback.call(target, cur, next - cur, this, source);
       cur  = Math.abs(next);
       next = content[cur];


### PR DESCRIPTION
I cannot for the life of me figure out how to write a test that "fails". I can write a test that creates the infinite loop and locks up the browser, but I can't figure out how to write a test for an infinite loop.

In any case, when the IndexSet's content is an empty array, next will be undefined, which unfortunately does not equal 0. So, both of these loops set `cur` to undefined, then set `next` to undefined and the loop never exits.

I cannot see any reason why this modification would make anything change, and I did check to make sure all existing IndexSet tests still pass, but I don't know of an easy way to run ALL of the tests to make sure I didn't break something else.

If someone is willing to help me write a test for an infinite loop, I'd be happy to add that to the pull request :-)
