### PR TITLE
Removes the keypress handler which has no listener and is not used anymore

### DIFF
--- a/frameworks/core_foundation/system/root_responder.js
+++ b/frameworks/core_foundation/system/root_responder.js
@@ -779,22 +779,6 @@ SC.RootResponder = SC.Object.extend(
     if(SC.browser.isIE8OrLower) this.listenFor(['focusin', 'focusout'], document);
     else this.listenFor(['focus', 'blur'], window);
 
-    // handle special case for keypress- you can't use normal listener to block
-    // the backspace key on Mozilla
-    if (this.keypress) {
-      if (SC.CAPTURE_BACKSPACE_KEY && SC.browser.isMozilla) {
-        var responder = this ;
-        document.onkeypress = function(e) {
-          e = SC.Event.normalizeEvent(e);
-          return responder.keypress.call(responder, e);
-        };
-
-      // Otherwise, just add a normal event handler.
-      } else {
-        SC.Event.add(document, 'keypress', this, this.keypress);
-      }
-    }
-
     // Add an array of transition listeners for immediate use (these will be cleaned up when actual testing completes).
     // Because the transition test happens asynchronously and because we don't want to
     // delay the launch of the application in order to a transition test (the app won't
@@ -2017,14 +2001,11 @@ SC.RootResponder = SC.Object.extend(
       // duplicate the event sent in keydown when a modifier key is pressed.
       if (isFirefoxArrowKeys || this._isPrintableKey(evt)) {
         return this.sendEvent('keyDown', evt) ? evt.hasCustomEventHandling : YES;
-    }
+      }
     }
   },
 
   keyup: function(evt) {
-    // to end the simulation of keypress in firefox set the _ffevt to null
-    if(this._ffevt) this._ffevt=null;
-
     // modifier keys are handled separately by the 'flagsChanged' event
     // send event for modifier key changes, but only stop processing if this is only a modifier change
     var ret = this._handleModifierChanges(evt);

--- a/frameworks/core_foundation/system/root_responder.js
+++ b/frameworks/core_foundation/system/root_responder.js
@@ -1874,27 +1874,10 @@ SC.RootResponder = SC.Object.extend(
     return !!SC.MODIFIER_KEYS[evt.charCode];
   },
 
-   /**
-     @private
-     Determines if the key is printable (and therefore should be dispatched from keypress).
-     Some browsers send backspace, tab, enter, and escape on keypress, so we want to
-     explicitly ignore those here.
-
-     @param {KeyboardEvent} evt keypress event
-     @returns {Boolean}
-   */
-  _isPrintableKey: function (evt) {
-    return ((evt.originalEvent.which === undefined || evt.originalEvent.which > 0) &&
-      !(evt.which === 8 || evt.which === 9 || evt.which === 13 || evt.which === 27));
-  },
-
   /** @private
     The keydown event occurs whenever the physically depressed key changes.
     This event is used to deliver the flagsChanged event and to with function
     keys and keyboard shortcuts.
-
-    All actions that might cause an actual insertion of text are handled in
-    the keypress event.
 
     References:
         http://www.quirksmode.org/js/keys.html
@@ -1904,9 +1887,6 @@ SC.RootResponder = SC.Object.extend(
   keydown: function(evt) {
     if (SC.none(evt)) return YES;
     var keyCode = evt.keyCode;
-    if (SC.browser.isMozilla && evt.keyCode===9) {
-      this.keydownCounter = 1;
-    }
     // Fix for IME input (japanese, mandarin).
     // If the KeyCode is 229 wait for the keyup and
     // trigger a keyDown if it is is enter onKeyup.
@@ -1944,10 +1924,6 @@ SC.RootResponder = SC.Object.extend(
       // otherwise, send as keyDown event.  If no one was interested in this
       // keyDown event (probably the case), just let the browser do its own
       // processing.
-
-      // Arrow keys are handled in keypress for firefox
-      if (keyCode>=37 && keyCode<=40 && SC.browser.isMozilla) return YES;
-
       ret = this.sendEvent('keyDown', evt) ;
 
       // attempt key equivalent if key not handled
@@ -1962,47 +1938,6 @@ SC.RootResponder = SC.Object.extend(
     }
 
     return forceBlock ? NO : ret ;
-  },
-
-  /** @private
-    The keypress event occurs after the user has typed something useful that
-    the browser would like to insert.  Unlike keydown, the input codes here
-    have been processed to reflect that actual text you might want to insert.
-
-    Normally ignore any function or non-printable key events.  Otherwise, just
-    trigger a keyDown.
-  */
-  keypress: function(evt) {
-    var ret,
-        keyCode   = evt.keyCode,
-        isFirefox = SC.browser.isMozilla;
-
-    if (isFirefox && evt.keyCode===9) {
-      this.keydownCounter++;
-      if (this.keydownCounter === 2) return YES;
-    }
-
-    // delete is handled in keydown() for most browsers
-    if (isFirefox && (evt.which === 8)) {
-      //get the keycode and set it for which.
-      evt.which = keyCode;
-      ret = this.sendEvent('keyDown', evt);
-      return ret ? (SC.allowsBackspaceToPreviousPage || evt.hasCustomEventHandling) : YES ;
-
-    // normal processing.  send keyDown for printable keys...
-    //there is a special case for arrow key repeating of events in FF.
-    } else {
-      var isFirefoxArrowKeys = (keyCode >= 37 && keyCode <= 40 && isFirefox),
-          charCode           = evt.charCode;
-
-      if ((charCode !== undefined && charCode === 0 && evt.keyCode!==9) && !isFirefoxArrowKeys) return YES;
-      if (isFirefoxArrowKeys) evt.which = keyCode;
-      // we only want to rethrow if this is a printable key so that we don't
-      // duplicate the event sent in keydown when a modifier key is pressed.
-      if (isFirefoxArrowKeys || this._isPrintableKey(evt)) {
-        return this.sendEvent('keyDown', evt) ? evt.hasCustomEventHandling : YES;
-      }
-    }
   },
 
   keyup: function(evt) {

--- a/frameworks/desktop/tests/panes/menu/ui.js
+++ b/frameworks/desktop/tests/panes/menu/ui.js
@@ -90,7 +90,6 @@ function clickOn(view, shiftKey, ctrlKey) {
 
   @param {SC.View} view the view
   @param {Number} keyCode key to simulate
-  @param {Boolean} [isKeyPress] simulate key press event
   @param {Boolean} [shiftKey] simulate shift key pressed
   @param {Boolean} [ctrlKey] simulate ctrlKey pressed
 */
@@ -100,7 +99,7 @@ function keyPressOn(view, keyCode, isKeyPress, shiftKey, ctrlKey) {
       shiftKey: !!shiftKey,
       ctrlKey: !!ctrlKey,
       keyCode: keyCode,
-      charCode: isKeyPress ? keyCode : 0,
+      charCode: 0,
       which: keyCode
     },
     ev;
@@ -109,11 +108,6 @@ function keyPressOn(view, keyCode, isKeyPress, shiftKey, ctrlKey) {
 
   ev = SC.Event.simulateEvent(layer, 'keydown', opts);
   SC.Event.trigger(layer, 'keydown', [ev]);
-
-  if (isKeyPress) {
-    ev = SC.Event.simulateEvent(layer, 'keypress', opts);
-    SC.Event.trigger(layer, 'keypress', [ev]);
-  }
 
   ev = SC.Event.simulateEvent(layer, 'keyup', opts);
   SC.Event.trigger(layer, 'keyup', [ev]);

--- a/frameworks/desktop/tests/views/collection/keyboard.js
+++ b/frameworks/desktop/tests/views/collection/keyboard.js
@@ -22,17 +22,16 @@ pane.add('default', SC.CollectionView, {
 
   @param {SC.View} view the view
   @param {Number} keyCode key to simulate
-  @param {Boolean} [isKeyPress] simulate key press event
   @param {Boolean} [shiftKey] simulate shift key pressed
   @param {Boolean} [ctrlKey] simulate ctrlKey pressed
 */
-function keyPressOn(view, keyCode, isKeyPress, shiftKey, ctrlKey) {
+function keyPressOn(view, keyCode, shiftKey, ctrlKey) {
   var layer = view.get('layer'),
     opts = {
       shiftKey: !!shiftKey,
       ctrlKey: !!ctrlKey,
       keyCode: keyCode,
-      charCode: isKeyPress ? keyCode : 0,
+      charCode: 0,
       which: keyCode
     },
     ev;
@@ -41,11 +40,6 @@ function keyPressOn(view, keyCode, isKeyPress, shiftKey, ctrlKey) {
 
   ev = SC.Event.simulateEvent(layer, 'keydown', opts);
   SC.Event.trigger(layer, 'keydown', [ev]);
-
-  if (isKeyPress) {
-    ev = SC.Event.simulateEvent(layer, 'keypress', opts);
-    SC.Event.trigger(layer, 'keypress', [ev]);
-  }
 
   ev = SC.Event.simulateEvent(layer, 'keyup', opts);
   SC.Event.trigger(layer, 'keyup', [ev]);
@@ -129,7 +123,7 @@ test("moveDownAndModifySelection", function () {
   });
   equals(view.getPath('selection.length'), 1, 'Should have a single selected row');
   SC.run(function () {
-    keyPressOn(view, SC.Event.KEY_DOWN, false, true, false);
+    keyPressOn(view, SC.Event.KEY_DOWN, true, false);
   });
   equals(view.getPath('selection.length'), 2, 'Should have an additional selected row');
   SC.run(function () {
@@ -138,7 +132,7 @@ test("moveDownAndModifySelection", function () {
   });
   equals(view.getPath('selection.length'), 1, 'Should have a single selected row');
   SC.run(function () {
-    keyPressOn(view, SC.Event.KEY_DOWN, false, true, false);
+    keyPressOn(view, SC.Event.KEY_DOWN, true, false);
   });
   equals(view.getPath('selection.length'), 1, 'Should still have a single selected row');
 
@@ -157,7 +151,7 @@ test("moveUpAndModifySelection", function () {
   });
   equals(view.getPath('selection.length'), 1, 'Should have a single selected row');
   SC.run(function () {
-    keyPressOn(view, SC.Event.KEY_UP, false, true, false);
+    keyPressOn(view, SC.Event.KEY_UP, true, false);
   });
   equals(view.getPath('selection.length'), 2, 'Should have an additional selected row');
   SC.run(function () {
@@ -166,7 +160,7 @@ test("moveUpAndModifySelection", function () {
   });
   equals(view.getPath('selection.length'), 1, 'Should have a single selected row');
   SC.run(function () {
-    keyPressOn(view, SC.Event.KEY_UP, false, true, false);
+    keyPressOn(view, SC.Event.KEY_UP, true, false);
   });
   equals(view.getPath('selection.length'), 1, 'Should still have a single selected row');
 

--- a/frameworks/foundation/views/text_field.js
+++ b/frameworks/foundation/views/text_field.js
@@ -847,17 +847,6 @@ SC.TextFieldView = SC.FieldView.extend(SC.Editable,
       this.invokeLast(this._addTextAreaEvents);
     } else {
       this._addTextAreaEvents();
-
-      // In Firefox, for input fields only (that is, not textarea elements),
-      // if the cursor is at the end of the field, the "down" key will not
-      // result in a "keypress" event for the document (only for the input
-      // element), although it will be bubbled up in other contexts.  Since
-      // SproutCore's event dispatching requires the document to see the
-      // event, we'll manually forward the event along.
-      if (SC.browser.isMozilla) {
-        var input = this.$input();
-        SC.Event.add(input, 'keypress', this, this._firefox_dispatch_keypress);
-      }
     }
   },
 
@@ -918,7 +907,6 @@ SC.TextFieldView = SC.FieldView.extend(SC.Editable,
     SC.Event.remove(input, 'focus',  this, this._textField_fieldDidFocus);
     SC.Event.remove(input, 'blur',   this, this._textField_fieldDidBlur);
     SC.Event.remove(input, 'select', this, this._textField_selectionDidChange);
-    SC.Event.remove(input, 'keypress',  this, this._firefox_dispatch_keypress);
     SC.Event.remove(input, 'input', this, this._textField_inputDidChange);
   },
 
@@ -1026,28 +1014,6 @@ SC.TextFieldView = SC.FieldView.extend(SC.Editable,
     Move magic number out so it can be over-written later in inline editor
    */
   _topOffsetForFirefoxCursorFix: 3,
-
-  /** @private
-    In Firefox, as of 3.6 -- including 3.0 and 3.5 -- for input fields only
-    (that is, not textarea elements), if the cursor is at the end of the
-    field, the "down" key will not result in a "keypress" event for the
-    document (only for the input element), although it will be bubbled up in
-    other contexts.  Since SproutCore's event dispatching requires the
-    document to see the event, we'll manually forward the event along.
-   */
-  _firefox_dispatch_keypress: function (evt) {
-    var selection = this.get('selection'),
-        value     = this.get('value'),
-        valueLen  = value ? value.length : 0,
-        responder;
-
-    if (!selection || ((selection.get('length') === 0 && (selection.get('start') === 0) || selection.get('end') === valueLen))) {
-      responder = SC.RootResponder.responder;
-      if (evt.keyCode === 9) return;
-      responder.keypress.call(responder, evt);
-      evt.stopPropagation();
-    }
-  },
 
   /** @private */
   _textField_selectionDidChange: function () {


### PR DESCRIPTION
Also removes a Firefox keypress hack which is not needed anymore in recents version of Firefox and is
breaking copy/paste shortcut in text fields.