### PR TITLE
Add the `word-break` CSS property to _copy_computed_props so views with…

### DIFF
--- a/frameworks/foundation/system/utils/string_measurement.js
+++ b/frameworks/foundation/system/utils/string_measurement.js
@@ -10,7 +10,7 @@ SC.mixin( /** @scope SC */ {
   _copy_computed_props: [
     "maxWidth", "maxHeight", "paddingLeft", "paddingRight", "paddingTop", "paddingBottom",
     "fontFamily", "fontSize", "fontStyle", "fontWeight", "fontVariant", "lineHeight",
-    "whiteSpace", "letterSpacing", "wordWrap"
+    "whiteSpace", "letterSpacing", "wordWrap", "wordBreak"
   ],
 
   /**


### PR DESCRIPTION
… `SC.AutoResize` will consider words that are longer than the view is wide and correctly calculate the height for that view.