### PR TITLE
Adds an escapeForCSS method to SC.String.

### DIFF
--- a/frameworks/core_foundation/ext/string.js
+++ b/frameworks/core_foundation/ext/string.js
@@ -39,6 +39,13 @@ SC.supplement(String.prototype,
   },
 
   /**
+    @see SC.String.escapeForCSS
+  */
+  escapeForCSS: function () {
+    return SC.String.escapeForCSS(this);
+  },
+
+  /**
     @see SC.String.loc
   */
   loc: function() {

--- a/frameworks/core_foundation/system/string.js
+++ b/frameworks/core_foundation/system/string.js
@@ -16,6 +16,7 @@ SC.STRING_DASHERIZE_REGEXP = (/[ _]/g);
 SC.STRING_DASHERIZE_CACHE = {};
 SC.STRING_TRIM_LEFT_REGEXP = (/^\s+/g);
 SC.STRING_TRIM_RIGHT_REGEXP = (/\s+$/g);
+SC.STRING_CSS_ESCAPED_REGEXP = (/(:|\.|\[|\])/g);
 
 /**
   @namespace
@@ -113,6 +114,19 @@ SC.mixin(SC.String, {
     }
 
     return ret;
+  },
+
+  /**
+    Escapes the given string to make it safe to use as a jQuery selector.
+    jQuery will interpret '.' and ':' as class and pseudo-class indicators.
+
+    @see http://learn.jquery.com/using-jquery-core/faq/how-do-i-select-an-element-by-an-id-that-has-characters-used-in-css-notation/
+
+    @param {String} str the string to escape
+    @returns {String} the escaped string
+  */
+  escapeForCSS: function (str) {
+    return str.replace(SC.STRING_CSS_ESCAPED_REGEXP, '\\$1');
   },
 
   /**

--- a/frameworks/core_foundation/tests/mixins/string.js
+++ b/frameworks/core_foundation/tests/mixins/string.js
@@ -138,3 +138,8 @@ test("Multiply string", function() {
   equals('xyz'.mult(1), 'xyz');
   equals('xyz'.mult(2), 'xyzxyz');
 });
+
+test('CSS escaping a string', function () {
+  equals('AnHtmlId...WithSome:Problematic::Characters'.escapeForCSS(), 'AnHtmlId\\.\\.\\.WithSome\\:Problematic\\:\\:Characters', 'should be escaped');
+  equals('AnHtmlIdWithNormalCharacters'.escapeForCSS(), 'AnHtmlIdWithNormalCharacters', 'should be escaped, with no effect');
+});

--- a/frameworks/core_foundation/views/view.js
+++ b/frameworks/core_foundation/views/view.js
@@ -261,7 +261,7 @@ SC.CoreView.reopen(
     @returns {DOMElement} the discovered layer
   */
   findLayerInParentLayer: function (parentLayer) {
-    var id = "#" + this.get('layerId');
+    var id = "#" + this.get('layerId').escapeForCSS();
     return jQuery(id, parentLayer)[0] || jQuery(id)[0];
   },
 


### PR DESCRIPTION
The '.' and ':' characters are valid in HTML ids, but cannot be used in
a jQuery selector without being escaped. I added a method to escape a
string for use as a jQuery selector.
