### PR TITLE
Un-deprecates rotate.

### DIFF
--- a/frameworks/core_foundation/tests/views/view/layoutDidChange.js
+++ b/frameworks/core_foundation/tests/views/view/layoutDidChange.js
@@ -193,29 +193,47 @@ test("is invoked on parentView if no layoutView whenever layout property changes
   view.destroy();
 });
 
-test("sets rotateZ when rotate is set", function () {
-  var view = SC.View.create({});
+test("proxies rotate to rotateZ when 3D transforms are supported", function () {
+  // Retain CSS support information so we can return to it.
+  var actualSupport = SC.platform.get('supportsCSS3DTransforms'),
+      view;
 
+  // YES SUPPORT
+  SC.platform.set('supportsCSS3DTransforms', YES);
+  view = SC.View.create();
   SC.run(function () {
     view.set('layout', { rotate: 45 });
   });
-
+  equals(view.get('layout').rotate, undefined, "should clear rotate");
   equals(view.get('layout').rotateZ, 45, "should set rotateZ");
-
   // Clean up.
   view.destroy();
+
+  // NO SUPPORT
+  SC.platform.set('supportsCSS3DTransforms', NO);
+  view = SC.View.create();
+  SC.run(function () {
+    view.set('layout', { rotate: 45 });
+  });
+  equals(view.get('layout').rotate, 45, "should retain rotate");
+  equals(view.get('layout').rotateZ, undefined, "should not set rotateZ");
+  // Clean up.
+  view.destroy();
+
+  // Clean up bigger picture.
+  SC.platform.set('supportsCSS3DTransforms', actualSupport);
 });
 
-test("rotateZ overrides rotate", function () {
+test("rotateZ and rotate together", function () {
   var view = SC.View.create({});
 
   SC.run(function () {
     view.set('layout', { rotate: 45, rotateZ: 90 });
   });
 
-  equals(view.get('layout').rotate, undefined, "should clear rotate for rotateX");
+  equals(view.get('layout').rotate, 45, "if both rotate and rotateZ values are present, both should be retained; rotate is");
 
-  equals(view.get('layout').rotateZ, 90, "rotateZ value should hold firm in the face of a rotate value");
+  equals(view.get('layout').rotateZ, 90, "if both rotate and rotateZ values are present, both should be retained; rotateZ is");
 
   // Clean up.
   view.destroy();

--- a/frameworks/core_foundation/views/view/layout.js
+++ b/frameworks/core_foundation/views/view/layout.js
@@ -1016,13 +1016,10 @@ SC.View.reopen(
 
     // Handle old style rotation.
     if (!SC.none(currentLayout.rotate)) {
-      //@if (debug)
-      SC.Logger.warn('Developer Warning: Please set rotateZ instead of rotate.');
-      //@endif
-      if (SC.none(currentLayout.rotateZ)) {
+      if (SC.none(currentLayout.rotateZ) && SC.platform.get('supportsCSS3DTransforms')) {
         currentLayout.rotateZ = currentLayout.rotate;
+        delete currentLayout.rotate;
       }
-      delete currentLayout.rotate;
     }
 
     // Optimize notifications depending on if we resized or just moved.

--- a/frameworks/core_foundation/views/view/layout_style.js
+++ b/frameworks/core_foundation/views/view/layout_style.js
@@ -11,8 +11,9 @@ sc_require('views/view/animation');
 SC.CSS_TRANSFORM_NAMES = ['rotateX', 'rotateY', 'rotateZ', 'scale'];
 
 SC.CSS_TRANSFORM_MAP = {
-  rotate: function () {
-    return null;
+  rotate: function (val) {
+    if (SC.typeOf(val) === SC.T_NUMBER) { val += 'deg'; }
+    return 'rotate(' + val + ')';
   },
 
   rotateX: function (val) {


### PR DESCRIPTION
For use in browsers without 3D support (i.e. IE9). In supporting browsers, rotate is proxied to rotateZ for performance. (If rotate and rotateZ are both supplied, both are applied.)
