### PR TITLE
SC.Request should not try to SC.json.encode the body when isJSON is true...

### DIFF
--- a/frameworks/ajax/system/request.js
+++ b/frameworks/ajax/system/request.js
@@ -157,7 +157,9 @@ SC.Request = SC.Object.extend(SC.Copyable, SC.Freezable,
   encodedBody: function() {
     // TODO: support XML
     var ret = this.get('body');
-    if (ret && this.get('isJSON')) { ret = SC.json.encode(ret); }
+    if (ret && this.get('isJSON') && SC.typeOf(ret) !== SC.T_STRING) { 
+      ret = SC.json.encode(ret); 
+    }
     return ret;
   }.property('isJSON', 'isXML', 'body').cacheable(),
 

--- a/frameworks/ajax/tests/system/request.js
+++ b/frameworks/ajax/tests/system/request.js
@@ -126,6 +126,7 @@ test("Default properties are correct for different types of requests.", function
   req3 = SC.Request.putUrl(url, xmlBody).xml()._prep();
   req4 = SC.Request.patchUrl(url, jsonBody).json()._prep();
   req5 = SC.Request.deleteUrl(url)._prep();
+  req6 = SC.Request.putUrl(url, JSON.stringify(jsonBody)).json()._prep();
 
   ok(req1.get('isJSON'), 'req1 should have isJSON true');
   ok(!req1.get('isXML'), 'req1 should have isXML false');
@@ -142,6 +143,8 @@ test("Default properties are correct for different types of requests.", function
   ok(!req5.get('isJSON'), 'req5 should have isJSON false');
   ok(!req5.get('isXML'), 'req5 should have isXML false');
   equals(req5.header('Content-Type'), undefined, 'req5 should have Content-Type header as');
+  ok(req6.get('isJSON'), 'req6 should have isJSON true');
+  equals(req6.get('encodedBody'), JSON.stringify(jsonBody), 'req6 should not try to re-encode a string');
 });
 
 test("Test Asynchronous GET Request", function() {


### PR DESCRIPTION
... and the provided body is already a string. 

SC.Request doesn't make overriding the way an object is JSON.encode()'d very easy without monkeypatching. 
A use case for overriding the default way of encoding is when a server requires stringified functions in the JSON request. It is much easier to be able to custom encode it and still send it as JSON. However, the current implementation will re-encode the provided string, causing double escaping, and consequently invalid JSON.
