### PR TITLE
Fixes SC.PickerPane resizing.

### DIFF
--- a/frameworks/desktop/panes/picker.js
+++ b/frameworks/desktop/panes/picker.js
@@ -644,7 +644,9 @@ SC.PickerPane = SC.PalettePane.extend(
       // Create an adjustment layout from the computed position.
       adjustHash = {
         left: frame.x,
-        top: frame.y
+        top: frame.y,
+        width: frame.width,
+        height: frame.height
       };
 
       // If the computed position also constrains width or height, add it to the adjustment.


### PR DESCRIPTION
Previously, a menu longer than the screen would not know to resize itself or create a scroll view, so the items off screen were unreachable.

These lines were removed in commit 9fc9ee89 for the new transition feature, but it my brief testing it looks like this removal was unnecessary.
