### PR TITLE
Use CollectionView's layerId rather than guid in contentIndexForLayerId.

### DIFF
--- a/frameworks/desktop/tests/views/collection/layerIdFor.js
+++ b/frameworks/desktop/tests/views/collection/layerIdFor.js
@@ -29,6 +29,19 @@ test("10 index", function() {
   equals(view.contentIndexForLayerId(layerId), 10, 'should parse out idx');
 });
 
+test("with custom layerId", function () {
+  var layerId,
+      contentIndex;
+  view.set('layerId', 'my-custom-layer-id');
+  layerId = view.layerIdFor(10);
+  ok(layerId.indexOf('my-custom-layer-id') === 0, 'index layerId uses custom layerId prefix');
+  contentIndex = view.contentIndexForLayerId(layerId);
+  equals(contentIndex, 10, 'should parse out index from content index layerId');
+
+  contentIndex = view.contentIndexForLayerId('my-custom-layer-id-100');
+  equals(contentIndex, 100, 'should parse out index with custom layerId');
+});
+
 // ..........................................................
 // TEST SPECIAL PARSING CASES
 // 
@@ -62,4 +75,3 @@ test("parse empty string", function() {
 test("parse garbage", function() {
   equals(view.contentIndexForLayerId(234), null, 'should return null');
 });
-

--- a/frameworks/desktop/views/collection.js
+++ b/frameworks/desktop/views/collection.js
@@ -1171,7 +1171,7 @@ SC.CollectionView = SC.View.extend(SC.CollectionViewDelegate, SC.CollectionConte
   */
   layerIdFor: function(idx) {
     var ret = this._TMP_LAYERID;
-    ret[0] = SC.guidFor(this);
+    ret[0] = this.get('layerId');
     ret[1] = idx;
     return ret.join('-');
   },
@@ -1185,8 +1185,7 @@ SC.CollectionView = SC.View.extend(SC.CollectionViewDelegate, SC.CollectionConte
   contentIndexForLayerId: function(id) {
     if (!id || !(id = id.toString())) return null ; // nothing to do
 
-    var base = this._baseLayerId;
-    if (!base) base = this._baseLayerId = SC.guidFor(this)+"-";
+    var base = this.get('layerId') + '-';
 
     // no match
     if ((id.length <= base.length) || (id.indexOf(base) !== 0)) return null ;


### PR DESCRIPTION
Previously, use of guid meant CollectionView's could not have a custom
layerId set.
