### PR TITLE
Improves nested store handling of record loading. Includes unit tests.

### DIFF
--- a/frameworks/datastore/system/store.js
+++ b/frameworks/datastore/system/store.js
@@ -554,6 +554,8 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     and execute `flush()` once at the end of the runloop.
   */
   _notifyRecordPropertyChange: function (storeKey, statusOnly, key) {
+    // Do this first so that it gets in line ahead of any of its chained stores.
+    this.invokeOnce(this.flush);
 
     var records      = this.records,
         nestedStores = this.get('nestedStores'),
@@ -564,18 +566,22 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     len = nestedStores ? nestedStores.length : 0 ;
     for(idx=0;idx<len;idx++) {
       store = nestedStores[idx];
-      status = store.peekStatus(storeKey); // important: peek avoids read-lock
       editState = store.storeKeyEditState(storeKey);
 
-      // when store needs to propagate out changes in the parent store
-      // to nested stores
+      // If the chained-store record is reflecting its parent store, simply
+      // notify it that it's changed.
       if (editState === K.INHERITED) {
         store._notifyRecordPropertyChange(storeKey, statusOnly, key);
-
-      } else if (status & SC.Record.BUSY) {
-        // make sure nested store does not have any changes before resetting
-        if(store.get('hasChanges')) throw K.CHAIN_CONFLICT_ERROR;
-        store.reset();
+      }
+      // If the chained-store record is editable but not locked, roll it back
+      // to accept updates from the parent store. (This will trigger a call
+      // to store._notifyRecordPropertyChange.)
+      else if (editState === K.EDITABLE) {
+        store.rollBackEditable(storeKey);
+      }
+      // Otherwise, the chained record is locked and we are unable to proceed.
+      else {
+        throw K.CHAIN_CONFLICT_ERROR;
       }
     }
 
@@ -622,7 +628,6 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
       }
     }
 
-    this.invokeOnce(this.flush);
     return this;
   },
 


### PR DESCRIPTION
SC.NestedStore#lockOnRead, which defaults to YES, is intended to safely silo nested stores from each other. However, by overaggressively locking records even when they’re not yet loaded, it causes problems even when operating on its own. If a record is retrieved from a solo nested store (e.g. by following a toOne relationship) and read-and-locked while loading (e.g. by being bound to a view), one of two bugs is triggered when the record finishes loading:
- If the nested store has no other changes, then the load triggers a full reset of the nested store, but fails to notify the nested-store record that it has loaded. The record’s status is stranded at BUSY_LOADING, and any cached attributes stay null. (If this were the only issue, it could be solvable by changing the `reset` call to `discardChanges`.)
- If any other (unrelated) records have been dirtied in the nested store, it throws a CHAIN_CONFLICT_ERROR, even though the record being loaded is conflict-free.

This commit solves the first problem by preventing lockOnRead from locking nested-store records when they are read in EMPTY or BUSY_LOADING states; this prevents the record from locking before there is anything to lock. It solves the second problem by modifying the behavior of SC.Store#_notifyRecordPropertyChange to switch behavior solely based on the chained record’s editable (locked) state, rather than worrying about record status or store-wide dirtiness.
