### PR TITLE
Fixes 1318

### DIFF
--- a/frameworks/core_foundation/core.js
+++ b/frameworks/core_foundation/core.js
@@ -192,6 +192,10 @@ SC.mixin(/** @lends SC */ {
     }
     //@endif
 
+    if(element instanceof HTMLDocument) {
+      return null;
+    }
+
     // Search for the view for the given element.
     var viewCache = SC.View.views,
       view = viewCache[element.getAttribute('id')];


### PR DESCRIPTION
 SC.View#viewFor now bails if the element is an instance of HTMLDocument.