### PR TITLE
removed dependency on deprecated SC.MENUPANE.VERTICAL_OFFSET property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Edge
 ### DEPRECATIONS & REMOVALS
 ### BUG FIXES
 
+* Removed dependency on deprecated SC.MENUPANE.VERTICAL_OFFSET property that could cause a height NaN error in SC.PickerPane
+
 1.11.1
 -----------
 

--- a/frameworks/desktop/panes/picker.js
+++ b/frameworks/desktop/panes/picker.js
@@ -939,7 +939,7 @@ SC.PickerPane = SC.PalettePane.extend(
 
     // If the height of the menu is bigger than the window height, resize it.
     if (frame.height + frame.y + 35 >= windowFrame.height) {
-      frame.height = windowFrame.height - frame.y - (SC.MenuPane.VERTICAL_OFFSET * 2);
+      frame.height = windowFrame.height - frame.y - (this.get('windowPadding') * 2);
     }
 
     return frame;


### PR DESCRIPTION
The SC.MENUPANE.VERTICAL_OFFSET property has been deprecated and removed. I removed a function that still relies on it, and currently creates a height NaN error because SC.MenuPane.VERTICAL_OFFSET is undef. Could you please review? 

Let me know if I can help fix this another way, i.e. by replacing SC.MenuPane.VERTICAL_OFFSET with something. For now I have just bypassed this function since currently it does nothing and also causes a breaking error. Thanks! 