### PR TITLE
ScrollView - Replace positioning of content using scrollTop/left by marginTop/Left

### DIFF
--- a/frameworks/desktop/tests/views/scroll/ui.js
+++ b/frameworks/desktop/tests/views/scroll/ui.js
@@ -104,12 +104,12 @@
     view.scrollTo(0,100);
     SC.RunLoop.begin().end();
     var elem = view.get('containerView').$()[0];
-    equals(elem.scrollTop, 100, 'vertical scrolling should adjust scrollTop of container view');
+    equals(elem.style.marginTop, "-100px", 'vertical scrolling should adjust marginTop of container view');
 
     view.scrollTo(50,0);
     SC.RunLoop.begin().end();
     elem = view.get('containerView').$()[0];
-    equals(elem.scrollLeft, 50, 'horizontal scrolling should adjust scrollLeft of container view');
+    equals(elem.style.marginLeft, "-50px", 'horizontal scrolling should adjust marginLeft of container view');
   });
 
   test("basic3", function() {
@@ -149,16 +149,16 @@
       equals(scroller.$()[0].style.bottom,'16px', 'should have style.bottom of scroller as ');
     });
 
-   test('ScrollView should readjust scrollTop/scrollLeft if layer changes', function() {
+   test('ScrollView should readjust marginTop/marginLeft if layer changes', function() {
      var view = pane.view('basic2'), cv = view.get('contentView'), container = view.get('containerView') ;
      view.scrollTo(10, 10);
      SC.RunLoop.begin().end();
-     equals(container.get('layer').scrollLeft, 10, 'precond - scrollLeft is set to 10');
-     equals(container.get('layer').scrollTop, 10, 'precond- scrollTop is set to 10');
+     equals(container.get('layer').style.marginLeft, "-10px", 'precond - marginLeft is set to -10px');
+     equals(container.get('layer').style.marginTop, "-10px", 'precond- marginTop is set to -10px');
      cv.replaceLayer();
      SC.RunLoop.begin().end();
-     equals(container.get('layer').scrollLeft, 10, 'scrollLeft should be readjusted to 10');
-     equals(container.get('layer').scrollTop, 10, 'scrollTop should be readjust to 10');
+     equals(container.get('layer').style.marginLeft, "-10px", 'marginLeft should be readjusted to -10px');
+     equals(container.get('layer').style.marginTop, "-10px", 'marginTop should be readjust to -10px');
    });
 
   test('Scroller views of scroll view should have aria attributes set', function() {

--- a/frameworks/desktop/views/scroll.js
+++ b/frameworks/desktop/views/scroll.js
@@ -2307,7 +2307,7 @@ SC.ScrollView = SC.View.extend({
 
   /** @private
     If we redraw after the initial render, we need to make sure that we reset
-    the scrollTop/scrollLeft properties on the content view.  This ensures
+    the marginTop/marginLeft properties on the content view.  This ensures
     that, for example, the scroll views displays correctly when switching
     views out in a ContainerView.
   */
@@ -2433,7 +2433,7 @@ SC.ScrollView = SC.View.extend({
 
   /** @private
     If the layer of the content view changes, we need to readjust the
-    scrollTop and scrollLeft properties on the new DOM element.
+    marginTop and marginLeft properties on the new DOM element.
   */
   contentViewLayerDidChange: function () {
     // Invalidate these cached values, as they're no longer valid
@@ -2461,8 +2461,8 @@ SC.ScrollView = SC.View.extend({
   }.observes('verticalScrollOffset'),
 
   /** @private
-    Called at the end of the run loop to actually adjust the scrollTop
-    and scrollLeft properties of the container view.
+    Called at the end of the run loop to actually adjust the marginTop
+    and marginLeft properties of the container view.
   */
   adjustElementScroll: function () {
     var container = this.get('containerView'),
@@ -2471,7 +2471,7 @@ SC.ScrollView = SC.View.extend({
         horizontalScrollOffset = this.get('horizontalScrollOffset');
 
     // We notify the content view that its frame property has changed
-    // before we actually update the scrollTop/scrollLeft properties.
+    // before we actually update the marginTop/marginLeft properties.
     // This gives views that use incremental rendering a chance to render
     // newly-appearing elements before they come into view.
     if (content) {
@@ -2484,12 +2484,12 @@ SC.ScrollView = SC.View.extend({
 
       if (container) {
         if (verticalScrollOffset !== this._verticalScrollOffset) {
-          container.scrollTop = verticalScrollOffset;
+          container.style.marginTop = -verticalScrollOffset + "px";
           this._verticalScrollOffset = verticalScrollOffset;
         }
 
         if (horizontalScrollOffset !== this._horizontalScrollOffset) {
-          container.scrollLeft = horizontalScrollOffset;
+          container.style.marginLeft = -horizontalScrollOffset + "px";
           this._horizontalScrollOffset = horizontalScrollOffset;
         }
       }


### PR DESCRIPTION
This fixes a bug with SC.ScrollView getting out of sync because browsers are automatically scrolling to make visible the focused text fields.
Steps to reproduce:
1. Create a scroll view containing a long form
2. Focus on the 1st text field
3. Scroll down so the text field gets hidden
4. Change the focus to another application
5. Go back to the browser
6. After a while, the browser scrolls up so the text field gets visible
7. The scroll views is out of sync

This is not a SC specific problem, and the behavior is consistent, tested on FF and WebKit. Any comments/testing/hint is welcome. Thanks
