### PR TITLE
Added placeholder console.trace() for browsers that don't have it

### DIFF
--- a/frameworks/runtime/core.js
+++ b/frameworks/runtime/core.js
@@ -29,6 +29,12 @@ if (typeof console === 'undefined') {
   console.log = console.info = console.warn = console.error = function () {};
 }
 
+// prevent console.trace from blowing things up - some browsers like IE10 has
+// a console object but no console.trace
+if (!console.trace) {
+    console.trace = function() {};
+}
+
 window.SC = window.SC || {};
 window.SproutCore = window.SproutCore || SC;
 


### PR DESCRIPTION
`console.trace` is used in some places in the SproutCore code (e.g., https://github.com/sproutcore/sproutcore/blob/master/frameworks/runtime/system/run_loop.js#L166), but some browsers don't support it (IE 10).

So, just added a check for that and provide a empty placeholder for that.