### PR TITLE
Ensure computeLayout returns sane values when itemsPerRow is 0 (plus test)

### DIFF
--- a/frameworks/desktop/tests/views/grid/methods.js
+++ b/frameworks/desktop/tests/views/grid/methods.js
@@ -4,7 +4,7 @@
 //            portions copyright @2011 Apple Inc.
 // License:   Licensed under MIT license (see license.js)
 // ==========================================================================
-/*global module, test, same, CoreTest */
+/*global module, test, same, ok, CoreTest */
 
 
 var scrollView, view;
@@ -166,4 +166,14 @@ test("Adjusts layout when the itemsPerRow changes.", function () {
   SC.RunLoop.end();
 
   view.adjustLayout.expect(2);
+});
+
+test("computeLayout gives back sane values when itemsPerRow is 0", function () {
+  SC.RunLoop.begin();
+  view.adjust('width', 0);
+  SC.RunLoop.end();
+
+  var layout = view.computeLayout();
+  var minHeightIsInfinity = layout.minHeight === Infinity;
+  ok(!minHeightIsInfinity, "SC.GridView#computeLayout should not have Infinity as value for layout.minHeight");
 });

--- a/frameworks/desktop/views/grid.js
+++ b/frameworks/desktop/views/grid.js
@@ -139,9 +139,12 @@ SC.GridView = SC.ListView.extend(
     var ret = this._cachedLayoutHash;
     if (!ret) ret = this._cachedLayoutHash = {};
 
-    // set minHeight
-    ret.minHeight = rows * rowHeight;
-    this.set('calculatedHeight', ret.minHeight);
+    // set minHeight, but only if there are items,
+    // as rows equals Infinity when itemsPerRow is 0
+    if (itemsPerRow > 0) {
+      ret.minHeight = rows * rowHeight;
+      this.set('calculatedHeight', ret.minHeight);
+    }
     return ret;
   },
 


### PR DESCRIPTION
Fixes a bug on SC.GridView where the minHeight layout property would be Infinite when itemsPerRow would be 0.
