### PR TITLE
Notify the text field selection changed in the next run loop.

### DIFF
--- a/frameworks/foundation/views/text_field.js
+++ b/frameworks/foundation/views/text_field.js
@@ -1288,7 +1288,8 @@ SC.TextFieldView = SC.FieldView.extend(SC.Editable,
     // The caret/selection could have moved.  In some browsers, though, the
     // element's values won't be updated until after this event is finished
     // processing.
-    this.notifyPropertyChange('selection');
+    this.invokeNext(this._textField_selectionDidChange);
+
     return sc_super();
   },
 


### PR DESCRIPTION
We ran into a case where the input element's selection had not changed
yet when mouseUp was called. This lead to text being incorrectly wiped
out when the previous selection spanned multiple characters.
