### PR TITLE
Adds a new SC.LinkView for creating simple programmable HTML anchors.

### DIFF
--- a/frameworks/core_foundation/system/platform.js
+++ b/frameworks/core_foundation/system/platform.js
@@ -4,7 +4,7 @@
 //            Portions ©2008-2011 Apple Inc. All rights reserved.
 // License:   Licensed under MIT license (see license.js)
 // ==========================================================================
-/*global jQuery*/
+
 
 /**
   A constant indicating an unsupported method, property or other.
@@ -96,10 +96,29 @@ SC.platform = SC.Object.create({
 
   /**
     A hash that contains properties that indicate support for new HTML5
+    a attributes.
+
+    For example, to test to see if the `download` attribute is supported,
+    you would verify that `SC.platform.a.download` is true.
+
+    @type Array
+  */
+  a: function () {
+    var elem = document.createElement('a');
+
+    return {
+      download: !!('download' in elem),
+      media: !!('media' in elem),
+      ping: !!('ping' in elem),
+    };
+  }(),
+
+  /**
+    A hash that contains properties that indicate support for new HTML5
     input attributes.
 
-    For example, to test to see if the placeholder attribute is supported,
-    you would verify that SC.platform.input.placeholder is YES.
+    For example, to test to see if the `placeholder` attribute is supported,
+    you would verify that `SC.platform.input.placeholder` is true.
 
     @type Array
   */
@@ -421,9 +440,9 @@ SC.platform = SC.Object.create({
 
     @type Boolean
    */
-  supportsXHR2LoadEndEvent: function() {
+  supportsXHR2LoadEndEvent: function () {
     return (new XMLHttpRequest).onloadend === null;
-  }(),
+  } (),
 
   /**
     Whether the browser supports the orientationchange event.

--- a/frameworks/desktop/tests/views/link_view_test.js
+++ b/frameworks/desktop/tests/views/link_view_test.js
@@ -40,15 +40,14 @@ test("The view renders as expected: Default values", function () {
   // rel: null
   // target: '_blank'
   // type: null
-  // Use SC.empty because different environments return different values ("" vs. undefined)
-  ok(SC.empty(layer.innerText), "The innerText of the layer is empty");
-  ok(SC.empty(layer.download), "The download attribute of the layer is empty");
+  equals(layer.innerText, "", "The innerText of the layer is");
+  if (SC.platform.a.download) { equals(layer.download, "", "The download attribute of the layer is"); }
   equals(layer.href, document.URL + "#", "The href attribute of the layer is");
   equals(layer.hreflang, SC.Locale.currentLocale.language, "The hreflang attribute of the layer is");
-  ok(SC.empty(layer.ping), "The ping attribute of the layer is empty");
-  ok(SC.empty(layer.rel), "The rel attribute of the layer is empty");
+  equals(layer.ping, "", "The ping attribute of the layer is");
+  equals(layer.rel, "", "The rel attribute of the layer is");
   equals(layer.target, "_blank", "The target attribute of the layer is");
-  ok(SC.empty(layer.type), "The type attribute of the layer is empty.");
+  equals(layer.type, "", "The type attribute of the layer is");
 });
 
 test("The view renders as expected: Custom values", function () {
@@ -67,10 +66,10 @@ test("The view renders as expected: Custom values", function () {
   var layer = linkView.get('layer');
 
   equals(layer.innerText, "<div>ABC</div>", "The innerText of the layer is");
-  equals(layer.download, "ABC.txt", "The download attribute of the layer is");
+  if (SC.platform.a.download) { equals(layer.download, "ABC.txt", "The download attribute of the layer is"); }
   equals(layer.href, "http://bogus-site.com/files/abc.txt", "The href attribute of the layer is");
   equals(layer.hreflang, 'fr', "The hreflang attribute of the layer is");
-  equals(layer.ping, "http://logback.com/?clicked=file", "The ping attribute of the layer is");
+  if (SC.platform.a.ping) { equals(layer.ping, "http://logback.com/?clicked=file", "The ping attribute of the layer is"); }
   equals(layer.rel, "author", "The rel attribute of the layer is");
   equals(layer.target, "_self", "The target attribute of the layer is");
   equals(layer.type, "text/plain", "The type attribute of the layer is");
@@ -105,10 +104,10 @@ test("The view updates as expected: Custom values", function () {
   var layer = linkView.get('layer');
 
   equals(layer.innerText, "<div>ABC</div>", "The innerText of the layer is");
-  equals(layer.download, "ABC.txt", "The download attribute of the layer is");
+  if (SC.platform.a.download) { equals(layer.download, "ABC.txt", "The download attribute of the layer is"); }
   equals(layer.href, "http://bogus-site.com/files/abc.txt", "The href attribute of the layer is");
   equals(layer.hreflang, 'fr', "The hreflang attribute of the layer is");
-  equals(layer.ping, "http://logback.com/?clicked=file", "The ping attribute of the layer is");
+  if (SC.platform.a.ping) { equals(layer.ping, "http://logback.com/?clicked=file", "The ping attribute of the layer is"); }
   equals(layer.rel, "author", "The rel attribute of the layer is");
   equals(layer.target, "_self", "The target attribute of the layer is");
   equals(layer.type, "text/plain", "The type attribute of the layer is");
@@ -125,12 +124,12 @@ test("The view updates as expected: Custom values", function () {
   });
 
   equals(layer.innerText, "<div>DEF</div>", "The innerText of the layer is now");
-  equals(layer.download, "DEF.js", "The download attribute of the layer is now");
+  if (SC.platform.a.download) { equals(layer.download, "DEF.js", "The download attribute of the layer is now"); }
   equals(layer.href, "http://bogus-site.com/files/def.js", "The href attribute of the layer is now");
   equals(layer.hreflang, 'es', "The hreflang attribute of the layer is now");
 
   // Some properties don't result in re-rendering and aren't updated for performance reasons.
-  equals(layer.ping, "http://logback.com/?clicked=file", "The ping attribute of the layer is still");
+  if (SC.platform.a.ping) { equals(layer.ping, "http://logback.com/?clicked=file", "The ping attribute of the layer is still"); }
   equals(layer.rel, "author", "The rel attribute of the layer is still");
   equals(layer.target, "_self", "The target attribute of the layer is still");
   equals(layer.type, "text/plain", "The type attribute of the layer is still");

--- a/frameworks/desktop/views/link_view.js
+++ b/frameworks/desktop/views/link_view.js
@@ -48,6 +48,15 @@
 SC.LinkView = SC.View.extend({
 
   /**
+    The WAI-ARIA role for link views.
+
+    @type String
+    @default 'link'
+    @readOnly
+  */
+  ariaRole: 'link',
+
+  /**
     The content of the anchor, such as text or an image.
 
     Note that this will be escaped by default, so any HTML tags will appear
@@ -147,8 +156,9 @@ SC.LinkView = SC.View.extend({
     Note: There are no restrictions on allowed values, but authors are cautioned
     that most file systems have limitations with regard to what punctuation is
     supported in file names, and user agents are likely to adjust file names
-    accordingly.
+    accordingly. Also, support for this attribute varies widely between browsers.
 
+    @see http://caniuse.com/#feat=download
     @see http://www.whatwg.org/specs/web-apps/current-work/multipage/links.html#attr-hyperlink-download
    */
   fileName: null,


### PR DESCRIPTION
Completes #982 .

It's a lot of lines, but most of it is just documentation. Note that some properties are explicitly not observed for changes, nor updated (like `rel`). This is for optimum performance.
