### PR TITLE
Implemented the documented verticalFade and horizontalFade properties on SC.ScrollView

### DIFF
--- a/frameworks/desktop/tests/views/scroll/ui.js
+++ b/frameworks/desktop/tests/views/scroll/ui.js
@@ -66,8 +66,17 @@
       verticalScrollerView: SC.OverlayScrollerView,
       horizontalOverlay: YES,
       horizontalScrollerView: SC.OverlayScrollerView
-    });
+    })
 
+    .add("no fade scrollers", SC.ScrollView, {
+      contentView: iv,
+      verticalOverlay: YES,
+      verticalScrollerView: SC.OverlayScrollerView,
+      verticalFade: NO,
+      horizontalOverlay: YES,
+      horizontalScrollerView: SC.OverlayScrollerView,
+      horizontalFade: NO
+    });
 
   // ..........................................................
   // TEST VIEWS
@@ -291,6 +300,29 @@
         start();
       }, 200);
 
+    }, 1000);
+  });
+
+  test('Scrollers remain visible with horizontalFade: NO, verticalFade: NO', function() {
+    var view = pane.view('no fade scrollers'),
+        verticalScroller = view.get('verticalScrollerView'),
+        horizontalScroller = view.get('horizontalScrollerView'),
+        horizontalOpacity,
+        verticalOpacity;
+
+    stop(2000);
+    expect(2);
+    SC.RunLoop.begin();
+    view._sc_fadeInHorizontalScroller();
+    view._sc_fadeInVerticalScroller();
+    SC.RunLoop.end();
+    setTimeout(function() {
+      verticalOpacity = verticalScroller.$().css('opacity');
+      horizontalOpacity = horizontalScroller.$().css('opacity');
+
+      equals(verticalOpacity, '0.5', 'after fadein, vertical scroller opacity should remain 0.5');
+      equals(horizontalOpacity, '0.5', 'after fadein, horizontal scroller opacity should remain 0.5');
+      start();
     }, 1000);
   });
 

--- a/frameworks/desktop/views/scroll_view.js
+++ b/frameworks/desktop/views/scroll_view.js
@@ -1219,6 +1219,7 @@ SC.ScrollView = SC.View.extend({
   /** @private Fade in the horizontal scroller. Each scroller fades in/out independently. */
   _sc_fadeInHorizontalScroller: function () {
     var canScrollHorizontal = this.get('canScrollHorizontal'),
+      horizontalFade = this.get('horizontalFade'),
       horizontalScroller = this.get('horizontalScrollerView'),
       delay;
 
@@ -1231,9 +1232,11 @@ SC.ScrollView = SC.View.extend({
         // Fade in.
         horizontalScroller.fadeIn();
 
-        // Wait the minimum time before fading out again.
-        delay = this.get('_sc_minimumFadeOutDelay');
-        this._sc_horizontalFadeOutTimer = this.invokeLater(this._sc_fadeOutHorizontalScroller, delay);
+        if (horizontalFade) {
+          // Wait the minimum time before fading out again.
+          delay = this.get('_sc_minimumFadeOutDelay');
+          this._sc_horizontalFadeOutTimer = this.invokeLater(this._sc_fadeOutHorizontalScroller, delay);
+        }
       }
     }
   },
@@ -1241,6 +1244,7 @@ SC.ScrollView = SC.View.extend({
   /** @private Fade in the vertical scroller. Each scroller fades in/out independently. */
   _sc_fadeInVerticalScroller: function () {
     var canScrollVertical = this.get('canScrollVertical'),
+      verticalFade = this.get('verticalFade'),
       verticalScroller = this.get('verticalScrollerView'),
       delay;
 
@@ -1254,9 +1258,11 @@ SC.ScrollView = SC.View.extend({
         // Fade in.
         verticalScroller.fadeIn();
 
-        // Wait the minimum time before fading out again.
-        delay = this.get('_sc_minimumFadeOutDelay');
-        this._sc_verticalFadeOutTimer = this.invokeLater(this._sc_fadeOutVerticalScroller, delay);
+        if (verticalFade) {
+          // Wait the minimum time before fading out again.
+          delay = this.get('_sc_minimumFadeOutDelay');
+          this._sc_verticalFadeOutTimer = this.invokeLater(this._sc_fadeOutVerticalScroller, delay);
+        }
       }
     }
   },


### PR DESCRIPTION
The SC.ScrollView has these 2 properties defined and documented, but they were not implemented.  This makes my application able to leverage the property to keep the scroll bars from fading.

verticalFade
Determines whether the vertical scroller should fade out while in overlay mode. Has no effect if verticalOverlay is set to false.

horizontalFade
Determines whether the horizontal scroller should fade out while in overlay mode. Has no effect if horizontalOverlay is set to false.