### PR TITLE
Removed hard-coded prefix for transforms

### DIFF
--- a/frameworks/core_foundation/tests/views/view/layoutStyle.js
+++ b/frameworks/core_foundation/tests/views/view/layoutStyle.js
@@ -65,8 +65,8 @@
     // test
     layoutKeys.forEach(function (key) {
       var testKey;
-      if (key === 'transform') testKey = SC.browser.domPrefix + 'Transform';
-      else if (key === 'transformOrigin') testKey = SC.browser.domPrefix + 'TransformOrigin';
+      if (key === 'transform') testKey = SC.browser.experimentalStyleNameFor('transform');
+      else if (key === 'transformOrigin') testKey = SC.browser.experimentalStyleNameFor('transformOrigin');
       else testKey = key;
       equals(layoutStyle[testKey], no_s[key], "STYLE NO PARENT %@".fmt(key));
     });
@@ -93,8 +93,8 @@
     // test again
     layoutKeys.forEach(function (key) {
       var testKey;
-      if (key === 'transform') testKey = SC.browser.domPrefix + 'Transform';
-      else if (key === 'transformOrigin') testKey = SC.browser.domPrefix + 'TransformOrigin';
+      if (key === 'transform') testKey = SC.browser.experimentalStyleNameFor('transform');
+      else if (key === 'transformOrigin') testKey = SC.browser.experimentalStyleNameFor('transformOrigin');
       else testKey = key;
       equals(layoutStyle[testKey], with_s[key], "STYLE W/ PARENT %@".fmt(key));
     });
@@ -659,7 +659,7 @@
   });
 
   function transformFor(view) {
-    return view.get('layer').style[SC.browser.domPrefix + 'Transform'];
+    return view.get('layer').style[SC.browser.experimentalStyleNameFor('transform')];
   }
 
   test("layout {rotateX}", function () {

--- a/frameworks/core_foundation/views/view/layout_style.js
+++ b/frameworks/core_foundation/views/view/layout_style.js
@@ -105,7 +105,7 @@ SC.View.LayoutStyleCalculator = {
       style[transformAttribute] = transforms.length > 0 ? transforms.join(' ') : null;
 
       // Transform origin.
-      var transformOriginAttribute = SC.browser.experimentalStyleNameFor('TransformOrigin'),
+      var transformOriginAttribute = SC.browser.experimentalStyleNameFor('transformOrigin'),
         originX = layout.transformOriginX,
         originY = layout.transformOriginY;
       if (originX == null && originY == null) {


### PR DESCRIPTION
Previously some unit tests were hardcoded to always add the domPrefix for transform tests (e.g., "Webkit" prefix added to "Transform").

This is bad because starting from Chrome 36, the prefix is removed. So, this patch removes the hard coded prefixing and uses SC.browser.experimentalStyleNameFor instead.
