### PR TITLE
Fix the SC.Validator.Number

### DIFF
--- a/frameworks/foundation/validators/number.js
+++ b/frameworks/foundation/validators/number.js
@@ -10,7 +10,7 @@ sc_require('system/utils/misc');
 
 /**
   Handles parsing and validating of numbers.
-  
+
   @extends SC.Validator
   @author Charles Jolley
   @version 1.0
@@ -20,13 +20,13 @@ SC.Validator.Number = SC.Validator.extend(
 /** @scope SC.Validator.Number.prototype */ {
 
   /**
-    Number of decimal places to show.  
-    
+    Number of decimal places to show.
+
     If 0, then numbers will be treated as integers.  Otherwise, numbers will
     show with a fixed number of decimals.
   */
   places: 0,
-  
+
   fieldValueForObject: function(object, form, field) {
     switch(SC.typeOf(object)) {
       case SC.T_NUMBER:
@@ -69,18 +69,18 @@ SC.Validator.Number = SC.Validator.extend(
     }
     return value ;
   },
-  
-  validate: function(form, field) { 
+
+  validate: function(form, field) {
     var value = field.get('fieldValue') ;
-    return (value === '') || !(isNaN(value) || isNaN(parseFloat(value))) ; 
+    return (value === '') || !(isNaN(value) || isNaN(parseFloat(value))) ;
   },
-  
+
   validateError: function(form, field) {
     var label = field.get('errorLabel') || 'Field' ;
     return SC.$error(SC.String.loc("Invalid.Number(%@)", label), label) ;
   },
-  
-  /** 
+
+  /**
     Allow only numbers, dashes, period, and commas
   */
   validateKeyDown: function(form, field, charStr) {
@@ -91,11 +91,11 @@ SC.Validator.Number = SC.Validator.extend(
 
     if(this.get('places')===0){
       if(charStr.length===0) return true;
-      else return text.match(/^[\-{0,1}]?[0-9,\0]*/)[0]===text;
+      else return (text.match(/^[\-{0,1}]?[0-9,\0]*/) || [])[0]===text;
     }else {
       if(charStr.length===0) return true;
-      else return text.match(/^[\-{0,1}]?[0-9,\0]*\.?[0-9\0]+/)===text;
+      else return (text.match(/^[\-{0,1}]?[0-9,\0]*\.?[0-9\0]+/) || [])[0]===text;
     }
   }
-    
+
 }) ;


### PR DESCRIPTION
The keydown validation was not working properly:
1. for floats was not working at all (was comparing an array with a string)
2. for integers was producing errors with some data input (not protected against mismatching that is producing a null array)