### PR TITLE
Fixes crash when mouse exits destroyed view

### DIFF
--- a/frameworks/core_foundation/system/root_responder.js
+++ b/frameworks/core_foundation/system/root_responder.js
@@ -2228,7 +2228,7 @@ SC.RootResponder = SC.Object.extend(
         // responding chain
         for (loc = 0, len = lh.length; loc < len; loc++) {
           view = lh[loc];
-          if (nh.indexOf(view) === -1) {
+          if (nh.indexOf(view) === -1 && !view.isDestroyed) {
             view.tryToPerform('mouseExited', evt);
           }
         }


### PR DESCRIPTION
When the root responder would call mouseExisted on views that the mouse was exiting, it would not check if the view had been destroyed. Since the root responder keeps a private list of views that the mouse is over, this check is necessary to ensure the view is still valid.
