### PR TITLE
Fixes a nasty initialization issue with SC.SplitView where size may be set to NaN

### DIFF
--- a/frameworks/desktop/views/split.js
+++ b/frameworks/desktop/views/split.js
@@ -561,7 +561,7 @@ SC.SplitView = SC.View.extend({
       if (isResizable === useResizable) {
         // if outOfSize === -1 then we are aggressively resizing (not resizing proportionally)
         if (outOfSize === -1) size += diff;
-        else size += (size / outOfSize) * diff;
+        else if (outOfSize !== 0) size += (size / outOfSize) * diff;
 
         size = Math.round(size);
 


### PR DESCRIPTION
I had for year a bad work around (which were making my split views uncollapse at each window resize) to prevent SC.SplitView from crashing my app at load. The issue was that the size of a child were set to `NaN`. I did not really know how to reproduce the issue, which makes adding a test quiet complicate. But I just found the proper way to fix it.