### PR TITLE
Do not make the SC.PickerPane#anchorElement cacheable

### DIFF
--- a/frameworks/desktop/panes/picker.js
+++ b/frameworks/desktop/panes/picker.js
@@ -316,7 +316,7 @@ SC.PickerPane = SC.PalettePane.extend(
         return value;
       }
     }
-  }.property().cacheable(),
+  }.property(),
 
   /** @private
     anchor rect calculated by computeAnchorRect from init popup


### PR DESCRIPTION
Otherwise, if we popup a pane from different anchor, it will always be attached to the same anchor.
