### PR TITLE
Prevent an issue if the validator is changed

### DIFF
--- a/frameworks/foundation/views/field.js
+++ b/frameworks/foundation/views/field.js
@@ -40,7 +40,7 @@ SC.FieldView = SC.View.extend(SC.Control, SC.Validatable,
     var value = this.get('value');
     if (SC.typeOf(value) === SC.T_ERROR) value = value.get('errorValue');
     return this.fieldValueForObject(value);
-  }.property('value', 'validator').cacheable(),
+  }.property('value', 'validatorObject').cacheable(),
 
   // ..........................................................
   // PRIMITIVES


### PR DESCRIPTION
The problem occur because when the validator is changed, the private
property _validator is updated after fieldValueForObject is call. Which
mean the previous validator is used.
For example, this is an issue if we update the format of an
SC.DateFieldView.