### PR TITLE
Make SC.ScrollView take scrollbar visibility into account when resizing.

### DIFF
--- a/frameworks/desktop/views/scroll.js
+++ b/frameworks/desktop/views/scroll.js
@@ -2051,14 +2051,19 @@ SC.ScrollView = SC.View.extend({
     this._scroll_contentWidth  = width;
     this._scroll_contentHeight = height;
 
-    dim       = this.getPath('containerView.frame');
-    dimWidth  = dim.width;
+    dim = this.getPath('containerView.frame');
+    dimWidth = dim.width;
     dimHeight = dim.height;
 
     if (this.get('hasHorizontalScroller') && (view = this.get('horizontalScrollerView'))) {
       // decide if it should be visible or not
       if (this.get('autohidesHorizontalScroller')) {
         this.set('isHorizontalScrollerVisible', width > dimWidth);
+
+        // re-check dimensions since a scrollbar visibility change could change them
+        dim = this.getPath('containerView.frame');
+        dimWidth = dim.width;
+        dimHeight = dim.height;
       }
       view.setIfChanged('maximum', width - dimWidth);
       view.setIfChanged('proportion', dimWidth / width);


### PR DESCRIPTION
After a scrollbar visibility change, re-check the dimensions to take it
into account.

We ran into some infinite looping with this code without this patch. We would get into a state were the view would constantly switch between thinking it did/did not need a scrollbar.
