### PR TITLE
SC.AutoResize bug fixes

### DIFF
--- a/frameworks/foundation/mixins/auto_resize.js
+++ b/frameworks/foundation/mixins/auto_resize.js
@@ -323,6 +323,10 @@ SC.AutoResize = {
     if (!this.get('shouldResizeWidth')) {
       layer.style.maxWidth = $(layer).outerWidth() + 'px';
     }
+
+    if (this.get('shouldResizeWidth') && this.get('maxWidth')) {
+      layer.style.maxWidth = this.get('maxWidth') + 'px';
+    }
   },
 
   /**

--- a/frameworks/foundation/mixins/auto_resize.js
+++ b/frameworks/foundation/mixins/auto_resize.js
@@ -220,13 +220,17 @@ SC.AutoResize = {
   scheduleMeasurement: function() {
     var batchResizeId = this.get('batchResizeId');
 
-    // only measure if we are visible, active, and the text or style actually changed
-    if (!this.get('shouldMeasureSize') || !this.get('isVisibleInWindow') || (this.get('autoResizeText') === this._lastMeasuredText && batchResizeId === this._lastMeasuredId)) return;
+    // only measure if we are visible, active, and the text or style or maxWidth or maxHeight actually changed
+    if (!this.get('shouldMeasureSize') ||
+        !this.get('isVisibleInWindow') ||
+        (this.get('autoResizeText') === this._lastMeasuredText && batchResizeId === this._lastMeasuredId && this.get('maxHeight') === this._lastMeasuredMaxHeight && this.get('maxWidth') === this._lastMeasuredMaxWidth)) {
+        return;
+    }
 
     // batchResizeId is allowed to be undefined; views without an id will just
     // get measured one at a time
     SC.AutoResizeManager.scheduleMeasurementForView(this, batchResizeId);
-  }.observes('isVisibleInWindow', 'shouldMeasureSize', 'autoResizeText', 'batchResizeId'),
+  }.observes('isVisibleInWindow', 'shouldMeasureSize', 'autoResizeText', 'batchResizeId', 'maxWidth', 'maxHeight'),
 
   /** @private */
   _lastMeasuredText: null,
@@ -297,6 +301,8 @@ SC.AutoResize = {
     // set the measured value so we can avoid extra measurements in the future
     this._lastMeasuredText = autoResizeText;
     this._lastMeasuredId = batchResizeId;
+    this._lastMeasuredMaxWidth = this.get('maxWidth');
+    this._lastMeasuredMaxHeight = this.get('maxHeight');
 
     return metrics;
   },

--- a/frameworks/foundation/tests/mixins/auto_resize_test.js
+++ b/frameworks/foundation/tests/mixins/auto_resize_test.js
@@ -306,3 +306,35 @@ test("Resize text only for input where input has padding.", function () {
     start();
   }, 500);
 });
+
+/**
+  When resizing the height and/or width, we should restrict the max width given.
+  This way, the height and width will grow appropriately to fit the target as
+  text wraps within the maximum values.
+  */
+test("Resizing height and width will also respect max width.", function () {
+  stop(700);
+
+  var pane = SC.Pane.create({
+    layout: { top: 200, left: 0, width: 50, height: 50 }
+  });
+
+  SC.run(function () {
+    view.set('shouldResizeWidth', true);
+    view.set('shouldResizeHeight', true);
+    view.set('maxWidth', 200);
+
+    pane.appendChild(view);
+    pane.append();
+  });
+
+  setTimeout(function () {
+    equals(view.get('frame').width, 200, 'frame width is 200');
+    ok(view.get('layout').height > 200, 'height > 200');
+
+    pane.destroy();
+    pane.remove();
+
+    start();
+  }, 500);
+});


### PR DESCRIPTION
- Respect auto resize max width better, when resizing both width and height. Currently, when dealing with a view with `maxWidth` set, the measurement element will still grow in width beyond `maxWidth`
- Allow re-measurement when `maxWidth` or `maxHeight` changes. Currently, even when `maxWidth` or `maxHeight` changes, the mixin doesn't allow re-measurement if the text/style didn't change.