### PR TITLE
Reimplement itemValueKey support to SC.MenuPane

### DIFF
--- a/frameworks/desktop/panes/menu.js
+++ b/frameworks/desktop/panes/menu.js
@@ -321,6 +321,15 @@ SC.MenuPane = SC.PickerPane.extend(
   itemTitleKey: 'title',
 
   /**
+    The name of the property that contains the value for each item.
+
+    @type String
+    @default "value"
+    @commonTask Menu Item Properties
+  */
+  itemValueKey: 'value',
+
+  /**
     The name of the property that contains the tooltip for each item.
 
     @type String
@@ -476,7 +485,7 @@ SC.MenuPane = SC.PickerPane.extend(
     @isReadOnly
     @type Array
   */
-  menuItemKeys: ['itemTitleKey', 'itemToolTipKey', 'itemIsEnabledKey', 'itemIconKey', 'itemSeparatorKey', 'itemActionKey', 'itemCheckboxKey', 'itemShortCutKey', 'itemHeightKey', 'itemSubMenuKey', 'itemKeyEquivalentKey', 'itemTargetKey', 'itemLayerIdKey'],
+  menuItemKeys: ['itemTitleKey', 'itemValueKey', 'itemToolTipKey', 'itemIsEnabledKey', 'itemIconKey', 'itemSeparatorKey', 'itemActionKey', 'itemCheckboxKey', 'itemShortCutKey', 'itemHeightKey', 'itemSubMenuKey', 'itemKeyEquivalentKey', 'itemTargetKey', 'itemLayerIdKey'],
 
   // ..........................................................
   // DEFAULT PROPERTIES

--- a/frameworks/desktop/tests/panes/menu/ui.js
+++ b/frameworks/desktop/tests/panes/menu/ui.js
@@ -448,6 +448,7 @@ test('Menu item keys', function () {
   items = [
     {
       TheTitle: 'Menu item',
+      TheValue: 1,
       TheToolTip: 'Menu tooltip',
       AmIEnabled: false,
       MyIcon: 'folder',
@@ -462,6 +463,7 @@ test('Menu item keys', function () {
       layout: { width: 200 },
       items: items,
       itemTitleKey: 'TheTitle',
+      itemValueKey: 'TheValue',
       itemToolTipKey: 'TheToolTip',
       itemIsEnabledKey: 'AmIEnabled',
       itemIconKey: 'MyIcon',
@@ -475,9 +477,11 @@ test('Menu item keys', function () {
   menuItem = menuPane.get('menuItemViews')[0];
 
   equals(menuItem.get('title'), 'Menu item');
+  equals(menuItem.get('value'), 1);
   equals(menuItem.get('toolTip'), 'Menu tooltip');
   equals(menuItem.get('isEnabled'), false);
   equals(menuItem.get('icon'), 'folder');
   ok(SC.kindOf(menuItem.get('subMenu'), SC.MenuPane));
   equals(menuItem.get('isSeparator'), false);
+  clickOn(menuPane);
 });

--- a/frameworks/desktop/views/menu_item.js
+++ b/frameworks/desktop/views/menu_item.js
@@ -96,6 +96,15 @@ SC.MenuItemView = SC.View.extend(SC.ContentDisplay,
   }.property().cacheable(),
 
   /**
+    The value from the content property.
+
+    @type String
+  */
+  value: function () {
+    return this.getContentProperty('itemValueKey');
+  }.property().cacheable(),
+
+  /**
     The tooltip from the content property.
 
     @type String
@@ -759,6 +768,7 @@ SC.MenuItemView = SC.View.extend(SC.ContentDisplay,
 */
 SC.MenuItemView._contentPropertyToMenuItemPropertyMapping = {
   itemTitleKey: 'title',
+  itemValueKey: 'value',
   itemToolTipKey: 'toolTip',
   itemIsEnabledKey: 'isEnabled',
   itemIconKey: 'icon',


### PR DESCRIPTION
`itemValueKey` support has been recently removed from SC.MenuPane https://github.com/sproutcore/sproutcore/pull/1225. 

But I may be useful for an app to access the value of the `selectedItem`.
