### PR TITLE
Have SC.ScrollView#scrollToRect prefer the top/left of the rect.

### DIFF
--- a/frameworks/desktop/tests/views/scroll/methods.js
+++ b/frameworks/desktop/tests/views/scroll/methods.js
@@ -133,6 +133,17 @@ test("Scrolling relative to the current possition of the container view", functi
   });
 });
 
+test("Scrolling to a rectangle", function () {
+  equals(view.get('horizontalScrollOffset'), 0, "Initial horizontal offset must be zero");
+  equals(view.get('verticalScrollOffset'), 0, "Initial vertical offset must be zero");
+
+  SC.run(function () {
+    view.scrollToRect({ x: 100, y: 100, width: 2000, height: 2000 });
+    equals(view.get('horizontalScrollOffset'), 100, "After scrolling to rect, horizontal offset must be 100");
+    equals(view.get('verticalScrollOffset'), 100, "After scrolling to rect, vertical offset must be 100");
+  });
+});
+
 test("Scrolling through line by line", function () {
   var line = 3;
   equals(view.get('horizontalScrollOffset'), 0, "Initial horizontal offset must be zero");

--- a/frameworks/desktop/views/scroll.js
+++ b/frameworks/desktop/views/scroll.js
@@ -696,31 +696,35 @@ SC.ScrollView = SC.View.extend({
 
   /**
     Scroll to the supplied rectangle.
+    If the rectangle is bigger than the viewport, the top-left
+    will be preferred.
     @param {Rect} rect Rectangle to scroll to.
     @returns {Boolean} YES if scroll position was changed.
   */
   scrollToRect: function (rect) {
     // find current visible frame.
-    var vo = SC.cloneRect(this.get('containerView').get('frame'));
+    var vo = SC.cloneRect(this.get('containerView').get('frame')),
+        origX = this.get('horizontalScrollOffset'),
+        origY = this.get('verticalScrollOffset');
 
-    vo.x = this.get('horizontalScrollOffset');
-    vo.y = this.get('verticalScrollOffset');
-
-    var origX = vo.x, origY = vo.y;
-
-    // if top edge is not visible, shift origin
-    vo.y -= Math.max(0, SC.minY(vo) - SC.minY(rect));
-    vo.x -= Math.max(0, SC.minX(vo) - SC.minX(rect));
+    vo.x = origX;
+    vo.y = origY;
 
     // if bottom edge is not visible, shift origin
     vo.y += Math.max(0, SC.maxY(rect) - SC.maxY(vo));
     vo.x += Math.max(0, SC.maxX(rect) - SC.maxX(vo));
 
+    // if top edge is not visible, shift origin
+    vo.y -= Math.max(0, SC.minY(vo) - SC.minY(rect));
+    vo.x -= Math.max(0, SC.minX(vo) - SC.minX(rect));
+
     // scroll to that origin.
     if ((origX !== vo.x) || (origY !== vo.y)) {
       this.scrollTo(vo.x, vo.y);
       return YES;
-    } else return NO;
+    } else {
+      return NO;
+    }
   },
 
 


### PR DESCRIPTION
Previously, the top/left side would be scrolled into view first, then the
bottom/right side. This resulted in the bottom right being in view if the
rect was larger than the viewport.

Now scroll the bottom/right first, so the top/left is in view in this case.
