### PR TITLE
Do not call _doShow() if the view is already in ATTACHED_SHOWN state

### DIFF
--- a/frameworks/core_foundation/tests/views/view/view_states_test.js
+++ b/frameworks/core_foundation/tests/views/view/view_states_test.js
@@ -760,9 +760,35 @@ test("In ATTACHED_SHOWN state, _isVisibleDidChange should not call _doShow.", fu
   view._doAttach(document.body);
   equals(view.viewState, SC.CoreView.ATTACHED_SHOWN, "A newly created orphan view that is rendered and attached should be in the state");
 
+  // set up _doShow to fail, if called
   view._doShow = function() {
-    ok(false, '_doShow was called in teh ATTACHED_SHOWN state');
+    ok(false, '_doShow should not be called in the ATTACHED_SHOWN state');
   };
 
+  // call _isVisibleDidChange
+  view._isVisibleDidChange();
+});
+
+test("In ATTACHED_SHOWING state, _isVisibleDidChange should not call _doShow.", function () {
+ // Test expected state of the view.
+  view._doRender();
+  view._doAttach(document.body);
+
+  var transitionShow = { run: function () {} };
+  view.set('transitionShow', transitionShow);
+
+  SC.run(function () {
+    view.set('isVisible', false);
+    view.set('isVisible', true);
+  });
+
+  equals(view.viewState, SC.CoreView.ATTACHED_SHOWING, "The view should be in the state");
+
+  // set up _doShow to fail, if called
+  view._doShow = function() {
+    ok(false, '_doShow should not be called in the ATTACHED_SHOWING state');
+  };
+
+  // call _isVisibleDidChange
   view._isVisibleDidChange();
 });

--- a/frameworks/core_foundation/tests/views/view/view_states_test.js
+++ b/frameworks/core_foundation/tests/views/view/view_states_test.js
@@ -751,3 +751,18 @@ test("Test adding a hidden child view to attached shown parentView.", function (
   ok(!view.get('isVisibleInWindow'), "isVisibleInWindow should be false");
   ok(!child.get('isVisibleInWindow'), "isVisibleInWindow of child should be false");
 });
+
+test("In ATTACHED_SHOWN state, _isVisibleDidChange should not call _doShow.", function () {
+  var view = SC.View.create();
+
+  // Test expected state of the view.
+  view._doRender();
+  view._doAttach(document.body);
+  equals(view.viewState, SC.CoreView.ATTACHED_SHOWN, "A newly created orphan view that is rendered and attached should be in the state");
+
+  view._doShow = function() {
+    ok(false, '_doShow was called in teh ATTACHED_SHOWN state');
+  };
+
+  view._isVisibleDidChange();
+});

--- a/frameworks/core_foundation/views/view/statechart.js
+++ b/frameworks/core_foundation/views/view/statechart.js
@@ -1511,8 +1511,10 @@ SC.CoreView.reopen(
   */
   _isVisibleDidChange: function () {
     if (this.get('isVisible')) {
-      // show the view if it's not being shown already
-      if (this.get('viewState') !== SC.CoreView.ATTACHED_SHOWN) {
+      // show the view if it's not being shown already,
+      // unless the view is transitioning to being hidden
+      var viewState = this.get('viewState');
+      if (!(viewState & SC.CoreView.IS_SHOWN) || (viewState == SC.CoreView.ATTACHED_HIDING)) {
         this._doShow();
       }
     } else {

--- a/frameworks/core_foundation/views/view/statechart.js
+++ b/frameworks/core_foundation/views/view/statechart.js
@@ -1511,7 +1511,10 @@ SC.CoreView.reopen(
   */
   _isVisibleDidChange: function () {
     if (this.get('isVisible')) {
-      this._doShow();
+      // show the view if it's not being shown already
+      if (this.get('viewState') !== SC.CoreView.ATTACHED_SHOWN) {
+        this._doShow();
+      }
     } else {
       this._doHide();
     }


### PR DESCRIPTION
Fixes #1325.