### PR TITLE
allowing orderBy to use a property path

### DIFF
--- a/frameworks/core_foundation/controllers/array.js
+++ b/frameworks/core_foundation/controllers/array.js
@@ -409,8 +409,8 @@ SC.ArrayController = SC.Controller.extend(SC.Array, SC.SelectionSupport,
         }
         order = match[2] ? -1 : 1;
 
-        if (a) { valueA = a.isObservable ? a.get(key) : a[key]; }
-        if (b) { valueB = b.isObservable ? b.get(key) : b[key]; }
+        if (a) { valueA = a.isObservable ? a.getPath(key) : a[key]; }
+        if (b) { valueB = b.isObservable ? b.getPath(key) : b[key]; }
 
         status = SC.compare(valueA, valueB) * order;
       }

--- a/frameworks/core_foundation/tests/controllers/array/array_case.js
+++ b/frameworks/core_foundation/tests/controllers/array/array_case.js
@@ -227,14 +227,14 @@ test("array orderBy using String with property path", function(){
     orderBy: 'title.title ASC'
   });
 
-  equals(testController.get('firstSelectableObject'), content[0], 'first selectable object should be the first object in arrangedObjects');
-  equals(testController.get('lastObject'), content[4], 'lastObject should be the last object in content');
+  equals(testController.get('firstSelectableObject'), c[0], 'first selectable object should be the first object in arrangedObjects');
+  equals(testController.get('lastObject'), c[4], 'lastObject should be the last object in content');
 
   // Reorder the content
   testController.set('orderBy', 'title.title DESC');
 
-  equals(testController.get('firstSelectableObject'), content[4], 'first selectable object should be the first object in arrangedObjects (changed order)');
-  equals(testController.get('lastObject'), content[0], 'lastObject should be the first object in content (changed order)');
+  equals(testController.get('firstSelectableObject'), c[4], 'first selectable object should be the first object in arrangedObjects (changed order)');
+  equals(testController.get('lastObject'), c[0], 'lastObject should be the first object in content (changed order)');
 });
 
 

--- a/frameworks/core_foundation/tests/controllers/array/array_case.js
+++ b/frameworks/core_foundation/tests/controllers/array/array_case.js
@@ -217,6 +217,26 @@ test("array orderBy using String", function(){
   equals(testController.get('lastObject'), content[0], 'lastObject should be the first object in content (changed order)');
 });
 
+test("array orderBy using String with property path", function(){
+  var c = "1 2 3 4 5".w().map(function(x) {
+    return TestObject.create({ title: { title: x }});
+  });
+
+  var testController = SC.ArrayController.create({
+    content: c,
+    orderBy: 'title.title ASC'
+  });
+
+  equals(testController.get('firstSelectableObject'), content[0], 'first selectable object should be the first object in arrangedObjects');
+  equals(testController.get('lastObject'), content[4], 'lastObject should be the last object in content');
+
+  // Reorder the content
+  testController.set('orderBy', 'title.title DESC');
+
+  equals(testController.get('firstSelectableObject'), content[4], 'first selectable object should be the first object in arrangedObjects (changed order)');
+  equals(testController.get('lastObject'), content[0], 'lastObject should be the first object in content (changed order)');
+});
+
 
 test("array orderBy using Array", function(){
   var complexContent,
@@ -312,7 +332,7 @@ test("verify enumerable propety chains invalidate without error on ArrayControll
   } catch (e) {
     didError = YES;
   }
-  
+
   ok(!didError, "Adding an object to an empty array controller with orderBy and an enumerable property chain proceeds without error.");
 
 });


### PR DESCRIPTION
This fixes the situation that only direct properties can be chosen for ordering. In a situation where nested records are used, it can be very useful to also be able to order by a property value on a nested object.
