### PR TITLE
Apply transforms when checking if binding should be synced.

### DIFF
--- a/frameworks/core_foundation/tests/views/pane/child_view.js
+++ b/frameworks/core_foundation/tests/views/pane/child_view.js
@@ -43,12 +43,12 @@ test("SC.Pane should only render once when appended.", function () {
     },
 
     child: SC.View.extend({
-      childValueBinding: SC.Binding.oneWay('.pane.paneValue').transform(
-        function (paneValue) {
-          equals(paneValue, 'bar', "Bound value should be set once to 'bar'");
+      childValueBinding: SC.Binding.oneWay('.pane.paneValue'),
 
-          return paneValue;
-        }),
+      childValueDidChange: function () {
+        equals(this.get('childValue'), 'bar', "Bound value should be set once to 'bar'");
+      }.observes('childValue'),
+
       render: function () {
         ok(true, 'Render was called once on child.');
       }

--- a/frameworks/runtime/tests/system/binding.js
+++ b/frameworks/runtime/tests/system/binding.js
@@ -372,7 +372,8 @@ module("Binding transforms", {
       booleanValue: NO,
       numericValue: 42,
       stringValue: 'forty-two',
-      arrayValue: [4, 2]
+      arrayValue: [4, 2],
+      undefinedValue: undefined
     });
     // temporarily set up two source objects in the SC namespace so we can
     // use property paths to access them
@@ -386,6 +387,24 @@ module("Binding transforms", {
     SC.testControllerB.destroy();
     delete SC.testControllerB;
   }
+});
+
+test('Binding sync when only transformed value has changed', function () {
+  var toObject;
+  SC.run(function () {
+    toObject = SC.Object.create({
+      transformedValue: null,
+      transformedValueBinding: SC.Binding.oneWay('SC.testControllerA.undefinedValue').transform(function (value, binding) {
+        if (value === undefined) {
+          return 'VALUE IS UNDEFINED';
+        } else {
+          return value;
+        }
+      })
+    });
+  });
+
+  equals(toObject.get('transformedValue'), 'VALUE IS UNDEFINED', 'value is undefined, so bound value should be');
 });
 
 test("ALL THE OTHER BINDING TRANSFORMS.");


### PR DESCRIPTION
Previously, sync would only check that the value had changed. Now it will
also apply transforms and see if the transformed value changed.

For example:

``` javascript
A = SC.Object.create({
  abc: undefined
});
B = SC.Object.create({
  def: SC.Binding.oneWay('A.abc').transform(function (value, binding) {
    if (value === undefined) {
      return 'A valid value';
    } else {
      return value;
    }
  })
});
```

In this example, B.def would initially be undefined, not 'A valid value', since the transform would be ignored when determining if the value should be initially synced.
