### PR TITLE
Fixes SC.MenuScrollView scrollers

### DIFF
--- a/frameworks/desktop/views/menu_scroll.js
+++ b/frameworks/desktop/views/menu_scroll.js
@@ -100,7 +100,7 @@ SC.MenuScrollView = SC.ScrollView.extend(
   },
 
   /** @private @see SC.ScrollView. When the content view's size changes, we need to update our scroll offset properties. */
-  _sc_repositionContentViewUnfiltered: function () {
+  _sc_updateScrollers: function () {
     var hasVerticalScroller = this.get('hasVerticalScroller'),
         // UNUSED. minimumVerticalScrollOffset = this.get('minimumVerticalScrollOffset'),
         maximumVerticalScrollOffset = this.get('maximumVerticalScrollOffset');


### PR DESCRIPTION
Previously they only partially worked because they never had the 'maximum' property set by the scroll view. The _sc_contentViewSizeDidChangeUnfiltered function was not being called, most likely because it was removed in the recent SC.ScrollView refactor. Changing it to _sc_updateScrollers resolves the issue.