### PR TITLE
Re-attach pane modal if owner pane is re-attached during transition out

### DIFF
--- a/frameworks/core_foundation/views/view/statechart.js
+++ b/frameworks/core_foundation/views/view/statechart.js
@@ -2139,6 +2139,12 @@ SC.CoreView.reopen(
     var transitionOut = this.get('transitionOut'),
       options = this.get('transitionOutOptions') || {};
 
+    //@if (debug)
+    if (SC.LOG_VIEW_STATES || this.SC_LOG_VIEW_STATE) {
+      SC.Logger.log('%c%@ — _transitionOut()'.fmt(this), SC.LOG_VIEW_STATES_STYLE[this.get('viewState')]);
+    }
+    //@endif
+
     if (!inPlace) {
       this._setupTransition(transitionOut);
     }

--- a/frameworks/desktop/panes/modal.js
+++ b/frameworks/desktop/panes/modal.js
@@ -44,7 +44,23 @@ SC.ModalPane = SC.Pane.extend(
   paneWillAppend: function(pane) {
     var _tmpPane;
     this._openPaneCount++;
-    if (!this.get('isVisibleInWindow')) this.append();
+    if (!this.get('isVisibleInWindow')) {
+      // before appending the modal pane, need to figure out if the pane
+      // is visible or not so we can know where to attach the picker pane.
+      
+      if (pane.get('isVisibleInWindow')) {
+        // if the pane is already visible, make sure the modal pane is
+        // append below the pane
+        var self = this;
+        this.insert(function () {
+          self._doAttach(document.body, pane.get('layer'));
+        });
+      }
+      else {
+        // if the pane is not visible, just do a simple append
+        this.append();
+      }
+    }
     var panes = SC.RootResponder.responder.panes;
     for(var i=0, iLen=panes.length; i<iLen; i++ ){
       _tmpPane = panes[i];

--- a/frameworks/desktop/panes/panel.js
+++ b/frameworks/desktop/panes/panel.js
@@ -170,7 +170,9 @@ SC.PanelPane = SC.Pane.extend(
   /** @private - whenever showing on screen, deal with modal pane as well */
   appendTo: function(elem) {
     var pane ;
-    if (!this.get('isVisibleInWindow') && this.get('isModal') && (pane = this._modalPane())) {
+    // show the modal only if the pane is currently not visible, or if the pane
+    // is currently transitioning out
+    if ((!this.get('isVisibleInWindow') || this.get('viewState') == SC.CoreView.ATTACHED_BUILDING_OUT) && this.get('isModal') && (pane = this._modalPane())) {
       this._isShowingModal = YES;
       pane.paneWillAppend(this);
     }

--- a/frameworks/desktop/tests/panes/panel/ui.js
+++ b/frameworks/desktop/tests/panes/panel/ui.js
@@ -118,6 +118,43 @@ test("Verify SC.PanelPane#isModal", function() {
   });
 });
 
+test("Verify panel pane's modal will be attached/detached during lifecycle", function() {
+  var modalPane = SC.ModalPane.create();
+  var pane = SC.PanelPane.create({
+    contentView: SC.View,
+    modalPane: modalPane,
+    isModal: YES,
+    transitionIn: SC.View.FADE_IN,
+    transitionOut: SC.View.FADE_OUT
+  });
+
+  // normal life cycle
+
+  SC.run(function () {
+    pane.append();
+  });
+  equals(pane.getPath('modalPane.viewState'), SC.CoreView.ATTACHED_SHOWN, "Modal pane is attached when pane becomes visible");
+  equals(pane.$().prev()[0], modalPane.get('layer'), "Modal pane is attached right before the pane");
+  SC.run(function () {
+    pane.remove();
+  });
+  equals(pane.getPath('modalPane.viewState'), SC.CoreView.UNATTACHED, "Modal pane is unattached when pane becomes isvisible");
+
+  // life cycle when there are midstream changes
+
+  SC.run(function () {
+    pane.append();
+    pane.remove();
+    pane.append();
+  });
+  equals(pane.getPath('modalPane.viewState'), SC.CoreView.ATTACHED_SHOWN, "Modal pane is attached when pane becomes visible");
+  equals(pane.$().prev()[0], modalPane.get('layer'), "Modal pane is attached right before the pane");
+
+  SC.run(function () {
+    pane.destroy();
+  });
+});
+
 test("Should changing isModal when a pane is transitioning out not append the modal pane?");
 /*
   Previously, if the panel pane was not shown it would simply not append the modal pane to it. Which


### PR DESCRIPTION
This fixes a bug with picker pane if the user quickly popups the pickerpane while it's transition out animation is taking place. This will cause the modal pane not to be attached.

This puts the app in a weird state, because even though the picker pane is already visible, a button or another UI for opening the pane is still clickable and an error would occur.