### PR TITLE
Handle the scroll event on SC.ScrollView's ContainerView.

### DIFF
--- a/frameworks/desktop/tests/views/scroll/ui.js
+++ b/frameworks/desktop/tests/views/scroll/ui.js
@@ -161,6 +161,22 @@
      equals(container.get('layer').scrollTop, 10, 'scrollTop should be readjust to 10');
    });
 
+  test('ScrollView should adjust horizontalScrollOffset/verticalScrollOffset if browser scrolls', function () {
+    var view = pane.view('basic2'),
+        elem = view.getPath('containerView.layer');
+
+    elem.scrollLeft = 50;
+    elem.scrollTop = 50;
+
+    window.stop();
+
+    SC.Timer.schedule({ target: this, action: function () {
+      equals(view.get('horizontalScrollOffset'), 50, 'horizontalScrollOffset should be adjusted to 50');
+      equals(view.get('verticalScrollOffset'), 50, 'verticalScrollOffset should be adjusted to 50');
+      window.start();
+    }, interval: 200 });
+  });
+
   test('Scroller views of scroll view should have aria attributes set', function() {
     var view = pane.view("aria-attributes"),
         horizontalScrollerView = view.get('horizontalScrollerView'),

--- a/frameworks/desktop/views/scroll.js
+++ b/frameworks/desktop/views/scroll.js
@@ -1899,7 +1899,63 @@ SC.ScrollView = SC.View.extend({
 
     childViews.push(this.containerView = this.createChildView(view, {
       contentView: this.contentView,
-      isScrollContainer: YES
+      isScrollContainer: YES,
+
+      /**
+        Add scroll event handler in order to maintain our scroll position
+        when native browser scroll events occur.
+      */
+      didCreateLayer: function () {
+        var layer = this.get('layer');
+        if (layer) {
+          SC.Event.add(layer, 'scroll', this, this._maintainScroll);
+        }
+      },
+
+      /**
+        Remove scroll event handler.
+      */
+      willDestroyLayer: function () {
+        var layer = this.get('layer');
+        if (layer) {
+          SC.Event.remove(layer, 'scroll', this, this._maintainScroll);
+        }
+      },
+
+      /**
+        Scroll event handler. When we receive a native browser
+        scroll event, update our horizontalScrollOffset and
+        verticalScrollOffset to stay in sync, if the event was
+        not caused by the scroll view.
+
+        @param {UIEvent} evt scroll event
+        @private
+      */
+      _maintainScroll: function (evt) {
+        var jq = this.$(),
+            pv = this.get('parentView'),
+            scrollTop = jq.scrollTop() || 0,
+            scrollLeft = jq.scrollLeft() || 0,
+            horizontalScrollOffset,
+            verticalScrollOffset;
+
+        if (pv) {
+          horizontalScrollOffset = pv.get('horizontalScrollOffset');
+          verticalScrollOffset = pv.get('verticalScrollOffset');
+
+          if (scrollLeft !== horizontalScrollOffset) {
+            // Scroll event was not caused by changing horizontalScrollOffset,
+            // update to match.
+            pv.set('horizontalScrollOffset', scrollLeft);
+          }
+
+          if (scrollTop !== verticalScrollOffset) {
+            // Scroll event was not caused by changing verticalScrollOffset,
+            // update to match.
+            pv.set('verticalScrollOffset', scrollTop);
+          }
+        }
+      }
     }));
 
     // and replace our own contentView...


### PR DESCRIPTION
Update verticalScrollOffset/horizontalScrollOffset if the do not match
scrollTop/scrollLeft on a scroll event. This prevents the ScrollView from
getting out of sync.

We saw this behavior when using text fields inside a scroll view. Chrome would automatically scroll to the text field in some cases, which would cause the ScrollView to become out of sync.
