### PR TITLE
Made check for pending animations in SC.View's adjust() method safer

### DIFF
--- a/frameworks/core_foundation/views/view/layout.js
+++ b/frameworks/core_foundation/views/view/layout.js
@@ -171,7 +171,7 @@ SC.View.reopen(
           animateLayout[key] = value;
         }
 
-        if (this._pendingAnimations[key]) {
+        if (this._pendingAnimations && this._pendingAnimations[key]) {
           // Adjusting a value that was previously about to be animated cancels the animation.
           delete this._pendingAnimations[key];
         }


### PR DESCRIPTION
In IE 9, it can happen that SC.View's `adjust()` method will try to access a property of `_pendingAnimations` while `_pendingAnimations` is set to `null`.

![screen shot 2014-10-13 at 11 26 43](https://cloud.githubusercontent.com/assets/446063/4611596/e1112cfa-52bc-11e4-8082-5d64431e7e64.png)

I fixed this by checking for `_pendingAnimations` first.

Let me know if this makes sense for you.
