### PR TITLE
Live update subMenu if its content changed

### DIFF
--- a/frameworks/desktop/tests/panes/menu/ui.js
+++ b/frameworks/desktop/tests/panes/menu/ui.js
@@ -281,6 +281,11 @@ test('Basic Submenus', function () {
     menuItem.get('content').set('subMenu', [{ title: 'Submenu item 3' }]);
     subMenu = menuItem.get('subMenu');
     equals(subMenu.getPath('items.length'), 1, 'submenus should have 1 item');
+
+    smallMenu.destroy();
+    ok(smallMenu.get('isDestroyed'), 'smallMenu should be destroyed');
+    ok(menuItem.get('isDestroyed'), 'menuItem should be destroyed');
+    ok(subMenu.get('isDestroyed'), 'submenus should be destroyed');
     start();
   }, 150);
 });

--- a/frameworks/desktop/views/menu_item.js
+++ b/frameworks/desktop/views/menu_item.js
@@ -228,6 +228,17 @@ SC.MenuItemView = SC.View.extend(SC.ContentDisplay,
     this.contentDidChange();
   },
 
+  /** @private */
+  destroy: function () {
+    sc_super();
+
+    var subMenu = this._subMenu;
+    if (subMenu) {
+      subMenu.destroy();
+      this._subMenu = null;
+    }
+  },
+
   /** SC.MenuItemView is not able to update itself in place at this time. */
   // TODO: add update: support.
   isReusable: false,


### PR DESCRIPTION
More than updating the subMenu if its content changed while it is visible, it also fixes an issue where the subMenu where never removed.
This PR also takes care to destroy subMenus when their parents menus are destroy.
