### PR TITLE
Fixes proper use of sc_static in desktop/tests/views/segmented/ui.js test

### DIFF
--- a/frameworks/desktop/tests/views/segmented/ui.js
+++ b/frameworks/desktop/tests/views/segmented/ui.js
@@ -10,7 +10,7 @@
 
 var pane;
 (function () {
-  var iconURL = sc_static("sproutcore-32.png");
+  var iconURL = sc_static("foundation:sproutcore-32.png");
 
   pane = SC.ControlTestPane.design()
 


### PR DESCRIPTION
Clarifies where exactly to load the referred image from.
