### PR TITLE
fixing issue #1374 by trying to detect a single click event by a timer

### DIFF
--- a/frameworks/core_foundation/system/root_responder.js
+++ b/frameworks/core_foundation/system/root_responder.js
@@ -2185,8 +2185,15 @@ SC.RootResponder = SC.Object.extend(
     @param {Event} evt the click event
     @returns {Boolean} whether the event should be propagated to the browser
   */
-  click: function(evt) {
+   click: function(evt) {
     if (!this._lastMouseUpCustomHandling || !this._lastMouseDownCustomHandling) {
+      var diff = Date.now() - (this._lastMouseUpAt || 0);
+      if (diff > 250) { // should be single click event.
+        var view = this.targetViewForEvent(evt);
+        // single click event, fake mouseDown and mouseUp
+        this.sendEvent('mouseDown', evt, view);
+        this.sendEvent('mouseUp', evt, view)
+      }
       evt.preventDefault();
       evt.stopPropagation();
       return NO;


### PR DESCRIPTION
As described in issue #1374, there is an issue where IE only sends a click event without any mouse events. As SC only uses mousedown and mouseup to trigger controls, an attempt is made to detect whether the click event is a standalone event by checking whether the last time the mouseup event was handled was at least 250ms ago. If that is the case, the event is mapped onto the mouseDown and mouseUp events.