### PR TITLE
Made becomeFirstResponder accept and pass along the event that caused it

### DIFF
--- a/frameworks/core_foundation/panes/pane.js
+++ b/frameworks/core_foundation/panes/pane.js
@@ -272,9 +272,9 @@ SC.Pane = SC.View.extend(SC.ResponderContext,
 
     // if we are currently key pane, then notify key views of change also
     if (isKeyPane) {
-      if (current) { current.tryToPerform('willLoseKeyResponderTo', view); }
+      if (current) { current.tryToPerform('willLoseKeyResponderTo', view, evt); }
       if (view) {
-        view.tryToPerform('willBecomeKeyResponderFrom', current);
+        view.tryToPerform('willBecomeKeyResponderFrom', current, evt);
       }
     }
 
@@ -296,10 +296,10 @@ SC.Pane = SC.View.extend(SC.ResponderContext,
     // and notify again if needed.
     if (isKeyPane) {
       if (view) {
-        view.tryToPerform('didBecomeKeyResponderFrom', current);
+        view.tryToPerform('didBecomeKeyResponderFrom', current, evt);
       }
       if (current) {
-        current.tryToPerform('didLoseKeyResponderTo', view);
+        current.tryToPerform('didLoseKeyResponderTo', view, evt);
       }
     }
 
@@ -334,7 +334,7 @@ SC.Pane = SC.View.extend(SC.ResponderContext,
   },
 
 
-  didBecomeKeyResponderFrom: function(responder) {},
+  didBecomeKeyResponderFrom: function(responder, evt) {},
 
   /**
     Called just after the pane has lost its keyPane status.  Notifies the

--- a/frameworks/core_foundation/system/responder.js
+++ b/frameworks/core_foundation/system/responder.js
@@ -69,13 +69,18 @@ SC.Responder = SC.Object.extend( /** @scope SC.Responder.prototype */ {
     Call this method on your view or responder to make it become first
     responder.
 
+    @param {SC.Event} [evt] event that caused this to be invoked. optional because there is not always an event that
+                            triggers this to be called, but should be passed if available. will be passed through to
+                            the [will|did]LoseKeyResponderTo/[will|did]BecomeKeyResponderFrom callbacks.
     @returns {SC.Responder} receiver
   */
-  becomeFirstResponder: function () {
+  becomeFirstResponder: function (evt) {
     var pane = this.get('pane') || this.get('responderContext') ||
               this.pane();
     if (pane && this.get('acceptsFirstResponder')) {
-      if (pane.get('firstResponder') !== this) pane.makeFirstResponder(this);
+      if (pane.get('firstResponder') !== this) {
+        pane.makeFirstResponder(this, evt);
+      }
     }
     return this;
   },

--- a/frameworks/core_foundation/views/view/keyboard.js
+++ b/frameworks/core_foundation/views/view/keyboard.js
@@ -23,7 +23,7 @@ SC.View.reopen(
 
     @param {SC.Responder} responder
   */
-  willLoseKeyResponderTo: function(responder) {},
+  willLoseKeyResponderTo: function(responder, evt) {},
 
   /**
     This method is invoked just before you become the key responder.  The
@@ -35,13 +35,13 @@ SC.View.reopen(
 
     @param {SC.Responder} responder
   */
-  willBecomeKeyResponderFrom: function(responder) {},
+  willBecomeKeyResponderFrom: function(responder, evt) {},
 
   /**
     Invokved just after the responder loses key responder status.
     @param {SC.Responder} responder
   */
-  didLoseKeyResponderTo: function(responder) {},
+  didLoseKeyResponderTo: function(responder, evt) {},
 
   /**
     Invoked just after the responder gains key responder status.
@@ -50,7 +50,7 @@ SC.View.reopen(
   
     @param {SC.Responder} responder
   */
-  didBecomeKeyResponderFrom: function(responder) {},
+  didBecomeKeyResponderFrom: function(responder, evt) {},
 
   /**
     This method will process a key input event, attempting to convert it to

--- a/frameworks/desktop/views/button.js
+++ b/frameworks/desktop/views/button.js
@@ -646,7 +646,7 @@ SC.ButtonView = SC.View.extend(SC.Control,
       this._action(evt);
     } else if (!this._isFocused && (buttonBehavior!==SC.PUSH_BEHAVIOR)) {
       this._isFocused = YES ;
-      this.becomeFirstResponder();
+      this.becomeFirstResponder(evt);
     }
 
     return YES;
@@ -698,7 +698,7 @@ SC.ButtonView = SC.View.extend(SC.Control,
       this._action(touch);
     } else if (!this._isFocused && (buttonBehavior!==SC.PUSH_BEHAVIOR)) {
       this._isFocused = YES ;
-      this.becomeFirstResponder();
+      this.becomeFirstResponder(touch);
     }
 
     // don't want to do whatever default is...
@@ -742,7 +742,7 @@ SC.ButtonView = SC.View.extend(SC.Control,
      if(!this.get('isEnabledInPane')) return YES;
     if (evt.which === 9 || evt.keyCode === 9) {
       var view = evt.shiftKey ? this.get('previousValidKeyView') : this.get('nextValidKeyView');
-      if(view) view.becomeFirstResponder();
+      if(view) view.becomeFirstResponder(evt);
       else evt.allowDefault();
       return YES ; // handled
     }

--- a/frameworks/desktop/views/checkbox.js
+++ b/frameworks/desktop/views/checkbox.js
@@ -109,7 +109,7 @@ SC.CheckboxView = SC.ButtonView.extend(
 
     if (evt.which === 9 || evt.keyCode === 9) {
       var view = evt.shiftKey ? this.get('previousValidKeyView') : this.get('nextValidKeyView');
-      if(view) view.becomeFirstResponder();
+      if(view) view.becomeFirstResponder(evt);
       else evt.allowDefault();
       return YES ; // handled
     }

--- a/frameworks/desktop/views/collection.js
+++ b/frameworks/desktop/views/collection.js
@@ -2048,14 +2048,14 @@ SC.CollectionView = SC.View.extend(SC.CollectionViewDelegate, SC.CollectionConte
 
   insertTab: function(evt) {
     var view = this.get('nextValidKeyView');
-    if (view) view.becomeFirstResponder();
+    if (view) view.becomeFirstResponder(evt);
     else evt.allowDefault();
     return YES ; // handled
   },
 
   insertBacktab: function(evt) {
     var view = this.get('previousValidKeyView');
-    if (view) view.becomeFirstResponder();
+    if (view) view.becomeFirstResponder(evt);
     else evt.allowDefault();
     return YES ; // handled
   },
@@ -2091,7 +2091,7 @@ SC.CollectionView = SC.View.extend(SC.CollectionViewDelegate, SC.CollectionConte
     if(!this.get('isSelectable')) return NO;
 
     // become first responder if possible.
-    this.becomeFirstResponder() ;
+    this.becomeFirstResponder(ev);
 
     // Toggle the selection if selectOnMouseDown is true
     if (this.get('useToggleSelection')) {
@@ -2321,7 +2321,7 @@ SC.CollectionView = SC.View.extend(SC.CollectionViewDelegate, SC.CollectionConte
     if (!this.get('isEnabledInPane')) return contentIndex > -1;
 
     // become first responder if possible.
-    this.becomeFirstResponder() ;
+    this.becomeFirstResponder(touch);
 
     this._touchSelectedView = itemView;
 

--- a/frameworks/desktop/views/menu_item.js
+++ b/frameworks/desktop/views/menu_item.js
@@ -472,7 +472,7 @@ SC.MenuItemView = SC.View.extend(SC.ContentDisplay,
 
     // Become first responder to show highlight
     if (this.get('isEnabled')) {
-      this.becomeFirstResponder();
+      this.becomeFirstResponder(evt);
     }
 
     if (this.get('hasSubMenu')) {

--- a/frameworks/desktop/views/popup_button.js
+++ b/frameworks/desktop/views/popup_button.js
@@ -211,7 +211,7 @@ SC.PopupButtonView = SC.ButtonView.extend(
       });
     }, 1);
 
-    this.becomeFirstResponder();
+    this.becomeFirstResponder(evt);
 
     return YES ;
   },

--- a/frameworks/desktop/views/radio.js
+++ b/frameworks/desktop/views/radio.js
@@ -407,7 +407,7 @@ SC.RadioView = SC.View.extend(SC.Control,
     // handle tab key
     if (evt.which === 9 || evt.keyCode === 9) {
       var view = evt.shiftKey ? this.get('previousValidKeyView') : this.get('nextValidKeyView');
-      if(view) view.becomeFirstResponder();
+      if(view) view.becomeFirstResponder(evt);
       else evt.allowDefault();
       return YES ; // handled
     }

--- a/frameworks/desktop/views/segmented.js
+++ b/frameworks/desktop/views/segmented.js
@@ -757,7 +757,7 @@ SC.SegmentedView = SC.View.extend(SC.Control,
     // handle tab key
     if (evt.which === 9 || evt.keyCode === 9) {
       var view = evt.shiftKey ? this.get('previousValidKeyView') : this.get('nextValidKeyView');
-      if (view) view.becomeFirstResponder();
+      if (view) view.becomeFirstResponder(evt);
       else evt.allowDefault();
       return YES; // handled
     }

--- a/frameworks/desktop/views/select.js
+++ b/frameworks/desktop/views/select.js
@@ -707,7 +707,7 @@ SC.SelectView = SC.ButtonView.extend(
     if (!SC.empty(itemIdx) && itemIdx > -1) {
     // if there is an item selected, make it the first responder
       customView = menu.menuItemViewForContentIndex(itemIdx);
-      if (customView) { customView.becomeFirstResponder(); }
+      if (customView) { customView.becomeFirstResponder(evt); }
     }
 
     this.set('isActive', YES);
@@ -801,7 +801,7 @@ SC.SelectView = SC.ButtonView.extend(
     if (!this.get('isEnabledInPane')) return YES; // handled event, but do nothing
     this.set('isActive', YES);
     this._isMouseDown = YES;
-    this.becomeFirstResponder();
+    this.becomeFirstResponder(evt);
     this._action();
     return YES;
   },

--- a/frameworks/desktop/views/select_button.js
+++ b/frameworks/desktop/views/select_button.js
@@ -628,7 +628,7 @@ SC.SelectButtonView = SC.ButtonView.extend(
 
     customView = menu.menuItemViewForContentIndex(this.get('itemIdx'));
     menu.set('currentMenuItem', customView) ;
-    if (customView) customView.becomeFirstResponder();
+    if (customView) customView.becomeFirstResponder(evt);
 
     this.set('isActive', YES);
     return YES ;
@@ -722,7 +722,7 @@ SC.SelectButtonView = SC.ButtonView.extend(
     if (!this.get('isEnabled')) return YES ; // handled event, but do nothing
     this.set('isActive', YES);
     this._isMouseDown = YES;
-    this.becomeFirstResponder() ;
+    this.becomeFirstResponder(evt) ;
     this._action() ;
 
     // Store the current timestamp. We register the timestamp after a setTimeout
@@ -871,14 +871,14 @@ SC.SelectButtonView = SC.ButtonView.extend(
 
   insertTab: function(evt) {
     var view = this.get('nextValidKeyView');
-    if (view) view.becomeFirstResponder();
+    if (view) view.becomeFirstResponder(evt);
     else evt.allowDefault();
     return YES ; // handled
   },
 
   insertBacktab: function(evt) {
     var view = this.get('previousValidKeyView');
-    if (view) view.becomeFirstResponder();
+    if (view) view.becomeFirstResponder(evt);
     else evt.allowDefault();
     return YES ; // handled
   },

--- a/frameworks/desktop/views/slider.js
+++ b/frameworks/desktop/views/slider.js
@@ -219,7 +219,7 @@ SC.SliderView = SC.View.extend(SC.Control,
      // handle tab key
      if (evt.which === 9 || evt.keyCode === 9) {
        var view = evt.shiftKey ? this.get('previousValidKeyView') : this.get('nextValidKeyView');
-       if(view) view.becomeFirstResponder();
+       if(view) view.becomeFirstResponder(evt);
        else evt.allowDefault();
        return YES ; // handled
      }

--- a/frameworks/foundation/views/field.js
+++ b/frameworks/foundation/views/field.js
@@ -266,7 +266,7 @@ SC.FieldView = SC.View.extend(SC.Control, SC.Validatable,
     // handle tab key
     if (evt.which === 9 || evt.keyCode===9) {
       var view = evt.shiftKey ? this.get('previousValidKeyView') : this.get('nextValidKeyView');
-      if (view) view.becomeFirstResponder();
+      if (view) view.becomeFirstResponder(evt);
       else evt.allowDefault();
       return YES ; // handled
     }

--- a/frameworks/foundation/views/text_field.js
+++ b/frameworks/foundation/views/text_field.js
@@ -1002,7 +1002,7 @@ SC.TextFieldView = SC.FieldView.extend(SC.Editable,
   },
 
   fieldDidFocus: function (evt) {
-    this.becomeFirstResponder();
+    this.becomeFirstResponder(evt);
 
     this.beginEditing(evt);
 
@@ -1328,7 +1328,7 @@ SC.TextFieldView = SC.FieldView.extend(SC.Editable,
       return YES;
     } else {
       this._txtFieldMouseDown = YES;
-      this.becomeFirstResponder();
+      this.becomeFirstResponder(evt);
 
       return sc_super();
     }

--- a/frameworks/template_view/mixins/template_helpers/text_field_support.js
+++ b/frameworks/template_view/mixins/template_helpers/text_field_support.js
@@ -87,7 +87,7 @@ SC.TextFieldSupport = /** @scope SC.TextFieldSupport */{
   },
 
   focusIn: function(event) {
-    this.becomeFirstResponder();
+    this.becomeFirstResponder(event);
     this.tryToPerform('focus', event);
   },
 


### PR DESCRIPTION
to be called. This will be passed along to the didBecomeKeyResponderFrom
(and friends) callbacks to allow them to determine why focus is changing.

This helped us when we wanted to be able to see if the focus was changed by Tab or Shift-Tab, to decide where to set initial focus in our view.
