### PR TITLE
Allow maxLength on SC.TextFieldView to be updated.

### DIFF
--- a/frameworks/foundation/tests/views/text_field/ui.js
+++ b/frameworks/foundation/tests/views/text_field/ui.js
@@ -340,6 +340,19 @@
     equals(hint.css('line-height'), "14px", "The line-height of the hint of a non-empty text field should be");
   });
 
+  test("Changing maxLength", function () {
+    var view = pane.view('with value'),
+        input = view.$input();
+
+    equals(input.attr('maxLength'), 5096, 'Max length should begin at')
+
+    SC.run(function () {
+      view.set('maxLength', 1234);
+    });
+
+    equals(input.attr('maxLength'), 1234, 'Max length should now be');
+  });
+
 
   if (!SC.browser.isIE && !SC.platform.input.placeholder) {
     test("Changing value to null -- password field", function () {

--- a/frameworks/foundation/views/text_field.js
+++ b/frameworks/foundation/views/text_field.js
@@ -514,7 +514,8 @@ SC.TextFieldView = SC.FieldView.extend(SC.Editable,
   // SC.Control. It is not a display property directly in SC.Control, because the use of it in
   // SC.Control is only applied to input fields, which very few consumers of SC.Control have.
   // TODO: Pull the disabled attribute updating out of SC.Control.
-  displayProperties: ['isBrowserFocusable', 'formattedHint', 'fieldValue', 'isEditing', 'isEditable', 'isEnabledInPane', 'leftAccessoryView', 'rightAccessoryView', 'isTextArea'],
+  displayProperties: ['isBrowserFocusable', 'formattedHint', 'fieldValue', 'isEditing', 'isEditable', 'isEnabledInPane',
+                      'leftAccessoryView', 'rightAccessoryView', 'isTextArea', 'maxLength'],
 
   createChildViews: function () {
     sc_super();
@@ -753,6 +754,8 @@ SC.TextFieldView = SC.FieldView.extend(SC.Editable,
 
       if (hintOnFocus) context.$('.hint')[0].innerHTML = hint;
       else if (!hintOnFocus) element.placeholder = hint;
+
+      input.attr('maxLength', maxLength);
 
       // IE8 has problems aligning the input text in the center
       // This is a workaround for centering it.


### PR DESCRIPTION
Made maxLength a display property and set it during a render update.
