### PR TITLE
Adds horizontal layout support to SC.GridView

### DIFF
--- a/frameworks/desktop/views/grid.js
+++ b/frameworks/desktop/views/grid.js
@@ -70,6 +70,26 @@ SC.GridView = SC.ListView.extend(
   exampleView: SC.LabelView,
 
   /**
+    Determines the layout direction of the rows of items, either vertically or
+    horizontally. Possible values:
+
+      - SC.LAYOUT_HORIZONTAL
+      - SC.LAYOUT_VERTICAL
+
+    @type String
+    @default SC.LAYOUT_VERTICAL
+  */
+  layoutDirection: SC.LAYOUT_VERTICAL,
+
+  /**
+    Stretch the items to fill the frame
+
+    @type Boolean
+    @default false
+  */
+  stretchItems: false,
+
+  /**
     Possible values:
 
       - SC.HORIZONTAL_ORIENTATION
@@ -82,38 +102,161 @@ SC.GridView = SC.ListView.extend(
 
   /** @private */
   itemsPerRow: function () {
-    var frameWidth = this.get('frame').width,
-      columnWidth = this.get('columnWidth') || 0;
+    var frameWidth = this.get('clippingFrame').width,
+      columnWidth = this.get('columnWidth') || 48,
+      itemsPerRow = Math.floor(frameWidth / columnWidth);
 
-    return (columnWidth < 1) ? 1 : Math.floor(frameWidth / columnWidth);
+    return itemsPerRow ? itemsPerRow : 1;
   }.property('columnWidth', '_frameWidth').cacheable(),
 
+  /** @private */
+  rowCount: function () {
+    var length = this.get('length'),
+      itemsPerRow = this.get('itemsPerRow') ;
+
+    return Math.ceil(length / itemsPerRow);
+  }.property('itemsPerRow', 'length').cacheable(),
+
+  /** @private */
+  itemsPerColumn: function() {
+    var frameHeight = this.get('clippingFrame').height,
+      rowHeight = this.get('rowHeight') || 64,
+      itemsPerColumn = Math.floor(frameHeight / rowHeight);
+
+    return itemsPerColumn ? itemsPerColumn : 1;
+  }.property('rowHeight', '_frameHeight').cacheable(),
+
+  /** @private */
+  columnCount: function () {
+    var length = this.get('length') || 0,
+      itemsPerColumn = this.get('itemsPerColumn');
+      
+    return Math.ceil(length / itemsPerColumn);
+  }.property('itemsPerColumn', 'length').cacheable(),
+
+  /** @private */
+  itemsPerPage: function() {
+    return this.get('itemsPerRow') * this.get('itemsPerColumn');
+  }.property('itemsPerRow', 'itemsPerColumn').cacheable(),
+
+  /** @private */
+  pageCount: function() {
+    return Math.ceil(this.get('length') / this.get('itemsPerPage'));
+  }.property('length', 'itemsPerPage').cacheable(),
+
+  /** @private */
+  stretchedColumnWidth: function() {
+    var frame = this.get('clippingFrame'),
+      frameWidth = frame.width,
+      itemsPerRow = this.get('itemsPerRow');
+
+    return (frameWidth / itemsPerRow) || 64;
+  }.property('_frameWidth', 'itemsPerRow').cacheable(),
+
+  /** @private */
+  stretchedRowHeight: function() {
+    var frame = this.get('clippingFrame'),
+      frameHeight = frame.height,
+      itemsPerColumn = this.get('itemsPerColumn');
+      
+    return (frameHeight / itemsPerColumn) || 48;
+  }.property('_frameHeight', 'itemsPerColumn').cacheable(),
+
+  /** @private */
+  realColumnWidth: function() {
+    var stretchItems = this.get('stretchItems');
+    
+    if (stretchItems) {
+      return this.get('stretchedColumnWidth');
+    }
+    else {
+      return this.get('columnWidth') || 64;
+    }
+  }.property('stretchItems', 'stretchedColumnWidth', 'columnWidth').cacheable(),
+
+  /** @private */
+  realRowHeight: function() {
+    var stretchItems = this.get('stretchItems');
+    
+    if (stretchItems) {
+      return this.get('stretchedRowHeight');
+    }
+    else {
+      return this.get('rowHeight') || 48;
+    }
+  }.property('stretchItems', 'stretchedRowHeight', 'rowHeight').cacheable(),
+
   /** @private
-    Find the contentIndexes to display in the passed rect. Note that we
-    ignore the width of the rect passed since we need to have a single
-    contiguous range.
+    Find the contentIndexes to display in the passed rect.
   */
   contentIndexesInRect: function (rect) {
-    var rowHeight = this.get('rowHeight') || 48,
-        itemsPerRow = this.get('itemsPerRow'),
-        min = Math.floor(SC.minY(rect) / rowHeight) * itemsPerRow,
-        max = Math.ceil(SC.maxY(rect) / rowHeight) * itemsPerRow;
+    var layoutDirection = this.get('layoutDirection'),
+      itemsPerRow = this.get('itemsPerRow'),
+      itemsPerColumn = this.get('itemsPerColumn'),
+      rowHeight, columnWidth,
+      min, max;
+
+    if (layoutDirection === SC.LAYOUT_HORIZONTAL) {
+      columnWidth = this.get('realColumnWidth');
+      min = Math.floor(SC.minX(rect) / columnWidth) * itemsPerColumn;
+      max = Math.ceil(SC.maxX(rect) / columnWidth) * itemsPerColumn;
+    }
+    else {
+      rowHeight = this.get('realRowHeight');
+      min = Math.floor(SC.minY(rect) / rowHeight) * itemsPerRow;
+      max = Math.ceil(SC.maxY(rect) / rowHeight) * itemsPerRow;
+    }
+
     return SC.IndexSet.create(min, max - min);
   },
 
   /** @private */
   layoutForContentIndex: function (contentIndex) {
-    var rowHeight = this.get('rowHeight') || 48,
-        frameWidth = this.get('frame').width,
-        itemsPerRow = this.get('itemsPerRow'),
-        columnWidth = Math.floor(frameWidth / itemsPerRow),
-        row = Math.floor(contentIndex / itemsPerRow),
-        col = contentIndex - (itemsPerRow * row);
+    var layoutDirection = this.get('layoutDirection'),
+      stretchItems = this.get('stretchItems'),
+      itemsPerRow = this.get('itemsPerRow'),
+      itemsPerColumn = this.get('itemsPerColumn'),
+      rowHeight = this.get('rowHeight') || 48,
+      columnWidth = this.get('columnWidth') || 64,
+      row, col;
 
     // If the frame is not ready, then just return an empty layout.
     // Otherwise, NaN will be entered into layout values.
-    if (frameWidth === 0 || itemsPerRow === 0) {
+    if (this.get('clippingFrame').width === 0) {
       return {};
+    }
+
+    if (layoutDirection === SC.LAYOUT_HORIZONTAL) {
+      if (stretchItems) {
+        columnWidth = this.get('stretchedColumnWidth');
+      }
+
+      rowHeight = this.get('stretchedRowHeight');
+      col = Math.floor(contentIndex / itemsPerColumn);
+      row = contentIndex - (itemsPerColumn * col);
+
+      /*
+      Initial work to make the item layout horizontally. This should also
+      be done in contentIndexesInRect.
+
+      var itemsPerPage = this.get('itemsPerPage'),
+        page = Math.floor(contentIndex / itemsPerPage);
+
+      row = Math.floor(contentIndex / itemsPerRow);
+      col = contentIndex - (itemsPerRow * row);
+
+      row -= page * itemsPerColumn;
+      col += page * itemsPerRow;
+      */
+    }
+    else {
+      if (stretchItems) {
+        rowHeight = this.get('stretchedRowHeight');
+      }
+      
+      columnWidth = this.get('stretchedColumnWidth');
+      row = Math.floor(contentIndex / itemsPerRow);
+      col = contentIndex - (itemsPerRow * row);
     }
 
     return {
@@ -129,19 +272,26 @@ SC.GridView = SC.ListView.extend(
     of the list view.
   */
   computeLayout: function () {
-    var content = this.get('content'),
-      count = (content) ? content.get('length') : 0,
-      rowHeight = this.get('rowHeight') || 48,
-      itemsPerRow = this.get('itemsPerRow'),
-      rows = Math.ceil(count / itemsPerRow);
+    var layoutDirection = this.get('layoutDirection');
 
     // use this cached layout hash to avoid allocing memory...
     var ret = this._cachedLayoutHash;
     if (!ret) ret = this._cachedLayoutHash = {};
 
-    // set minHeight
-    ret.minHeight = rows * rowHeight;
-    this.set('calculatedHeight', ret.minHeight);
+    // Support both vertical and horizontal grids.
+    if (layoutDirection === SC.LAYOUT_HORIZONTAL) {
+      var columnWidth = this.get('realColumnWidth'),
+        columnCount = this.get('columnCount');
+
+      ret.minWidth = columnCount * columnWidth;
+      this.set('calculatedWidth', ret.minWidth);
+    } else {
+      var rowHeight = this.get('realRowHeight'),
+        rowCount = this.get('rowCount');
+
+      ret.minHeight = rowCount * rowHeight;
+      this.set('calculatedHeight', ret.minHeight);
+    }
     return ret;
   },
 
@@ -261,42 +411,52 @@ SC.GridView = SC.ListView.extend(
 
     Update all of their layouts if necessary.
   */
-  _gv_frameDidChange: function () {
-    var frame = this.get('frame'),
+  viewDidResize: function () {
+    var frame = this.get('clippingFrame'),
       lastFrameWidth = this._lastFrameWidth,
-      width = frame.width;
+      width = frame.width,
+      lastFrameHeight = this._lastFrameHeight,
+      height = frame.height,
+      frameDidChange = true;
 
     // A change to the width of the frame is the only variable that
     // alters the layout of item views and our computed layout.
     if (!SC.none(lastFrameWidth) && width !== lastFrameWidth) {
-      var itemView,
-        nowShowing = this.get('nowShowing');
-
       // Internal property used to indicate a possible itemsPerRow change.  This
       // is better than having itemsPerRow dependent on frame which changes frequently.
       this.set('_frameWidth', width);
-
-      // Only loop through the now showing indexes, if the content was sparsely
-      // loaded we would inadvertently load all the content.
-      nowShowing.forEach(function (idx) {
-        itemView = this.itemViewForContentIndex(idx);
-        itemView.adjust(this.layoutForContentIndex(idx));
-      }, this);
+      frameDidChange = true;
     }
-
     this._lastFrameWidth = width;
-  }.observes('frame'),
 
-  /** @private Recompute our layout if itemsPerRow actually changes. */
-  _gv_itemsPerRowDidChange: function () {
-    var itemsPerRow = this.get('itemsPerRow'),
-      lastItemsPerRow = this._lastItemsPerRow || 0;
+    // A change to the height of the frame is the only variable that
+    // alters the layout of item views and our computed layout.
+    if (!SC.none(lastFrameHeight) && height !== lastFrameHeight) {
+      // Internal property used to indicate a possible itemsPerColumn change.  This
+      // is better than having itemsPerColumn dependent on frame which changes frequently.
+      this.set('_frameHeight', height);
+      frameDidChange = true;
+    }
+    this._lastFrameHeight = height;
 
-    if (itemsPerRow !== lastItemsPerRow) {
-      this.invokeOnce('adjustLayout');
+    if (frameDidChange) {
+      this.invokeLast('adjustChildLayouts');
+      this.invokeLast('adjustLayout');
     }
 
-    this._lastItemsPerRow = itemsPerRow;
-  }.observes('itemsPerRow')
+    sc_super();
+  },
+
+  /** @private */
+  adjustChildLayouts: function () {
+    var nowShowing = this.get('nowShowing');
+
+    // Only loop through the now showing indexes, if the content is sparsely
+    // loaded we could inadvertently trigger reloading unneeded content.
+    nowShowing.forEach(function(idx) {
+      var itemView = this.itemViewForContentIndex(idx);
+      itemView.adjust(this.layoutForContentIndex(idx));
+    }, this);
+  },
 
 });


### PR DESCRIPTION
Here is my initial work to add horizontal layout direction support to SC.GridView. There is still some work to do (unit tests mainly)...

I'm publishing it because there is some stuff to discuss. I needed horizontal support to make the same kind of view that you can see on the iOS home screen. For this, we need a notion of page. I already added two properties about that `itemsPerPage` and `pageCount` but, I now think that we should create a new kind of view which will extend `SC.GridView`. This view could be call `SC.SlideView` or `SC.GridPageView` or something else. 
I think we need a new kind of view because items should be layout per row and not by column like it is the case in the current implement when `layoutDirection` is set to `SC.LAYOUT_HORIZONTAL`. We will also need public methods like `pageIndex`, `showPreviousPage`, `showNextPage`...

So first, I'd like to know if you're agree with me that we need a new kind of view. And if so, we need to agree on a name.
