### PR TITLE
Re-introduce SC.Error#throw where throw has been renamed $throw to prevent a crash with YUI

### DIFF
--- a/frameworks/core_foundation/panes/manipulation.js
+++ b/frameworks/core_foundation/panes/manipulation.js
@@ -31,6 +31,6 @@ SC.Pane.reopen(
     @returns {void}
   */
   removeFromParent: function() {
-    throw SC.Error.desc("SC.Pane cannot be removed from its parent, since it's the root. Did you mean remove()?");
+    SC.$throw("SC.Pane cannot be removed from its parent, since it's the root. Did you mean remove()?");
   }
 });

--- a/frameworks/core_foundation/system/selection_set.js
+++ b/frameworks/core_foundation/system/selection_set.js
@@ -158,7 +158,7 @@ SC.SelectionSet = SC.Object.extend(SC.Enumerable, SC.Freezable, SC.Copyable,
   */
   add: function(source, start, length) {
 
-    if (this.isFrozen) throw SC.FROZEN_ERROR ;
+    if (this.isFrozen) throw new Error(SC.FROZEN_ERROR);
 
     var sets, len, idx, set, oldlen, newlen, setlen, objects;
 
@@ -218,7 +218,7 @@ SC.SelectionSet = SC.Object.extend(SC.Enumerable, SC.Freezable, SC.Copyable,
   */
   remove: function(source, start, length) {
 
-    if (this.isFrozen) throw SC.FROZEN_ERROR ;
+    if (this.isFrozen) throw new Error(SC.FROZEN_ERROR);
 
     var sets, len, idx, i, set, oldlen, newlen, setlen, objects, object;
 
@@ -536,7 +536,7 @@ SC.SelectionSet = SC.Object.extend(SC.Enumerable, SC.Freezable, SC.Copyable,
     @returns {SC.SelectionSet}
   */
   clear: function() {
-    if (this.isFrozen) throw SC.FROZEN_ERROR;
+    if (this.isFrozen) throw new Error(SC.FROZEN_ERROR);
     if (this._sets) this._sets.length = 0 ; // truncate
     if (this._objects) this._objects = null;
 

--- a/frameworks/core_foundation/tests/views/pane/append_remove.js
+++ b/frameworks/core_foundation/tests/views/pane/append_remove.js
@@ -192,7 +192,7 @@ test("removeFromParent throws an exception", function() {
     pane.append();
     pane.removeFromParent();
   } catch(e) {
-    exceptionCaught = (e instanceof SC.Error);
+    exceptionCaught = true;
   } finally {
     pane.remove();
   }

--- a/frameworks/core_foundation/tests/views/view/layoutStyle.js
+++ b/frameworks/core_foundation/tests/views/view/layoutStyle.js
@@ -919,7 +919,7 @@
 
 
   test("layout {centerX, centerY, width:auto, height:auto}", function () {
-    var error = 'NONE';
+    var error = null;
     var layout = { centerX: 0.1, centerY: 0.1, width: 'auto', height: 'auto' };
 
     try {
@@ -931,7 +931,7 @@
       error = e;
     }
 
-    equals(SC.T_ERROR, SC.typeOf(error), 'Layout style functions should throw an ' +
+    ok(error, 'Layout style functions should throw an ' +
                                            'error if centerx/y and width/height are set at the same time ' + error);
   });
 

--- a/frameworks/core_foundation/views/view/layout.js
+++ b/frameworks/core_foundation/views/view/layout.js
@@ -1168,7 +1168,7 @@ SC.View.reopen(
     sc_super();
 
     if (!this.isDestroyed) {
-      // Our frame may change once we've been removed from a parent.
+    // Our frame may change once we've been removed from a parent.
       this._checkForResize();
 
       // Notify all of our descendents that our parent has changed. They will update their `pane` value for one.

--- a/frameworks/core_foundation/views/view/layout_style.js
+++ b/frameworks/core_foundation/views/view/layout_style.js
@@ -158,9 +158,7 @@ SC.View.LayoutStyleCalculator = {
 
   // handles the case where you do width:auto or height:auto and are not using "staticLayout"
   _invalidAutoValue: function (view, property) {
-    var error = SC.Error.desc("%@.layout() you cannot use %@:auto if staticLayout is disabled".fmt(view, property), "%@".fmt(view), -1);
-    SC.Logger.error(error.toString());
-    throw error;
+    SC.$throw("%@.layout() you cannot use %@:auto if staticLayout is disabled".fmt(view, property), "%@".fmt(view), -1);
   },
 
   /** @private */

--- a/frameworks/datastore/data_sources/fixtures.js
+++ b/frameworks/datastore/data_sources/fixtures.js
@@ -67,11 +67,11 @@ SC.FixturesDataSource = SC.DataSource.extend(
 
     // can only handle local queries out of the box
     if (query.get('location') !== SC.Query.LOCAL) {
-      throw SC.$error('SC.Fixture data source can only fetch local queries');
+      SC.$throw('SC.Fixture data source can only fetch local queries');
     }
 
     if (!query.get('recordType') && !query.get('recordTypes')) {
-      throw SC.$error('SC.Fixture data source can only fetch queries with one or more record types');
+      SC.$throw('SC.Fixture data source can only fetch queries with one or more record types');
     }
 
     if (this.get('simulateRemoteResponse')) {

--- a/frameworks/datastore/models/record.js
+++ b/frameworks/datastore/models/record.js
@@ -542,7 +542,7 @@ SC.Record = SC.Object.extend(
         attrs;
 
     attrs = store.readEditableDataHash(storeKey);
-    if (!attrs) throw SC.Record.BAD_STATE_ERROR;
+    if (!attrs) SC.Record.BAD_STATE_ERROR.$throw();
 
     // if value is the same, do not flag record as dirty
     if (value !== attrs[key]) {
@@ -1346,7 +1346,7 @@ SC.Record.mixin( /** @scope SC.Record */ {
     @constant
     @type SC.Error
   */
-  BAD_STATE_ERROR:     SC.$error("Internal Inconsistency"),
+  BAD_STATE_ERROR: SC.$error("Internal Inconsistency"),
 
   /**
     Error for when you try to create a new record that already exists.
@@ -1364,7 +1364,7 @@ SC.Record.mixin( /** @scope SC.Record */ {
     @constant
     @type SC.Error
   */
-  NOT_FOUND_ERROR:     SC.$error("Not found "),
+  NOT_FOUND_ERROR: SC.$error("Not found "),
 
   /**
     Error for when you try to modify a record that is currently busy
@@ -1373,7 +1373,7 @@ SC.Record.mixin( /** @scope SC.Record */ {
     @constant
     @type SC.Error
   */
-  BUSY_ERROR:          SC.$error("Busy"),
+  BUSY_ERROR: SC.$error("Busy"),
 
   /**
     Generic unknown record error
@@ -1382,7 +1382,7 @@ SC.Record.mixin( /** @scope SC.Record */ {
     @constant
     @type SC.Error
   */
-  GENERIC_ERROR:       SC.$error("Generic Error"),
+  GENERIC_ERROR: SC.$error("Generic Error"),
 
   /**
     If true, then searches for records of this type will return subclass instances. For example:

--- a/frameworks/datastore/system/nested_store.js
+++ b/frameworks/datastore/system/nested_store.js
@@ -237,7 +237,7 @@ SC.NestedStore = SC.Store.extend(
     var nRecords, nr, sk;
     // requires a pstore to reset
     var parentStore = this.get('parentStore');
-    if (!parentStore) throw SC.Store.NO_PARENT_STORE_ERROR;
+    if (!parentStore) SC.Store.NO_PARENT_STORE_ERROR.$throw();
 
     // inherit data store from parent store.
     this.dataHashes = SC.beget(parentStore.dataHashes);
@@ -297,7 +297,7 @@ SC.NestedStore = SC.Store.extend(
 
   /** @private - adapt for nested store */
   chainAutonomousStore: function(attrs, newStoreClass) {
-    throw SC.Store.NESTED_STORE_UNSUPPORTED_ERROR;
+    SC.Store.NESTED_STORE_UNSUPPORTED_ERROR.$throw();
   },
 
   // ..........................................................
@@ -549,7 +549,7 @@ SC.NestedStore = SC.Store.extend(
         // status hierarchy, so even though lower stores would complete the
         // retrieval, the upper layers would never inherit the new statuses.
         if (status & K.DIRTY) {
-          throw SC.Store.NESTED_STORE_RETRIEVE_DIRTY_ERROR;
+          SC.Store.NESTED_STORE_RETRIEVE_DIRTY_ERROR.$throw();
         }
         else {
           // Not dirty?  Then abandon any status we had set (to re-establish
@@ -594,7 +594,7 @@ SC.NestedStore = SC.Store.extend(
     if( this.get( "dataSource" ) )
       return sc_super();
     else
-      throw SC.Store.NESTED_STORE_UNSUPPORTED_ERROR;
+      SC.Store.NESTED_STORE_UNSUPPORTED_ERROR.$throw();
   },
 
   /** @private - adapt for nested store */
@@ -602,7 +602,7 @@ SC.NestedStore = SC.Store.extend(
     if( this.get( "dataSource" ) )
       return sc_super();
     else
-      throw SC.Store.NESTED_STORE_UNSUPPORTED_ERROR;
+      SC.Store.NESTED_STORE_UNSUPPORTED_ERROR.$throw();
   },
 
   /** @private - adapt for nested store */
@@ -610,7 +610,7 @@ SC.NestedStore = SC.Store.extend(
     if( this.get( "dataSource" ) )
       return sc_super();
     else
-      throw SC.Store.NESTED_STORE_UNSUPPORTED_ERROR;
+      SC.Store.NESTED_STORE_UNSUPPORTED_ERROR.$throw();
   },
 
   /** @private - adapt for nested store */
@@ -618,7 +618,7 @@ SC.NestedStore = SC.Store.extend(
     if( this.get( "dataSource" ) )
       return sc_super();
     else
-      throw SC.Store.NESTED_STORE_UNSUPPORTED_ERROR;
+      SC.Store.NESTED_STORE_UNSUPPORTED_ERROR.$throw();
   },
 
   // ..........................................................
@@ -631,7 +631,7 @@ SC.NestedStore = SC.Store.extend(
     if( this.get( "dataSource" ) )
       return sc_super();
     else
-      throw SC.Store.NESTED_STORE_UNSUPPORTED_ERROR;
+      SC.Store.NESTED_STORE_UNSUPPORTED_ERROR.$throw();
   },
 
   /** @private - adapt for nested store */
@@ -639,7 +639,7 @@ SC.NestedStore = SC.Store.extend(
     if( this.get( "dataSource" ) )
       return sc_super();
     else
-      throw SC.Store.NESTED_STORE_UNSUPPORTED_ERROR;
+      SC.Store.NESTED_STORE_UNSUPPORTED_ERROR.$throw();
   },
 
   /** @private - adapt for nested store */
@@ -647,7 +647,7 @@ SC.NestedStore = SC.Store.extend(
     if( this.get( "dataSource" ) )
       return sc_super();
     else
-      throw SC.Store.NESTED_STORE_UNSUPPORTED_ERROR;
+      SC.Store.NESTED_STORE_UNSUPPORTED_ERROR.$throw();
   },
 
   /** @private - adapt for nested store */
@@ -655,7 +655,7 @@ SC.NestedStore = SC.Store.extend(
     if( this.get( "dataSource" ) )
       return sc_super();
     else
-      throw SC.Store.NESTED_STORE_UNSUPPORTED_ERROR;
+      SC.Store.NESTED_STORE_UNSUPPORTED_ERROR.$throw();
   },
 
   // ..........................................................
@@ -667,7 +667,7 @@ SC.NestedStore = SC.Store.extend(
     if( this.get( "dataSource" ) )
       return sc_super();
     else
-      throw SC.Store.NESTED_STORE_UNSUPPORTED_ERROR;
+      SC.Store.NESTED_STORE_UNSUPPORTED_ERROR.$throw();
   },
 
   /** @private - adapt for nested store */
@@ -675,7 +675,7 @@ SC.NestedStore = SC.Store.extend(
     if( this.get( "dataSource" ) )
       return sc_super();
     else
-      throw SC.Store.NESTED_STORE_UNSUPPORTED_ERROR;
+      SC.Store.NESTED_STORE_UNSUPPORTED_ERROR.$throw();
   },
 
   /** @private - adapt for nested store */
@@ -683,7 +683,7 @@ SC.NestedStore = SC.Store.extend(
     if( this.get( "dataSource" ) )
       return sc_super();
     else
-      throw SC.Store.NESTED_STORE_UNSUPPORTED_ERROR;
+      SC.Store.NESTED_STORE_UNSUPPORTED_ERROR.$throw();
   }
 
 }) ;

--- a/frameworks/datastore/system/query.js
+++ b/frameworks/datastore/system/query.js
@@ -455,7 +455,7 @@ SC.Query = SC.Object.extend(SC.Copyable, SC.Freezable,
     this._order = this.buildOrder(this.get('orderBy'));
 
     this._isReady = !!tree && !tree.error;
-    if (tree && tree.error) throw tree.error;
+    if (tree && tree.error) SC.$throw(tree.error);
     return this._isReady;
   },
 

--- a/frameworks/datastore/system/record_array.js
+++ b/frameworks/datastore/system/record_array.js
@@ -272,7 +272,7 @@ SC.RecordArray = SC.Object.extend(SC.Enumerable, SC.Array,
 
     if (!storeKeys) throw new Error("Unable to edit an SC.RecordArray that does not have its storeKeys property set.");
 
-    if (!this.get('isEditable')) throw SC.RecordArray.NOT_EDITABLE;
+    if (!this.get('isEditable')) SC.RecordArray.NOT_EDITABLE.$throw();
 
     // map to store keys
     keys = [] ;
@@ -814,7 +814,7 @@ SC.RecordArray.mixin(/** @scope SC.RecordArray.prototype */{
 
     @type SC.Error
   */
-  NOT_EDITABLE: SC.Error.desc("SC.RecordArray is not editable"),
+  NOT_EDITABLE: SC.$error("SC.RecordArray is not editable"),
 
   /**
     Number of milliseconds to allow a query matching to run for. If this number

--- a/frameworks/datastore/system/store.js
+++ b/frameworks/datastore/system/store.js
@@ -56,7 +56,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
   /**
     This type of store is not nested.
 
-    @default NO
+		@default NO
     @type Boolean
   */
   isNested: NO,
@@ -64,7 +64,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
   /**
     This type of store is not nested.
 
-    @default NO
+		@default NO
     @type Boolean
   */
   commitRecordsAutomatically: NO,
@@ -84,13 +84,13 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {SC.DataSource|String} dataSource the data source
     @returns {SC.Store} receiver
   */
-  from: function(dataSource) {
+  from: function (dataSource) {
     this.set('dataSource', dataSource);
     return this ;
   },
 
   // lazily convert data source to real object
-  _getDataSource: function() {
+  _getDataSource: function () {
     var ret = this.get('dataSource');
     if (typeof ret === SC.T_STRING) {
       ret = SC.requiredObjectForPropertyPath(ret);
@@ -108,7 +108,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {SC.DataSource...} dataSource one or more data source arguments
     @returns {SC.Store} receiver
   */
-  cascade: function(dataSource) {
+  cascade: function (dataSource) {
     var dataSources = SC.A(arguments) ;
     dataSource = SC.CascadeDataSource.create({
       dataSources: dataSources
@@ -134,7 +134,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {Class} newStoreClass optional the class of the newly-created nested store (defaults to SC.NestedStore)
     @returns {SC.NestedStore} new nested store chained to receiver
   */
-  chain: function(attrs, newStoreClass) {
+  chain: function (attrs, newStoreClass) {
     if (!attrs) attrs = {};
     attrs.parentStore = this;
 
@@ -211,7 +211,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
 
     @returns {SC.Store} receiver
   */
-  willDestroyNestedStore: function(nestedStore) {
+  willDestroyNestedStore: function (nestedStore) {
     if (this.nestedStores) {
       this.nestedStores.removeObject(nestedStore);
     }
@@ -225,7 +225,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {SC.Store} store store instance
     @returns {Boolean} YES if belongs
   */
-  hasNestedStore: function(store) {
+  hasNestedStore: function (store) {
     while(store && (store !== this)) store = store.get('parentStore');
     return store === this ;
   },
@@ -332,13 +332,13 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
   // to use these methods.
 
   /**
-    Returns the current edit status of a store key.  May be one of
+    Returns the current edit status of a storekey.  May be one of
     `EDITABLE` or `LOCKED`.  Used mostly for unit testing.
 
     @param {Number} storeKey the store key
     @returns {Number} edit status
   */
-  storeKeyEditState: function(storeKey) {
+  storeKeyEditState: function (storeKey) {
     var editables = this.editables;
     return (editables && editables[storeKey]) ? SC.Store.EDITABLE : SC.Store.LOCKED ;
   },
@@ -351,7 +351,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {Number} storeKey key to retrieve
     @returns {Hash} data hash or null
   */
-  readDataHash: function(storeKey) {
+  readDataHash: function (storeKey) {
     return this.dataHashes[storeKey];
   },
 
@@ -366,7 +366,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {Number} storeKey the store key to retrieve
     @returns {Hash} the attributes hash
   */
-  readEditableDataHash: function(storeKey) {
+  readEditableDataHash: function (storeKey) {
     // read the value - if there is no hash just return; nothing to do
     var ret = this.dataHashes[storeKey];
     if (!ret) return ret ; // nothing to do.
@@ -391,7 +391,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {String} propertyName property to read
     @returns {Object} editable property value
   */
-  readEditableProperty: function(storeKey, propertyName) {
+  readEditableProperty: function (storeKey, propertyName) {
     var hash      = this.readEditableDataHash(storeKey),
         editables = this.editables[storeKey], // get editable info...
         ret       = hash[propertyName];
@@ -427,7 +427,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {String} status the new hash status
     @returns {SC.Store} receiver
   */
-  writeDataHash: function(storeKey, hash, status) {
+  writeDataHash: function (storeKey, hash, status) {
 
     // update dataHashes and optionally status.
     if (hash) this.dataHashes[storeKey] = hash;
@@ -455,23 +455,23 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
               childHash = hash[childPath[0]];
             }
 
-            if (!processedPaths[hash[childPath[0]]]){
+            if(!processedPaths[hash[childPath[0]]]){
                 // update data hash: required to push changes beyond the first nesting level
                 this.writeDataHash(key, childHash, status);
             }
 
-            if (childPath.length > 1 && ! processedPaths[hash[childPath[0]]]) {
-              // save it so that we don't processed it over and over
-              processedPaths[hash[childPath[0]]]=true;
+            if(childPath.length > 1 && ! processedPaths[hash[childPath[0]]]) {
+                // save it so that we don't processed it over and over
+                processedPaths[hash[childPath[0]]]=true;
 
-              // force fetching of all children records by invoking the children_attribute wrapper code
-              // and then interating the list in an empty loop
-              // Ugly, but there's basically no other way to do it at the moment, other than
-              // leaving this broken as it was before
-              var that = this;
-              this.invokeLast(function() {
-                that.records[storeKey].get(childPath[0]).forEach(function (it) {});
-              });
+                // force fetching of all children records by invoking the children_attribute wrapper code
+                // and then interating the list in an empty loop
+                // Ugly, but there's basically no other way to do it at the moment, other than
+                // leaving this broken as it was before
+                var that = this;
+                this.invokeLast(function(){
+                  that.records[storeKey].get(childPath[0]).forEach(function(it){});
+                });
             }
           } else {
             this.writeDataHash(key, null, status);
@@ -480,7 +480,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
       }
     }
 
-    return this ;
+    return this;
   },
 
   /**
@@ -500,7 +500,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {String} status optional new status
     @returns {SC.Store} receiver
   */
-  removeDataHash: function(storeKey, status) {
+  removeDataHash: function (storeKey, status) {
      // don't use delete -- that will allow parent dataHash to come through
     this.dataHashes[storeKey] = null;
     this.statuses[storeKey] = status || SC.Record.EMPTY;
@@ -519,7 +519,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {Number} storeKey the store key
     @returns {Number} status
   */
-  readStatus: function(storeKey) {
+  readStatus: function (storeKey) {
     // use readDataHash to handle optimistic locking.  this could be inlined
     // but for now this minimized copy-and-paste code.
     this.readDataHash(storeKey);
@@ -534,7 +534,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {Number} storeKey the store key
     @returns {Number} status
   */
-  peekStatus: function(storeKey) {
+  peekStatus: function (storeKey) {
     return this.statuses[storeKey] || SC.Record.EMPTY;
   },
 
@@ -548,7 +548,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {SC.Error} error optional error object
     @returns {SC.Store} receiver
   */
-  writeStatus: function(storeKey, newStatus) {
+  writeStatus: function (storeKey, newStatus) {
     var that = this,
         ret;
     // use writeDataHash for now to handle optimistic lock.  maximize code
@@ -572,7 +572,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {String} key that changed (optional)
     @returns {SC.Store} receiver
   */
-  dataHashDidChange: function(storeKeys, rev, statusOnly, key) {
+  dataHashDidChange: function (storeKeys, rev, statusOnly, key) {
     // update the revision for storeKey.  Use generateStoreKey() because that
     // guarantees a universally (to this store hierarchy anyway) unique
     // key value.
@@ -593,7 +593,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
       this.revisions[storeKey] = rev;
       this._notifyRecordPropertyChange(storeKey, statusOnly, key);
 
-      this._propagateToChildren(storeKey, function(storeKey){
+      this._propagateToChildren(storeKey, function (storeKey) {
         that.dataHashDidChange(storeKey, null, statusOnly, key);
       });
     }
@@ -605,7 +605,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     Will push all changes to a the recordPropertyChanges property
     and execute `flush()` once at the end of the runloop.
   */
-  _notifyRecordPropertyChange: function(storeKey, statusOnly, key) {
+  _notifyRecordPropertyChange: function (storeKey, statusOnly, key) {
 
     var records      = this.records,
         nestedStores = this.get('nestedStores'),
@@ -626,7 +626,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
 
       } else if (status & SC.Record.BUSY) {
         // make sure nested store does not have any changes before resetting
-        if(store.get('hasChanges')) throw K.CHAIN_CONFLICT_ERROR;
+        if(store.get('hasChanges')) K.CHAIN_CONFLICT_ERROR.$throw();
         store.reset();
       }
     }
@@ -686,7 +686,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
 
     @returns {SC.Store} receiver
   */
-  flush: function() {
+  flush: function () {
     if (!this.recordPropertyChanges) return this;
 
     var changes              = this.recordPropertyChanges,
@@ -697,7 +697,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
         recordTypes = SC.CoreSet.create(),
         rec, recordType, statusOnly, keys;
 
-    storeKeys.forEach(function(storeKey) {
+    storeKeys.forEach(function (storeKey) {
       if (records.contains(storeKey)) {
         statusOnly = hasDataChanges.contains(storeKey) ? NO : YES;
         rec = this.records[storeKey];
@@ -736,12 +736,12 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
 
     @returns {SC.Store} receiver
   */
-  reset: function() {
+  reset: function () {
 
     // create a new empty data store
-    this.dataHashes = {} ;
-    this.revisions  = {} ;
-    this.statuses   = {} ;
+    this.dataHashes = {};
+    this.revisions = {};
+    this.statuses = {};
     this.records = {};
     this.childRecords = {};
     this.parentRecords = {};
@@ -792,7 +792,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {Boolean} force
     @returns {SC.Store} receiver
   */
-  commitChangesFromNestedStore: function(nestedStore, changes, force) {
+  commitChangesFromNestedStore: function (nestedStore, changes, force) {
     // first, check for optimistic locking problems
     if (!force) this._verifyLockRevisions(changes, nestedStore.locks);
 
@@ -856,7 +856,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {SC.Set} locks the locks to verify
     @returns {SC.Store} receiver
   */
-  _verifyLockRevisions: function(changes, locks) {
+  _verifyLockRevisions: function (changes, locks) {
     var len = changes.length, revs = this.revisions, i, storeKey, lock, rev ;
     if (locks && revs) {
       for(i=0;i<len;i++) {
@@ -867,7 +867,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
         // if the save revision for the item does not match the current rev
         // the someone has changed the data hash in this store and we have
         // a conflict.
-        if (lock < rev) throw SC.Store.CHAIN_CONFLICT_ERROR;
+        if (lock < rev) SC.Store.CHAIN_CONFLICT_ERROR.$throw();
       }
     }
     return this ;
@@ -938,7 +938,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {String} id the id to load
     @returns {SC.Record} record instance or null
   */
-  find: function(recordType, id) {
+  find: function (recordType, id) {
 
     // if recordType is passed as string, find object
     if (SC.typeOf(recordType)===SC.T_STRING) {
@@ -960,7 +960,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
   },
 
   /** @private */
-  _findQuery: function(query, createIfNeeded, refreshIfNew) {
+  _findQuery: function (query, createIfNeeded, refreshIfNew) {
 
     // lookup the local RecordArray for this query.
     var cache = this._scst_recordArraysByQuery,
@@ -986,7 +986,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
   },
 
   /** @private */
-  _findRecord: function(recordType, id) {
+  _findRecord: function (recordType, id) {
 
     var storeKey ;
 
@@ -1022,7 +1022,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {SC.RecordArray} recordArray the record array
     @returns {SC.Store} receiver
   */
-  recordArrayWillDestroy: function(recordArray) {
+  recordArrayWillDestroy: function (recordArray) {
     var cache = this._scst_recordArraysByQuery,
         set   = this.get('recordArrays');
 
@@ -1042,7 +1042,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {SC.Query} query the record array query to refresh
     @returns {SC.Store} receiver
   */
-  refreshQuery: function(query) {
+  refreshQuery: function (query) {
     if (!query) throw new Error("refreshQuery() requires a query");
 
     var cache    = this._scst_recordArraysByQuery,
@@ -1065,11 +1065,11 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {SC.Set} recordTypes
     @returns {SC.Store} receiver
   */
-  _notifyRecordArrays: function(storeKeys, recordTypes) {
+  _notifyRecordArrays: function (storeKeys, recordTypes) {
     var recordArrays = this.get('recordArrays');
     if (!recordArrays) return this;
 
-    recordArrays.forEach(function(recArray) {
+    recordArrays.forEach(function (recArray) {
       if (recArray) recArray.storeDidChangeStoreKeys(storeKeys, recordTypes);
     }, this);
 
@@ -1090,7 +1090,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {SC.Record} recordType the record type
     @returns {SC.Array} array instance - usually SC.RecordArray
   */
-  recordsFor: function(recordType) {
+  recordsFor: function (recordType) {
     var storeKeys     = [],
         storeKeysById = recordType.storeKeysById(),
         id, storeKey, ret;
@@ -1128,7 +1128,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {Number} storeKey The storeKey for the dataHash.
     @returns {SC.Record} Returns a record instance.
   */
-  materializeRecord: function(storeKey) {
+  materializeRecord: function (storeKey) {
     var records = this.records,
       ret, recordType, attrs;
 
@@ -1208,7 +1208,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
 
     @returns {SC.Record} Returns the created record
   */
-  createRecord: function(recordType, dataHash, id) {
+  createRecord: function (recordType, dataHash, id) {
     var primaryKey, prototype, storeKey, status, K = SC.Record, changelog, defaultVal, ret;
 
     //initialize dataHash if necessary
@@ -1237,11 +1237,11 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     if ((status & K.BUSY)  ||
         (status & K.READY) ||
         (status === K.DESTROYED_DIRTY)) {
-      throw id ? K.RECORD_EXISTS_ERROR : K.BAD_STATE_ERROR;
+      (id ? K.RECORD_EXISTS_ERROR : K.BAD_STATE_ERROR).$throw();
 
     // allow error or destroyed state only with id
     } else if (!id && (status===SC.DESTROYED_CLEAN || status===SC.ERROR)) {
-      throw K.BAD_STATE_ERROR;
+      K.BAD_STATE_ERROR.$throw();
     }
 
     // Store the dataHash and setup initial status.
@@ -1316,7 +1316,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {Array} ids (optional) ids to assign to records
     @returns {Array} array of materialized record instances.
   */
-  createRecords: function(recordTypes, dataHashes, ids) {
+  createRecords: function (recordTypes, dataHashes, ids) {
     var ret = [], recordType, id, isArray, len = dataHashes.length, idx ;
     isArray = SC.typeOf(recordTypes) === SC.T_ARRAY;
     if (!isArray) recordType = recordTypes;
@@ -1340,7 +1340,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {Number} storeKey (optional) if passed, ignores recordType and id
     @returns {SC.Store} receiver
   */
-  unloadRecord: function(recordType, id, storeKey, newStatus) {
+  unloadRecord: function (recordType, id, storeKey, newStatus) {
     if (storeKey === undefined) storeKey = recordType.storeKeyFor(id);
     var status = this.readStatus(storeKey), K = SC.Record;
     newStatus = newStatus || K.EMPTY;
@@ -1350,7 +1350,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
 
     // error out if empty
     } else if (status & K.BUSY) {
-      throw K.BUSY_ERROR ;
+      K.BUSY_ERROR.$throw();
 
     // otherwise, destroy in dirty state
     } else status = newStatus ;
@@ -1395,7 +1395,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {Array} storeKeys (optional) store keys to unload
     @returns {SC.Store} receiver
   */
-  unloadRecords: function(recordTypes, ids, storeKeys, newStatus) {
+  unloadRecords: function (recordTypes, ids, storeKeys, newStatus) {
     var len, isArray, idx, id, recordType, storeKey;
 
     if (storeKeys === undefined) {
@@ -1438,7 +1438,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {Number} storeKey (optional) if passed, ignores recordType and id
     @returns {SC.Store} receiver
   */
-  destroyRecord: function(recordType, id, storeKey) {
+  destroyRecord: function (recordType, id, storeKey) {
     if (storeKey === undefined) storeKey = recordType.storeKeyFor(id);
     var status = this.readStatus(storeKey), changelog, K = SC.Record;
 
@@ -1448,11 +1448,11 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
 
     // error out if empty
     } else if (status === K.EMPTY) {
-      throw K.NOT_FOUND_ERROR ;
+      K.NOT_FOUND_ERROR.$throw();
 
     // error out if busy
     } else if (status & K.BUSY) {
-      throw K.BUSY_ERROR ;
+      K.BUSY_ERROR.$throw();
 
     // if new status, destroy in clean state
     } else if (status === K.READY_NEW) {
@@ -1480,7 +1480,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     }
 
     var that = this;
-    this._propagateToChildren(storeKey, function(storeKey){
+    this._propagateToChildren(storeKey, function (storeKey){
       that.destroyRecord(null, null, storeKey);
     });
 
@@ -1507,7 +1507,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {Array} storeKeys (optional) store keys to destroy
     @returns {SC.Store} receiver
   */
-  destroyRecords: function(recordTypes, ids, storeKeys) {
+  destroyRecords: function (recordTypes, ids, storeKeys) {
     var len, isArray, idx, id, recordType, storeKey;
     if(storeKeys===undefined){
       len = ids.length;
@@ -1531,7 +1531,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
   /**
     register a Child Record to the parent
   */
-  registerChildToParent: function(parentStoreKey, childStoreKey, path){
+  registerChildToParent: function (parentStoreKey, childStoreKey, path) {
     var parentRecords, childRecords, oldPk, oldChildren, pkRef;
 
     // Check the child to see if it has a parent
@@ -1540,7 +1540,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
 
     // first rid of the old parent
     oldPk = childRecords[childStoreKey];
-    if (oldPk){
+    if (oldPk) {
       oldChildren = parentRecords[oldPk];
       delete oldChildren[childStoreKey];
       // this.recordDidChange(null, null, oldPk, key);
@@ -1562,7 +1562,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
 
     @param {Number} childStoreKey storeKey to unregister
   */
-  unregisterChildFromParent: function(childStoreKey) {
+  unregisterChildFromParent: function (childStoreKey) {
     var childRecords, oldPk, storeKeys,
         recordType = this.recordTypeFor(childStoreKey),
         id = this.idFor(childStoreKey),
@@ -1581,16 +1581,16 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     }
 
     if (childRecords) {
-      // Remove the parent's connection to the child.  This doesn't remove the
-      // parent store key from the cache of parent store keys if the parent
-      // no longer has any other registered children, because the amount of effort
-      // to determine that would not be worth the miniscule memory savings.
-      oldPk = childRecords[childStoreKey];
-      if (oldPk) {
-        delete this.parentRecords[oldPk][childStoreKey];
-      }
+    // Remove the parent's connection to the child.  This doesn't remove the
+    // parent store key from the cache of parent store keys if the parent
+    // no longer has any other registered children, because the amount of effort
+    // to determine that would not be worth the miniscule memory savings.
+    oldPk = childRecords[childStoreKey];
+    if (oldPk) {
+      delete this.parentRecords[oldPk][childStoreKey];
+    }
 
-      delete childRecords[childStoreKey];
+    delete childRecords[childStoreKey];
     }
 
     // 4. from the cache of ids
@@ -1607,7 +1607,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
   /**
     materialize the parent when passing in a store key for the child
   */
-  materializeParentRecord: function(childStoreKey){
+  materializeParentRecord: function (childStoreKey){
     var pk, crs;
     if (SC.none(childStoreKey)) return null;
     crs = this.childRecords;
@@ -1620,9 +1620,9 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
   /**
     function for retrieving a parent record key
 
-    @param {Number} storeKey The store key of the parent
+		@param {Number} storeKey The store key of the parent
   */
-  parentStoreKeyExists: function(storeKey){
+  parentStoreKeyExists: function (storeKey){
     if (SC.none(storeKey)) return ;
     var crs = this.childRecords || {};
     return crs[storeKey];
@@ -1631,7 +1631,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
   /**
     function that propagates a function call to all children
   */
-  _propagateToChildren: function(storeKey, func){
+  _propagateToChildren: function (storeKey, func) {
     // Handle all the child Records
     if ( SC.none(this.parentRecords) ) return;
     var children = this.parentRecords[storeKey] || {};
@@ -1655,19 +1655,19 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {Boolean} if the change is to statusOnly (optional)
     @returns {SC.Store} receiver
   */
-  recordDidChange: function(recordType, id, storeKey, key, statusOnly) {
+  recordDidChange: function (recordType, id, storeKey, key, statusOnly) {
     if (storeKey === undefined) storeKey = recordType.storeKeyFor(id);
     var status = this.readStatus(storeKey), changelog, K = SC.Record;
 
     // BUSY_LOADING, BUSY_CREATING, BUSY_COMMITTING, BUSY_REFRESH_CLEAN
     // BUSY_REFRESH_DIRTY, BUSY_DESTROYING
     if (status & K.BUSY) {
-      throw K.BUSY_ERROR ;
+      K.BUSY_ERROR.$throw();
 
     // if record is not in ready state, then it is not found.
     // ERROR, EMPTY, DESTROYED_CLEAN, DESTROYED_DIRTY
     } else if (!(status & K.READY)) {
-      throw K.NOT_FOUND_ERROR ;
+      K.NOT_FOUND_ERROR.$throw();
 
     // otherwise, make new status READY_DIRTY unless new.
     // K.READY_CLEAN, K.READY_DIRTY, ignore K.READY_NEW
@@ -1712,7 +1712,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {Array} storeKeys (optional) store keys to destroy
     @returns {SC.Store} receiver
   */
-  recordsDidChange: function(recordTypes, ids, storeKeys) {
+  recordsDidChange: function (recordTypes, ids, storeKeys) {
      var len, isArray, idx, id, recordType, storeKey;
       if(storeKeys===undefined){
         len = ids.length;
@@ -1752,7 +1752,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {Function|Array} callback function or array of functions
     @returns {Array} storeKeys to be retrieved
   */
-  retrieveRecords: function(recordTypes, ids, storeKeys, isRefresh, callbacks) {
+  retrieveRecords: function (recordTypes, ids, storeKeys, isRefresh, callbacks) {
 
     var source  = this._getDataSource(),
         isArray = SC.typeOf(recordTypes) === SC.T_ARRAY,
@@ -1797,11 +1797,11 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
           this._setCallbackForStoreKey(storeKey, callback, hasCallbackArray, storeKeys);
         // K.BUSY_DESTROYING, K.BUSY_COMMITTING, K.BUSY_CREATING
         } else if ((status === K.BUSY_DESTROYING) || (status === K.BUSY_CREATING) || (status === K.BUSY_COMMITTING)) {
-          throw K.BUSY_ERROR ;
+          K.BUSY_ERROR.$throw();
 
         // K.DESTROY_DIRTY, bad state...
         } else if (status === K.DESTROYED_DIRTY) {
-          throw K.BAD_STATE_ERROR ;
+          K.BAD_STATE_ERROR.$throw();
 
         // ignore K.BUSY_LOADING, K.BUSY_REFRESH_CLEAN, K.BUSY_REFRESH_DIRTY
         }
@@ -1844,7 +1844,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @private
     stores the callbacks for the storeKeys that are inflight
   **/
-  _setCallbackForStoreKey: function(storeKey, callback, hasCallbackArray, storeKeys){
+  _setCallbackForStoreKey: function (storeKey, callback, hasCallbackArray, storeKeys){
     var queue = this._callback_queue;
     if(hasCallbackArray) queue[storeKey] = {callback: callback, otherKeys: storeKeys};
     else queue[storeKey] = callback;
@@ -1867,13 +1867,13 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
       else if(SC.typeOf(callback) === SC.T_HASH){
         callback.completed = YES;
         keys = callback.storeKeys;
-        keys.forEach(function(key){
+        keys.forEach(function (key){
           if(!queue[key].completed) allFinished = YES;
         });
         if(allFinished){
           callback.callback.call(); // args?
           //cleanup
-          keys.forEach(function(key){
+          keys.forEach(function (key){
             delete queue[key];
           });
         }
@@ -1886,7 +1886,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @private
 
   */
-  _cancelCallback: function(storeKey){
+  _cancelCallback: function (storeKey){
     var queue = this._callback_queue;
     if(queue[storeKey]){
       delete queue[storeKey];
@@ -1912,7 +1912,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {Function} callback (optional)
     @returns {Number} storeKey that was retrieved
   */
-  retrieveRecord: function(recordType, id, storeKey, isRefresh, callback) {
+  retrieveRecord: function (recordType, id, storeKey, isRefresh, callback) {
     var array = this._TMP_RETRIEVE_ARRAY,
         ret;
 
@@ -1941,7 +1941,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {Function} callback (optional) when refresh completes
     @returns {Boolean} YES if the retrieval was a success.
   */
-  refreshRecord: function(recordType, id, storeKey, callback) {
+  refreshRecord: function (recordType, id, storeKey, callback) {
     return !!this.retrieveRecord(recordType, id, storeKey, YES, callback);
   },
 
@@ -1956,7 +1956,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {Function} callback (optional) when refresh completes
     @returns {Boolean} YES if the retrieval was a success.
   */
-  refreshRecords: function(recordTypes, ids, storeKeys, callback) {
+  refreshRecords: function (recordTypes, ids, storeKeys, callback) {
     var ret = this.retrieveRecords(recordTypes, ids, storeKeys, YES, callback);
     return ret && ret.length>0;
   },
@@ -1978,7 +1978,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
 
     @returns {Boolean} if the action was succesful.
   */
-  commitRecords: function(recordTypes, ids, storeKeys, params, callbacks) {
+  commitRecords: function (recordTypes, ids, storeKeys, params, callbacks) {
     var source    = this._getDataSource(),
         isArray   = SC.typeOf(recordTypes) === SC.T_ARRAY,
         hasCallbackArray = SC.typeOf(callbacks) === SC.T_ARRAY,
@@ -2014,7 +2014,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
       status = this.readStatus(storeKey);
 
       if (status === K.ERROR) {
-        throw K.NOT_FOUND_ERROR ;
+        K.NOT_FOUND_ERROR.$throw();
       }
       else {
         if(status === K.READY_NEW) {
@@ -2073,7 +2073,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {Function|Array} callback function or array of functions
     @returns {Boolean} if the action was successful.
   */
-  commitRecord: function(recordType, id, storeKey, params, callback) {
+  commitRecord: function (recordType, id, storeKey, params, callback) {
     var array = this._TMP_RETRIEVE_ARRAY,
         ret ;
     if (id === undefined && storeKey === undefined ) return NO;
@@ -2101,7 +2101,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {Array} storeKeys (optional) store keys to destroy
     @returns {SC.Store} the store.
   */
-  cancelRecords: function(recordTypes, ids, storeKeys) {
+  cancelRecords: function (recordTypes, ids, storeKeys) {
     var source  = this._getDataSource(),
         isArray = SC.typeOf(recordTypes) === SC.T_ARRAY,
         K       = SC.Record,
@@ -2124,7 +2124,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
         status = this.readStatus(storeKey);
 
         if ((status === K.EMPTY) || (status === K.ERROR)) {
-          throw K.NOT_FOUND_ERROR ;
+          K.NOT_FOUND_ERROR.$throw();
         }
         ret.push(storeKey);
         this._cancelCallback(storeKey);
@@ -2146,7 +2146,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {Array} storeKeys (optional) store keys to destroy
     @returns {SC.Store} the store.
   */
-  cancelRecord: function(recordType, id, storeKey) {
+  cancelRecord: function (recordType, id, storeKey) {
     var array = this._TMP_RETRIEVE_ARRAY,
         ret ;
 
@@ -2189,7 +2189,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {Array} id optional.  if not passed lookup on the hash
     @returns {String} store keys assigned to these id
   */
-  loadRecord: function(recordType, dataHash, id) {
+  loadRecord: function (recordType, dataHash, id) {
     var K       = SC.Record,
         ret, primaryKey, storeKey;
 
@@ -2235,7 +2235,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {Array} ids optional array of ids.  if not passed lookup on hashes
     @returns {Array} store keys assigned to these ids
   */
-  loadRecords: function(recordTypes, dataHashes, ids) {
+  loadRecords: function (recordTypes, dataHashes, ids) {
     var isArray = SC.typeOf(recordTypes) === SC.T_ARRAY,
         len     = dataHashes.get('length'),
         ret     = [],
@@ -2270,7 +2270,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
 
     @returns {SC.Error} SC.Error or undefined if no error associated with the record.
   */
-  readError: function(storeKey) {
+  readError: function (storeKey) {
     var errors = this.recordErrors ;
     return errors ? errors[storeKey] : undefined ;
   },
@@ -2282,7 +2282,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
 
     @returns {SC.Error} SC.Error or undefined if no error associated with the query.
   */
-  readQueryError: function(query) {
+  readQueryError: function (query) {
     var errors = this.queryErrors ;
     return errors ? errors[SC.guidFor(query)] : undefined ;
   },
@@ -2299,14 +2299,14 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {Number} storeKey record store key to cancel
     @returns {SC.Store} receiver
   */
-  dataSourceDidCancel: function(storeKey) {
+  dataSourceDidCancel: function (storeKey) {
     var status = this.readStatus(storeKey),
         K      = SC.Record;
 
     // EMPTY, ERROR, READY_CLEAN, READY_NEW, READY_DIRTY, DESTROYED_CLEAN,
     // DESTROYED_DIRTY
     if (!(status & K.BUSY)) {
-      throw K.BAD_STATE_ERROR; // should never be called in this state
+      K.BAD_STATE_ERROR.$throw(); // should never be called in this state
     }
 
     // otherwise, determine proper state transition
@@ -2336,7 +2336,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
         break;
 
       default:
-        throw K.BAD_STATE_ERROR ;
+        K.BAD_STATE_ERROR.$throw() ;
     }
     this.writeStatus(storeKey, status) ;
     this.dataHashDidChange(storeKey, null, YES);
@@ -2355,18 +2355,18 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {Object} newId optional new id to replace the old one
     @returns {SC.Store} receiver
   */
-  dataSourceDidComplete: function(storeKey, dataHash, newId) {
+  dataSourceDidComplete: function (storeKey, dataHash, newId) {
     var status = this.readStatus(storeKey), K = SC.Record, statusOnly;
 
     // EMPTY, ERROR, READY_CLEAN, READY_NEW, READY_DIRTY, DESTROYED_CLEAN,
     // DESTROYED_DIRTY
     if (!(status & K.BUSY)) {
-      throw K.BAD_STATE_ERROR; // should never be called in this state
+      K.BAD_STATE_ERROR.$throw(); // should never be called in this state
     }
 
     // otherwise, determine proper state transition
-    if(status === K.BUSY_DESTROYING) {
-      throw K.BAD_STATE_ERROR ;
+    if(status===K.BUSY_DESTROYING) {
+      K.BAD_STATE_ERROR.$throw() ;
     } else status = K.READY_CLEAN ;
 
     this.writeStatus(storeKey, status) ;
@@ -2394,13 +2394,13 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {Number} storeKey record store key to cancel
     @returns {SC.Store} receiver
   */
-  dataSourceDidDestroy: function(storeKey) {
+  dataSourceDidDestroy: function (storeKey) {
     var status = this.readStatus(storeKey), K = SC.Record;
 
     // EMPTY, ERROR, READY_CLEAN, READY_NEW, READY_DIRTY, DESTROYED_CLEAN,
     // DESTROYED_DIRTY
     if (!(status & K.BUSY)) {
-      throw K.BAD_STATE_ERROR; // should never be called in this state
+      K.BAD_STATE_ERROR.$throw(); // should never be called in this state
     }
     // otherwise, determine proper state transition
     else{
@@ -2427,12 +2427,12 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {SC.Error} error [optional] an SC.Error instance to associate with storeKey
     @returns {SC.Store} receiver
   */
-  dataSourceDidError: function(storeKey, error) {
+  dataSourceDidError: function (storeKey, error) {
     var status = this.readStatus(storeKey), errors = this.recordErrors, K = SC.Record;
 
     // EMPTY, ERROR, READY_CLEAN, READY_NEW, READY_DIRTY, DESTROYED_CLEAN,
     // DESTROYED_DIRTY
-    if (!(status & K.BUSY)) { throw K.BAD_STATE_ERROR; }
+    if (!(status & K.BUSY)) { K.BAD_STATE_ERROR.$throw(); }
 
     // otherwise, determine proper state transition
     else status = K.ERROR ;
@@ -2470,15 +2470,15 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {Number} storeKey optional store key.
     @returns {Number|Boolean} storeKey if push was allowed, NO if not
   */
-  pushRetrieve: function(recordType, id, dataHash, storeKey) {
+  pushRetrieve: function (recordType, id, dataHash, storeKey) {
     var K = SC.Record, status;
 
-    if(storeKey===undefined) storeKey = recordType.storeKeyFor(id);
+    if (storeKey === undefined) storeKey = recordType.storeKeyFor(id);
     status = this.readStatus(storeKey);
     if(status === K.EMPTY || status === K.ERROR || status === K.READY_CLEAN || status === K.DESTROYED_CLEAN) {
 
       status = K.READY_CLEAN;
-      if(dataHash === undefined) this.writeStatus(storeKey, status) ;
+      if (dataHash === undefined) this.writeStatus(storeKey, status) ;
       else this.writeDataHash(storeKey, dataHash, status) ;
 
       if (id && this.idFor(storeKey) !== id) SC.Store.replaceIdFor(storeKey, id);
@@ -2499,7 +2499,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {Number} storeKey optional store key.
     @returns {Number|Boolean} storeKey if push was allowed, NO if not
   */
-  pushDestroy: function(recordType, id, storeKey) {
+  pushDestroy: function (recordType, id, storeKey) {
     var K = SC.Record, status;
 
     if(storeKey===undefined){
@@ -2526,7 +2526,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {Number} storeKey optional store key.
     @returns {Number|Boolean} storeKey if push was allowed, NO if not
   */
-  pushError: function(recordType, id, error, storeKey) {
+  pushError: function (recordType, id, error, storeKey) {
     var K = SC.Record, status, errors = this.recordErrors;
 
     if(storeKey===undefined) storeKey = recordType.storeKeyFor(id);
@@ -2564,7 +2564,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {SC.Array} storeKeys array of store keys
     @returns {SC.Store} receiver
   */
-  loadQueryResults: function(query, storeKeys) {
+  loadQueryResults: function (query, storeKeys) {
     //@if(debug)
     if (query.get('location') === SC.Query.LOCAL) {
       throw new Error("Developer Error: You should not call loadQueryResults with a local query.  You need to use dataSourceDidFetchQuery instead.");
@@ -2640,11 +2640,11 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     if (recArray) recArray.storeDidFetchQuery(query);
 
     // notify nested stores
-    while(--loc >= 0) {
+    while (--loc >= 0) {
       nestedStores[loc]._scstore_dataSourceDidFetchQuery(query);
     }
 
-    return this ;
+    return this;
   },
 
   /**
@@ -2655,11 +2655,11 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {SC.Query} query the query you cancelled
     @returns {SC.Store} receiver
   */
-  dataSourceDidCancelQuery: function(query) {
+  dataSourceDidCancelQuery: function (query) {
     return this._scstore_dataSourceDidCancelQuery(query, YES);
   },
 
-  _scstore_dataSourceDidCancelQuery: function(query, createIfNeeded) {
+  _scstore_dataSourceDidCancelQuery: function (query, createIfNeeded) {
     var recArray     = this._findQuery(query, createIfNeeded, NO),
         nestedStores = this.get('nestedStores'),
         loc          = nestedStores ? nestedStores.get('length') : 0;
@@ -2684,7 +2684,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {SC.Error} error [optional] an SC.Error instance to associate with query
     @returns {SC.Store} receiver
   */
-  dataSourceDidErrorQuery: function(query, error) {
+  dataSourceDidErrorQuery: function (query, error) {
     var errors = this.queryErrors;
 
     // Add the error to the array of query errors (for lookup later on if necessary).
@@ -2696,7 +2696,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     return this._scstore_dataSourceDidErrorQuery(query, YES);
   },
 
-  _scstore_dataSourceDidErrorQuery: function(query, createIfNeeded) {
+  _scstore_dataSourceDidErrorQuery: function (query, createIfNeeded) {
     var recArray     = this._findQuery(query, createIfNeeded, NO),
         nestedStores = this.get('nestedStores'),
         loc          = nestedStores ? nestedStores.get('length') : 0;
@@ -2717,13 +2717,13 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
   //
 
   /** @private */
-  init: function() {
+  init: function () {
     sc_super();
     this.reset();
   },
 
 
-  toString: function() {
+  toString: function () {
     // Include the name if the client has specified one.
     var name = this.get('name');
     if (!name) {
@@ -2746,7 +2746,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {Number} storeKey the store key
     @returns {String} primaryKey value
   */
-  idFor: function(storeKey) {
+  idFor: function (storeKey) {
     return SC.Store.idFor(storeKey);
   },
 
@@ -2756,7 +2756,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {Number} storeKey the store key
     @returns {SC.Record} record instance
   */
-  recordTypeFor: function(storeKey) {
+  recordTypeFor: function (storeKey) {
     return SC.Store.recordTypeFor(storeKey) ;
   },
 
@@ -2768,7 +2768,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {String} primaryKey the primary key
     @returns {Number} storeKey
   */
-  storeKeyFor: function(recordType, primaryKey) {
+  storeKeyFor: function (recordType, primaryKey) {
     return recordType.storeKeyFor(primaryKey);
   },
 
@@ -2781,7 +2781,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {String} primaryKey the primary key
     @returns {Number} a storeKey.
   */
-  storeKeyExists: function(recordType, primaryKey) {
+  storeKeyExists: function (recordType, primaryKey) {
     return recordType.storeKeyExists(primaryKey);
   },
 
@@ -2792,7 +2792,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {SC.Record} recordType
     @returns {Array} set of storeKeys
   */
-  storeKeysFor: function(recordType) {
+  storeKeysFor: function (recordType) {
     var ret = [],
         isEnum = recordType && recordType.isEnumerable,
         recType, storeKey, isMatch ;
@@ -2817,7 +2817,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
 
     @returns {Array} set of storeKeys
   */
-  storeKeys: function() {
+  storeKeys: function () {
     var ret = [], storeKey;
     if(!this.statuses) return ret;
 
@@ -2837,7 +2837,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
     @param {Number} storeKey
     @returns {String}
   */
-  statusString: function(storeKey) {
+  statusString: function (storeKey) {
     var rec = this.materializeRecord(storeKey);
     return rec.statusString();
   }
@@ -2852,7 +2852,7 @@ SC.Store.mixin(/** @scope SC.Store.prototype */{
 
     @type Error
   */
-  CHAIN_CONFLICT_ERROR: new Error("Nested Store Conflict"),
+  CHAIN_CONFLICT_ERROR: SC.$error("Nested Store Conflict"),
 
   /**
     Standard error if you try to perform an operation on a nested store
@@ -2860,7 +2860,7 @@ SC.Store.mixin(/** @scope SC.Store.prototype */{
 
     @type Error
   */
-  NO_PARENT_STORE_ERROR: new Error("Parent Store Required"),
+  NO_PARENT_STORE_ERROR: SC.$error("Parent Store Required"),
 
   /**
     Standard error if you try to perform an operation on a nested store that
@@ -2868,7 +2868,7 @@ SC.Store.mixin(/** @scope SC.Store.prototype */{
 
     @type Error
   */
-  NESTED_STORE_UNSUPPORTED_ERROR: new Error("Unsupported In Nested Store"),
+  NESTED_STORE_UNSUPPORTED_ERROR: SC.$error("Unsupported In Nested Store"),
 
   /**
     Standard error if you try to retrieve a record in a nested store that is
@@ -2876,7 +2876,7 @@ SC.Store.mixin(/** @scope SC.Store.prototype */{
 
     @type Error
   */
-  NESTED_STORE_RETRIEVE_DIRTY_ERROR: new Error("Cannot Retrieve Dirty Record in Nested Store"),
+  NESTED_STORE_RETRIEVE_DIRTY_ERROR: SC.$error("Cannot Retrieve Dirty Record in Nested Store"),
 
   /**
     Data hash state indicates the data hash is currently editable
@@ -2935,7 +2935,7 @@ SC.Store.mixin(/** @scope SC.Store.prototype */{
 
     @type Number
   */
-  generateStoreKey: function() { return this.nextStoreKey++; },
+  generateStoreKey: function () { return this.nextStoreKey++; },
 
   /**
     Given a `storeKey` returns the `primaryKey` associated with the key.
@@ -2944,7 +2944,7 @@ SC.Store.mixin(/** @scope SC.Store.prototype */{
     @param {Number} storeKey the store key
     @returns {String} the primary key or null
   */
-  idFor: function(storeKey) {
+  idFor: function (storeKey) {
     return this.idsByStoreKey[storeKey] ;
   },
 
@@ -2955,7 +2955,7 @@ SC.Store.mixin(/** @scope SC.Store.prototype */{
     @param {Number} storeKey the store key
     @returns {SC.Query} query query object
   */
-  queryFor: function(storeKey) {
+  queryFor: function (storeKey) {
     return this.queriesByStoreKey[storeKey];
   },
 
@@ -2969,7 +2969,7 @@ SC.Store.mixin(/** @scope SC.Store.prototype */{
     @param {Number} storeKey the store key
     @returns {SC.Record} the record type
   */
-  recordTypeFor: function(storeKey) {
+  recordTypeFor: function (storeKey) {
     return this.recordTypesByStoreKey[storeKey];
   },
 
@@ -2982,7 +2982,7 @@ SC.Store.mixin(/** @scope SC.Store.prototype */{
     @param {String} newPrimaryKey the new primary key
     @returns {SC.Store} receiver
   */
-  replaceIdFor: function(storeKey, newId) {
+  replaceIdFor: function (storeKey, newId) {
     var oldId = this.idsByStoreKey[storeKey],
         recordType, storeKeys;
 
@@ -3015,7 +3015,7 @@ SC.Store.mixin(/** @scope SC.Store.prototype */{
     @param {SC.Record} recordType a record class
     @returns {SC.Store} receiver
   */
-  replaceRecordTypeFor: function(storeKey, recordType) {
+  replaceRecordTypeFor: function (storeKey, recordType) {
     this.recordTypesByStoreKey[storeKey] = recordType;
     return this ;
   }

--- a/frameworks/datastore/tests/models/record/writeAttribute.js
+++ b/frameworks/datastore/tests/models/record/writeAttribute.js
@@ -77,7 +77,7 @@ test("raises exception if you try to write an attribute before an attribute hash
   try {
     foo.writeAttribute("foo", "bar");
   } catch(e) {
-    equals(e, SC.Record.BAD_STATE_ERROR, 'should throw BAD_STATE_ERROR');
+    equals(e.message, SC.Record.BAD_STATE_ERROR.toString(), 'should throw BAD_STATE_ERROR');
     cnt++;
   }
   equals(cnt, 1, 'should raise exception');

--- a/frameworks/datastore/tests/system/nested_store/autonomous_dataSourceCallbacks.js
+++ b/frameworks/datastore/tests/system/nested_store/autonomous_dataSourceCallbacks.js
@@ -163,7 +163,7 @@ test("Confirm that dataSourceDidCancel switched the records to the right states"
   }catch(error){
     msg=error.message;
   }
-  equals(SC.Record.BAD_STATE_ERROR.message, msg,
+  equals(SC.Record.BAD_STATE_ERROR.toString(), msg,
     "should throw the following error ");
 
   store.dataSourceDidCancel(storeKey2);
@@ -196,7 +196,7 @@ test("Confirm that dataSourceDidCancel switched the records to the right states"
   }catch(error){
     msg=error.message;
   }
-  equals(SC.Record.BAD_STATE_ERROR.message, msg,
+  equals(SC.Record.BAD_STATE_ERROR.toString(), msg,
     "should throw the following error ");
 
 });
@@ -210,7 +210,7 @@ test("Confirm that dataSourceDidComplete switched the records to the right state
   }catch(error){
     msg=error.message;
   }
-  equals(SC.Record.BAD_STATE_ERROR.message, msg,
+  equals(SC.Record.BAD_STATE_ERROR.toString(), msg,
     "should throw the following error ");
 
   try{
@@ -219,7 +219,7 @@ test("Confirm that dataSourceDidComplete switched the records to the right state
   }catch(error){
     msg=error.message;
   }
-  equals(SC.Record.BAD_STATE_ERROR.message, msg,
+  equals(SC.Record.BAD_STATE_ERROR.toString(), msg,
     "should throw the following error ");
 
   store.dataSourceDidComplete(storeKey11);
@@ -237,7 +237,7 @@ test("Confirm that dataSourceDidDestroy switched the records to the right states
   }catch(error){
     msg=error.message;
   }
-  equals(SC.Record.BAD_STATE_ERROR.message, msg,
+  equals(SC.Record.BAD_STATE_ERROR.toString(), msg,
     "should throw the following error ");
 
   store.dataSourceDidDestroy(storeKey13);
@@ -255,7 +255,7 @@ test("Confirm that dataSourceDidError switched the records to the right states",
   }catch(error){
     msg = error.message;
   }
-  equals(SC.Record.BAD_STATE_ERROR.message, msg,
+  equals(SC.Record.BAD_STATE_ERROR.toString(), msg,
     "should throw the following error ");
 
   store.dataSourceDidError(storeKey15, SC.Record.BAD_STATE_ERROR);

--- a/frameworks/datastore/tests/system/store/commitChangesFromNestedStore.js
+++ b/frameworks/datastore/tests/system/store/commitChangesFromNestedStore.js
@@ -118,7 +118,7 @@ function createConflict(force) {
   try {
     child.commitChanges(force);
   } catch(e) {
-    equals(e, SC.Store.CHAIN_CONFLICT_ERROR, 'should throw CHAIN_CONFLICT_ERROR');
+    equals(e.message, SC.Store.CHAIN_CONFLICT_ERROR.toString(), 'should throw CHAIN_CONFLICT_ERROR');
     errorCount++;
   }
 

--- a/frameworks/datastore/tests/system/store/commitRecord.js
+++ b/frameworks/datastore/tests/system/store/commitRecord.js
@@ -156,7 +156,7 @@ test("Confirm that all the states are switched as expected after running commitR
     throwError=true;
     msg=error.message;
   }
-  equals(msg, SC.Record.NOT_FOUND_ERROR.message, "commitRecord should throw the following error");
+  equals(msg, SC.Record.NOT_FOUND_ERROR.toString(), "commitRecord should throw the following error");
 
   store.commitRecord(undefined, undefined, storeKey7);
   status = store.readStatus( storeKey7);

--- a/frameworks/datastore/tests/system/store/dataSourceCallbacks.js
+++ b/frameworks/datastore/tests/system/store/dataSourceCallbacks.js
@@ -161,7 +161,7 @@ test("Confirm that dataSourceDidCancel switched the records to the right states"
   }catch(error){
     msg=error.message;
   }
-  equals(SC.Record.BAD_STATE_ERROR.message, msg, 
+  equals(SC.Record.BAD_STATE_ERROR.toString(), msg, 
     "should throw the following error ");
   
   store.dataSourceDidCancel(storeKey2);
@@ -194,7 +194,7 @@ test("Confirm that dataSourceDidCancel switched the records to the right states"
   }catch(error){
     msg=error.message;
   }
-  equals(SC.Record.BAD_STATE_ERROR.message, msg, 
+  equals(SC.Record.BAD_STATE_ERROR.toString(), msg, 
     "should throw the following error ");
   
 });
@@ -208,7 +208,7 @@ test("Confirm that dataSourceDidComplete switched the records to the right state
   }catch(error){
     msg=error.message;
   }
-  equals(SC.Record.BAD_STATE_ERROR.message, msg, 
+  equals(SC.Record.BAD_STATE_ERROR.toString(), msg, 
     "should throw the following error ");
 
   try{
@@ -217,7 +217,7 @@ test("Confirm that dataSourceDidComplete switched the records to the right state
   }catch(error){
     msg=error.message;
   }
-  equals(SC.Record.BAD_STATE_ERROR.message, msg, 
+  equals(SC.Record.BAD_STATE_ERROR.toString(), msg, 
     "should throw the following error ");
   
   store.dataSourceDidComplete(storeKey11);
@@ -235,7 +235,7 @@ test("Confirm that dataSourceDidDestroy switched the records to the right states
   }catch(error){
     msg=error.message;
   }  
-  equals(SC.Record.BAD_STATE_ERROR.message, msg, 
+  equals(SC.Record.BAD_STATE_ERROR.toString(), msg, 
     "should throw the following error ");
   
   store.dataSourceDidDestroy(storeKey13);
@@ -253,7 +253,7 @@ test("Confirm that dataSourceDidError switched the records to the right states",
   }catch(error){
     msg = error.message;
   }
-  equals(SC.Record.BAD_STATE_ERROR.message, msg, 
+  equals(SC.Record.BAD_STATE_ERROR.toString(), msg, 
     "should throw the following error ");
 
   store.dataSourceDidError(storeKey15, SC.Record.BAD_STATE_ERROR);

--- a/frameworks/datastore/tests/system/store/destroyRecord.js
+++ b/frameworks/datastore/tests/system/store/destroyRecord.js
@@ -86,7 +86,7 @@ test("Check for different states after/before executing destroyRecord", function
   }catch(error1){
     msg=error1.message;
   }
-  equals(msg, SC.Record.NOT_FOUND_ERROR.message, "destroyRecord should throw the following error");
+  equals(msg, SC.Record.NOT_FOUND_ERROR.toString(), "destroyRecord should throw the following error");
 
   try{
     store.destroyRecord(undefined, undefined, storeKey4);
@@ -94,7 +94,7 @@ test("Check for different states after/before executing destroyRecord", function
   }catch(error2){
     msg=error2.message;
   }
-  equals(msg, SC.Record.BUSY_ERROR.message, "destroyRecord should throw the following error");
+  equals(msg, SC.Record.BUSY_ERROR.toString(), "destroyRecord should throw the following error");
 
   store.destroyRecord(undefined, undefined, storeKey5);
   status = store.readStatus(storeKey5);

--- a/frameworks/datastore/tests/system/store/recordDidChange.js
+++ b/frameworks/datastore/tests/system/store/recordDidChange.js
@@ -56,13 +56,13 @@ test("recordDidChange", function() {
   try{
     store.recordDidChange(undefined, undefined, storeKey1);
   }catch(error1){
-    equals(SC.Record.BUSY_ERROR.message, error1.message, "the status shouldn't have changed.");
+    equals(SC.Record.BUSY_ERROR.toString(), error1.message, "the status shouldn't have changed.");
   }
   
   try{
     store.recordDidChange(undefined, undefined, storeKey2);
   }catch(error2){
-    equals(SC.Record.NOT_FOUND_ERROR.message, error2.message, "the status shouldn't have changed.");
+    equals(SC.Record.NOT_FOUND_ERROR.toString(), error2.message, "the status shouldn't have changed.");
   }
   
   store.recordDidChange(undefined, undefined, storeKey3);

--- a/frameworks/datastore/tests/system/store/retrieveRecord.js
+++ b/frameworks/datastore/tests/system/store/retrieveRecord.js
@@ -119,7 +119,7 @@ function testStates(canLoad) {
   }catch(error1){
     msg=error1.message;
   }
-  equals(msg, SC.Record.BUSY_ERROR.message, "should throw error");
+  equals(msg, SC.Record.BUSY_ERROR.toString(), "should throw error");
 
   try{
     store.retrieveRecord(undefined, undefined, storeKey5, YES);
@@ -127,7 +127,7 @@ function testStates(canLoad) {
   }catch(error2){
     msg=error2.message;
   }
-  equals(msg, SC.Record.BUSY_ERROR.message, "should throw error");
+  equals(msg, SC.Record.BUSY_ERROR.toString(), "should throw error");
   
   try{
     store.retrieveRecord(undefined, undefined, storeKey6, YES);
@@ -135,7 +135,7 @@ function testStates(canLoad) {
   }catch(error3){
     msg=error3.message;
   }
-  equals(msg, SC.Record.BUSY_ERROR.message, "should throw error");
+  equals(msg, SC.Record.BUSY_ERROR.toString(), "should throw error");
 
   try{
     store.retrieveRecord(undefined, undefined, storeKey7, YES);
@@ -143,7 +143,7 @@ function testStates(canLoad) {
   }catch(error4){
     msg=error4.message;
   }
-  equals(msg, SC.Record.BAD_STATE_ERROR.message, "should throw error");
+  equals(msg, SC.Record.BAD_STATE_ERROR.toString(), "should throw error");
 
 
   store.retrieveRecord(undefined, undefined, storeKey8, YES);

--- a/frameworks/datetime/frameworks/core/system/datetime.js
+++ b/frameworks/datetime/frameworks/core/system/datetime.js
@@ -12,7 +12,7 @@
   @constant
   @type Error
 */
-SC.SCANNER_OUT_OF_BOUNDS_ERROR = new Error("Out of bounds.");
+SC.SCANNER_OUT_OF_BOUNDS_ERROR = SC.$error("Out of bounds.");
 
 /**
   Standard error thrown by `SC.Scanner` when  you pass a value not an integer.
@@ -21,7 +21,7 @@ SC.SCANNER_OUT_OF_BOUNDS_ERROR = new Error("Out of bounds.");
   @constant
   @type Error
 */
-SC.SCANNER_INT_ERROR = new Error("Not an int.");
+SC.SCANNER_INT_ERROR = SC.$error("Not an int.");
 
 /**
   Standard error thrown by `SC.SCanner` when it cannot find a string to skip.
@@ -30,7 +30,7 @@ SC.SCANNER_INT_ERROR = new Error("Not an int.");
   @constant
   @type Error
 */
-SC.SCANNER_SKIP_ERROR = new Error("Did not find the string to skip.");
+SC.SCANNER_SKIP_ERROR = SC.$error("Did not find the string to skip.");
 
 /**
   Standard error thrown by `SC.Scanner` when it can any kind a string in the
@@ -40,7 +40,7 @@ SC.SCANNER_SKIP_ERROR = new Error("Did not find the string to skip.");
   @constant
   @type Error
 */
-SC.SCANNER_SCAN_ARRAY_ERROR = new Error("Did not find any string of the given array to scan.");
+SC.SCANNER_SCAN_ARRAY_ERROR = SC.$error("Did not find any string of the given array to scan.");
 
 /**
   Standard error thrown when trying to compare two dates in different
@@ -50,7 +50,7 @@ SC.SCANNER_SCAN_ARRAY_ERROR = new Error("Did not find any string of the given ar
   @constant
   @type Error
 */
-SC.DATETIME_COMPAREDATE_TIMEZONE_ERROR = new Error("Can't compare the dates of two DateTimes that don't have the same timezone.");
+SC.DATETIME_COMPAREDATE_TIMEZONE_ERROR = SC.$error("Can't compare the dates of two DateTimes that don't have the same timezone.");
 
 /**
   Standard ISO8601 date format
@@ -106,7 +106,7 @@ SC.Scanner = SC.Object.extend(
     @returns {String} The characters
   */
   scan: function(len) {
-    if (this.scanLocation + len > this.length) throw SC.SCANNER_OUT_OF_BOUNDS_ERROR;
+    if (this.scanLocation + len > this.length) SC.SCANNER_OUT_OF_BOUNDS_ERROR.$throw();
     var str = this.string.substr(this.scanLocation, len);
     this.scanLocation += len;
     return str;
@@ -125,7 +125,7 @@ SC.Scanner = SC.Object.extend(
     var str = this.scan(max_len);
     var re = new RegExp("^\\d{" + min_len + "," + max_len + "}");
     var match = str.match(re);
-    if (!match) throw SC.SCANNER_INT_ERROR;
+    if (!match) SC.SCANNER_INT_ERROR.$throw();
     if (match[0].length < max_len) {
       this.scanLocation += match[0].length - max_len;
     }
@@ -140,7 +140,7 @@ SC.Scanner = SC.Object.extend(
     @returns {Boolean} YES if the given string was successfully scanned, NO otherwise
   */
   skipString: function(str) {
-    if (this.scan(str.length) !== str) throw SC.SCANNER_SKIP_ERROR;
+    if (this.scan(str.length) !== str) SC.SCANNER_SKIP_ERROR.$throw();
     return YES;
   },
 
@@ -158,7 +158,7 @@ SC.Scanner = SC.Object.extend(
       }
       this.scanLocation -= ary[i].length;
     }
-    throw SC.SCANNER_SCAN_ARRAY_ERROR;
+    SC.SCANNER_SCAN_ARRAY_ERROR.$throw();
   }
 
 });
@@ -1211,7 +1211,7 @@ SC.DateTime.mixin(SC.Comparable,
   */
   compareDate: function(a, b) {
     if (SC.none(a) || SC.none(b)) throw new Error("You must pass two valid dates to compareDate()");
-    if (a.get('timezone') !== b.get('timezone')) throw SC.DATETIME_COMPAREDATE_TIMEZONE_ERROR;
+    if (a.get('timezone') !== b.get('timezone')) SC.DATETIME_COMPAREDATE_TIMEZONE_ERROR.$throw();
     var ma = a.adjust({hour: 0}).get('milliseconds');
     var mb = b.adjust({hour: 0}).get('milliseconds');
     return ma < mb ? -1 : ma === mb ? 0 : 1;
@@ -1244,7 +1244,7 @@ SC.DateTime.mixin(SC.Comparable,
       case 'S': divider = 1e3; break; // second: 1000
       case 's': divider = 1; break;
       case 'W': divider = 6048e5; break; // week: 1000 * 60 * 60 * 24 * 7
-      default: throw format+" is not supported"; break;
+      default: throw new Error(format+" is not supported"); break;
     }
 
     var ret = diff/divider;

--- a/frameworks/designer/coders/object.js
+++ b/frameworks/designer/coders/object.js
@@ -309,7 +309,7 @@ SC.ObjectCoder = SC.Object.extend({
   begin: function(object) {
     var methodName = this.get('encodeMethodName');
     if (SC.typeOf(object[methodName]) !== SC.T_FUNCTION) {
-      throw SC.$error("Cannot encode %@ because it does not respond to %@()".fmt(object, methodName)) ;
+      SC.$throw("Cannot encode %@ because it does not respond to %@()".fmt(object, methodName));
     } 
     
     // save className for later coding

--- a/frameworks/desktop/panes/picker.js
+++ b/frameworks/desktop/panes/picker.js
@@ -296,7 +296,7 @@ SC.PickerPane = SC.PalettePane.extend(
       // Throw an error if a null or empty value is set. You're not allowed to go anchorless.
       // (TODO: why can't we go anchorless? positionPane happily centers an unmoored pane.)
       if (!value) {
-        throw "You must set 'anchorElement' to either a view or a DOM element";
+        SC.$throw("You must set 'anchorElement' to either a view or a DOM element");
       }
 
       // Clean up any previous anchor elements.

--- a/frameworks/foundation/tests/mixins/staticLayout.js
+++ b/frameworks/foundation/tests/mixins/staticLayout.js
@@ -121,9 +121,9 @@ test("Test that an exception is thrown when calling adjust and setting to auto",
     parent.adjust('width', 'auto').adjust('height', 'auto');
     parent.get('layoutStyle');
   }catch(e){
-    error=e;
+    error=true;
   }
-  equals(SC.T_ERROR,SC.typeOf(error),'Layout style functions should throw an error if width/height are set to auto but staticLayout is not enabled' + error );
+  ok(error,'Layout style functions should throw an error if width/height are set to auto but staticLayout is not enabled' + error );
 });
 
 test("Test SC.StaticLayout frame support", function() {

--- a/frameworks/runtime/debug/test_suites/array/insertAt.js
+++ b/frameworks/runtime/debug/test_suites/array/insertAt.js
@@ -34,7 +34,7 @@ SC.ArraySuite.define(function(T) {
     try {
       obj.insertAt(200, T.expected(1));
     } catch (e) {
-      equals(e, SC.OUT_OF_RANGE_EXCEPTION, 'should throw SC.OUT_OF_RANGE_EXCEPTION');
+      equals(e.message, SC.OUT_OF_RANGE_EXCEPTION, 'should throw SC.OUT_OF_RANGE_EXCEPTION');
       didThrow = YES ;
     }
     ok(didThrow, 'should raise exception');
@@ -73,7 +73,7 @@ SC.ArraySuite.define(function(T) {
     try {
       obj.insertAt(200, T.expected(1));
     } catch (e) {
-      equals(e, SC.OUT_OF_RANGE_EXCEPTION, 'should throw SC.OUT_OF_RANGE_EXCEPTION');
+      equals(e.message, SC.OUT_OF_RANGE_EXCEPTION, 'should throw SC.OUT_OF_RANGE_EXCEPTION');
       didThrow = YES ;
     }
     ok(didThrow, 'should raise exception');

--- a/frameworks/runtime/debug/test_suites/array/removeAt.js
+++ b/frameworks/runtime/debug/test_suites/array/removeAt.js
@@ -35,7 +35,7 @@ SC.ArraySuite.define(function(T) {
     try {
       obj.removeAt(200);
     } catch (e) {
-      equals(e, SC.OUT_OF_RANGE_EXCEPTION, 'should throw SC.OUT_OF_RANGE_EXCEPTION');
+      equals(e.message, SC.OUT_OF_RANGE_EXCEPTION, 'should throw SC.OUT_OF_RANGE_EXCEPTION');
       didThrow = YES ;
     }
     ok(didThrow, 'should raise exception');

--- a/frameworks/runtime/ext/array.js
+++ b/frameworks/runtime/ext/array.js
@@ -16,7 +16,7 @@ SC.mixin(Array.prototype,
 
   // primitive for array support.
   replace: function (idx, amt, objects) {
-    if (this.isFrozen) { throw SC.FROZEN_ERROR; }
+    if (this.isFrozen) { throw new Error(SC.FROZEN_ERROR); }
 
     var args;
     var len = objects ? (objects.get ? objects.get('length') : objects.length) : 0;

--- a/frameworks/runtime/mixins/array.js
+++ b/frameworks/runtime/mixins/array.js
@@ -138,7 +138,7 @@ SC.CoreArray = /** @lends SC.Array.prototype */ {
     @param {Object} object object to insert
   */
   insertAt: function (idx, object) {
-    if (idx > this.get('length')) throw SC.OUT_OF_RANGE_EXCEPTION;
+    if (idx > this.get('length')) throw new Error(SC.OUT_OF_RANGE_EXCEPTION);
     this.replace(idx, 0, [object]);
     return this;
   },
@@ -162,7 +162,7 @@ SC.CoreArray = /** @lends SC.Array.prototype */ {
     if (typeof start === SC.T_NUMBER) {
 
       if ((start < 0) || (start >= this.get('length'))) {
-        throw SC.OUT_OF_RANGE_EXCEPTION;
+        throw new Error(SC.OUT_OF_RANGE_EXCEPTION);
       }
 
       // fast case

--- a/frameworks/runtime/mixins/freezable.js
+++ b/frameworks/runtime/mixins/freezable.js
@@ -11,7 +11,7 @@
 
   @type Error
 */
-SC.FROZEN_ERROR = new Error("Cannot modify a frozen object");
+SC.FROZEN_ERROR = "Cannot modify a frozen object";
 
 /**
   @class
@@ -48,7 +48,7 @@ SC.FROZEN_ERROR = new Error("Cannot modify a frozen object");
 
           // swaps the names
           swapNames: function() {
-            if (this.get('isFrozen')) throw SC.FROZEN_ERROR;
+            if (this.get('isFrozen')) throw new Error(SC.FROZEN_ERROR);
             var tmp = this.get('firstName');
             this.set('firstName', this.get('lastName'));
             this.set('lastName', tmp);

--- a/frameworks/runtime/system/enumerator.js
+++ b/frameworks/runtime/system/enumerator.js
@@ -57,7 +57,7 @@ SC.Enumerator.prototype = /** @scope SC.Enumerator.prototype */{
   */
   reset: function() {
     var e = this.enumerable ;
-    if (!e) throw SC.$error("Enumerator has been destroyed");
+    if (!e) SC.$throw("Enumerator has been destroyed");
     this._length = e.get ? e.get('length') : e.length ;
     var len = this._length;
     this._index = 0;

--- a/frameworks/runtime/system/error.js
+++ b/frameworks/runtime/system/error.js
@@ -77,6 +77,27 @@ SC.Error = SC.Object.extend(
   }.property().cacheable(),
 
   /**
+    Throw the error.
+
+    @type SC.Error
+  */
+  $throw: function() {
+    var error = this.toString()
+    SC.Logger.error(error);
+
+    throw new Error(error);
+  },
+
+  /**
+    The error stacktrace.
+
+    @type SC.Error
+  */
+  trace: function() {
+    return (new Error).trace;
+  }.property().cacheable(),
+
+  /**
     Human readable name of the item with the error.
 
     @type String
@@ -94,24 +115,41 @@ SC.Error = SC.Object.extend(
     @type Boolean
   */
   isError: YES
-}) ;
+});
 
-/**
-  Creates a new SC.Error instance with the passed description, label, and
-  code.  All parameters are optional.
+SC.Error.mixin({
 
-  @param description {String} human readable description of the error
-  @param label {String} human readable name of the item with the error
-  @param code {Number} an error code to use for testing.
-  @returns {SC.Error} new error instance.
-*/
-SC.Error.desc = function(description, label, value, code) {
-  var opts = { message: description } ;
-  if (label !== undefined) opts.label = label ;
-  if (code !== undefined) opts.code = code ;
-  if (value !== undefined) opts.errorValue = value ;
-  return this.create(opts) ;
-} ;
+  /**
+    Creates a new SC.Error instance with the passed description, label, and
+    code.  All parameters are optional.
+
+    @param description {String} human readable description of the error
+    @param label {String} human readable name of the item with the error
+    @param code {Number} an error code to use for testing.
+    @returns {SC.Error} new error instance.
+  */
+  desc: function(description, label, value, code) {
+    var opts = { message: description } ;
+    if (label !== undefined) opts.label = label ;
+    if (code !== undefined) opts.code = code ;
+    if (value !== undefined) opts.errorValue = value ;
+    return this.create(opts) ;
+  },
+
+  /**
+    Throw a new SC.Error instance with the passed description, label, and
+    code.  All parameters are optional.
+
+    @param description {String} human readable description of the error
+    @param label {String} human readable name of the item with the error
+    @param code {Number} an error code to use for testing.
+    @returns {SC.Error} new error instance.
+  */
+  $throw: function(description, label, value, code) {
+    this.desc.apply(this, arguments).$throw();
+  },
+
+});
 
 /**
   Shorthand form of the SC.Error.desc method.
@@ -121,10 +159,21 @@ SC.Error.desc = function(description, label, value, code) {
   @param code {Number} an error code to use for testing.
   @returns {SC.Error} new error instance.
 */
-
 SC.$error = function(description, label, value, c) {  
   return SC.Error.desc(description,label, value, c);
-} ;
+};
+
+/**
+  Shorthand form of the SC.Error.$throw method.
+
+  @param description {String} human readable description of the error
+  @param label {String} human readable name of the item with the error
+  @param code {Number} an error code to use for testing.
+  @returns {SC.Error} new error instance.
+*/
+SC.$throw = function(description, label, value, c) {  
+  SC.Error.$throw(description,label, value, c);
+};
 
 /**
   Returns NO if the passed value is an error object or false.

--- a/frameworks/runtime/system/index_set.js
+++ b/frameworks/runtime/system/index_set.js
@@ -475,7 +475,7 @@ SC.IndexSet = SC.mixin({},
     this._sc_validateIndexSetArguments.apply(this, arguments);
     //@endif
 
-    if (this.isFrozen) throw SC.FROZEN_ERROR;
+    if (this.isFrozen) throw new Error(SC.FROZEN_ERROR);
 
     var content, cur, next;
 
@@ -652,7 +652,7 @@ SC.IndexSet = SC.mixin({},
     this._sc_validateIndexSetArguments.apply(this, arguments);
     //@endif
 
-    if (this.isFrozen) throw SC.FROZEN_ERROR;
+    if (this.isFrozen) throw new Error(SC.FROZEN_ERROR);
 
     // normalize input
     if (length === undefined) {
@@ -829,7 +829,7 @@ SC.IndexSet = SC.mixin({},
     Clears the set
   */
   clear: function () {
-    if (this.isFrozen) throw SC.FROZEN_ERROR;
+    if (this.isFrozen) throw new Error(SC.FROZEN_ERROR);
 
     var oldlen = this.length;
     this._content.length = 1;
@@ -845,7 +845,7 @@ SC.IndexSet = SC.mixin({},
     @param {Enumerable} objects The list of ranges you want to add
   */
   addEach: function (objects) {
-    if (this.isFrozen) throw SC.FROZEN_ERROR;
+    if (this.isFrozen) throw new Error(SC.FROZEN_ERROR);
 
     this.beginPropertyChanges();
     var idx = objects.get('length');
@@ -865,7 +865,7 @@ SC.IndexSet = SC.mixin({},
     @param {Object...} objects The list of objects you want to remove
   */
   removeEach: function (objects) {
-    if (this.isFrozen) throw SC.FROZEN_ERROR;
+    if (this.isFrozen) throw new Error(SC.FROZEN_ERROR);
 
     this.beginPropertyChanges();
 

--- a/frameworks/runtime/system/set.js
+++ b/frameworks/runtime/system/set.js
@@ -195,7 +195,7 @@ SC.Set = SC.mixin({},
     @returns {SC.Set}
   */
   clear: function() {
-    if (this.isFrozen) throw SC.FROZEN_ERROR;
+    if (this.isFrozen) throw new Error(SC.FROZEN_ERROR);
     this.length = 0;
     return this ;
   },
@@ -275,7 +275,7 @@ SC.Set = SC.mixin({},
     @returns {SC.Set} receiver
   */
   add: function(obj) {
-    if (this.isFrozen) throw SC.FROZEN_ERROR;
+    if (this.isFrozen) throw new Error(SC.FROZEN_ERROR);
 
     // cannot add null to a set.
     if (SC.none(obj)) return this;
@@ -306,7 +306,7 @@ SC.Set = SC.mixin({},
     @returns {SC.Set} receiver
   */
   addEach: function(objects) {
-    if (this.isFrozen) throw SC.FROZEN_ERROR;
+    if (this.isFrozen) throw new Error(SC.FROZEN_ERROR);
     if (!objects || !objects.isEnumerable) {
       throw new Error("%@.addEach must pass enumerable".fmt(this));
     }
@@ -336,7 +336,7 @@ SC.Set = SC.mixin({},
     @returns {SC.Set} receiver
   */
   remove: function(obj) {
-    if (this.isFrozen) throw SC.FROZEN_ERROR;
+    if (this.isFrozen) throw new Error(SC.FROZEN_ERROR);
 
     // Implementation note:  SC.none() and SC.hashFor() are inlined because
     // sets are fundamental in SproutCore, and the inlined code is ~ 25%
@@ -381,7 +381,7 @@ SC.Set = SC.mixin({},
     @returns {Object} an object from the set or null
   */
   pop: function() {
-    if (this.isFrozen) throw SC.FROZEN_ERROR;
+    if (this.isFrozen) throw new Error(SC.FROZEN_ERROR);
     var obj = (this.length > 0) ? this[this.length-1] : null ;
     this.remove(obj) ;
     return obj ;
@@ -394,7 +394,7 @@ SC.Set = SC.mixin({},
     @returns {SC.Set} receiver
   */
   removeEach: function(objects) {
-    if (this.isFrozen) throw SC.FROZEN_ERROR;
+    if (this.isFrozen) throw new Error(SC.FROZEN_ERROR);
     if (!objects || !objects.isEnumerable) {
       throw new Error("%@.addEach must pass enumerable".fmt(this));
     }

--- a/frameworks/runtime/tests/system/error.js
+++ b/frameworks/runtime/tests/system/error.js
@@ -57,3 +57,24 @@ test("errorObject property should return the error itself", function() {
   var er = SC.$error("foo");
   equals(er.get('errorObject'), er, 'errorObject should return receiver');
 });
+
+test("SC.Error#throw throw an error with description,label and code", function() {
+  var msg='',
+    error = SC.Error.desc('This is an error instance','Error Instance', "FOO", 99999);
+  try{
+    error.throw();
+  }catch(e){
+    msg=e.message;
+  }
+  equals(error.toString(), msg, "should throw the following error ");
+});
+
+test("SC.$throw creates and throw an error instance with description,label and code", function() {
+  var msg='';
+  try{
+    SC.$throw('This is an error instance','Error Instance', "FOO", 99999)
+  }catch(error){
+    msg=error.message;
+  }
+  equals(msg.split(':')[2], 'This is an error instance (99999)', "should throw the following error ");
+});

--- a/frameworks/runtime/tests/system/error.js
+++ b/frameworks/runtime/tests/system/error.js
@@ -62,7 +62,7 @@ test("SC.Error#throw throw an error with description,label and code", function()
   var msg='',
     error = SC.Error.desc('This is an error instance','Error Instance', "FOO", 99999);
   try{
-    error.throw();
+    error.$throw();
   }catch(e){
     msg=e.message;
   }

--- a/frameworks/statechart/system/statechart.js
+++ b/frameworks/statechart/system/statechart.js
@@ -570,7 +570,7 @@ SC.StatechartManager = /** @scope SC.StatechartManager.prototype */{
     if (!(SC.kindOf(rootState, SC.State) && rootState.isClass)) {
       msg = "Unable to initialize statechart. Root state must be a state class";
       this.statechartLogError(msg);
-      throw msg;
+      SC.$throw(msg);
     }
 
     rootState = this.createRootState(rootState, {
@@ -584,7 +584,7 @@ SC.StatechartManager = /** @scope SC.StatechartManager.prototype */{
     if (SC.kindOf(rootState.get('initialSubstate'), SC.EmptyState)) {
       msg = "Unable to initialize statechart. Root state must have an initial substate explicitly defined";
       this.statechartLogError(msg);
-      throw msg;
+      SC.$throw(msg);
     }
 
     if (!SC.empty(this.get('initialState'))) {

--- a/frameworks/template_view/ext/handlebars.js
+++ b/frameworks/template_view/ext/handlebars.js
@@ -93,5 +93,5 @@ Handlebars.registerHelper('helperMissing', function(path, options) {
   var error;
 
   error = "%@ Handlebars error: Could not find property '%@' on object %@.";
-  throw error.fmt(options.data.view, path, this);
+  throw new Error(error.fmt(options.data.view, path, this));
 });

--- a/frameworks/testing/system/plan.js
+++ b/frameworks/testing/system/plan.js
@@ -540,7 +540,7 @@ CoreTest.Plan = {
       }
 
       if (QUNIT_BREAK_ON_TEST_FAIL & !pass) {
-        throw msg;
+        SC.$throw(msg);
       }
 
       return !!pass ? this.pass(msg) : this.fail(msg);


### PR DESCRIPTION
Same goal as https://github.com/sproutcore/sproutcore/pull/1279 with a renamed throw method for YUI (as reported here https://github.com/sproutcore/sproutcore/issues/1297).

To summary, this change allow SC.Error to correctly throw error by instantiating an `Error` object first. This is needed to get a correct stacktrace. Currently errors throw in SC do not get a correct stacktrace. 