### PR TITLE
SC.TextFieldView hint fixes

### DIFF
--- a/frameworks/foundation/views/text_field.js
+++ b/frameworks/foundation/views/text_field.js
@@ -992,6 +992,9 @@ SC.TextFieldView = SC.FieldView.extend(SC.Editable,
     if (this.get('applyImmediately') && timerNotPending) {
       this.invokeLater(this.fieldValueDidChange, 10);
     }
+    else {
+      this.updateHintOnFocus();
+    }
   },
 
   /** @private

--- a/frameworks/foundation/views/text_field.js
+++ b/frameworks/foundation/views/text_field.js
@@ -872,8 +872,8 @@ SC.TextFieldView = SC.FieldView.extend(SC.Editable,
 
     if (this.get('useHintOverlay') && !this.get('isTextArea')) {
       var hintJQ = this.$('.hint');
-
-      hintJQ.css('line-height', hintJQ.outerHeight() + 'px');
+      // in some cases hintJQ.outerHeight() can return 0, so default to height
+      hintJQ.css('line-height', (hintJQ.outerHeight() || height) + 'px');
     }
   },
 


### PR DESCRIPTION
Fixing two small issues with the hint. First is that under the Aki theme the hint can get height 0. The second is that when applyImmediately is set to false, the hint would only disappear on commit (loss of focus).