### PR TITLE
Fixes an issue with SC.offset relative to the offset parent

### DIFF
--- a/frameworks/core_foundation/system/utils.js
+++ b/frameworks/core_foundation/system/utils.js
@@ -98,15 +98,15 @@ SC.mixin( /** @scope SC */ {
     var userAgent,
         index,
         mobileBuildNumber,
-        result;
+        result = jQuery(elem).offset();
 
     relativeToFlag = relativeToFlag || 'document';
 
     if (relativeToFlag === 'parent') {
-      result = jQuery(elem).position();
+      var parentOffset = jQuery(elem).offsetParent().offset();
+      result.left -= parentOffset.left;
+      result.top -= parentOffset.top;
     } else {
-      result = jQuery(elem).offset();
-
       // jQuery does not workaround a problem with Mobile Safari versions prior to 4.1 that add the scroll
       // offset to the results of getBoundingClientRect.
       //

--- a/frameworks/foundation/views/inline_text_field.js
+++ b/frameworks/foundation/views/inline_text_field.js
@@ -259,7 +259,7 @@ SC.InlineTextFieldView = SC.TextFieldView.extend(SC.InlineEditor,
     if (exampleFrame && elem) {
       var frame = SC.offset(elem, 'parent');
 
-      layout.top = targetLayout.top + frame.y - exampleFrame.height/2;
+      layout.top = targetLayout.top + frame.y;
       layout.left = targetLayout.left + frame.x;
       layout.height = exampleFrame.height;
       layout.width = exampleFrame.width;


### PR DESCRIPTION
jQuery fail to compute the correct offset when using $.position.
This is because, in SC, centered elements are positioned in percentage
like this: top: 50%; margin-top: -10px. And jQuery is subtracting the
margin from the offset which lead to a wrong value.
This commit fixe this and remove some hacky code in
positionOverTargetView which was related to this behaviour. This hack
were causing trouble when an SC.InlineTextFieldView were displayed from
an element positioned without percentage (like in SC.TableView).