### PR TITLE
Adds passive event listeners support

### DIFF
--- a/frameworks/core_foundation/system/event.js
+++ b/frameworks/core_foundation/system/event.js
@@ -636,7 +636,15 @@ SC.mixin(SC.Event, /** @scope SC.Event */ {
 
       // Bind the global event handler to the element
       if (elem.addEventListener) {
-        elem.addEventListener(eventType, listener, useCapture);
+        if (SC.platform.supportsPassiveEventlisteners) {
+          elem.addEventListener(eventType, listener, {
+            capture: useCapture,
+            passive: false
+          });
+        }
+        else {
+          elem.addEventListener(eventType, listener, useCapture);
+        }
       } else if (elem.attachEvent) {
         // attachEvent is not working for IE8 and xhr objects
         // there is currently a hack in request , but it needs to fixed here.

--- a/frameworks/core_foundation/system/platform.js
+++ b/frameworks/core_foundation/system/platform.js
@@ -344,6 +344,24 @@ SC.platform = SC.Object.create({
   },
 
   /**
+    Whether the browser supports passive event listeners.
+
+    @type Boolean
+  */
+  supportsPassiveEventlisteners: function () {
+    var supportsPassiveOption = false;
+    try {
+      var opts = Object.defineProperty({}, 'passive', {
+        get: function() {
+          supportsPassiveOption = true;
+        }
+      });
+      window.addEventListener('test', null, opts);
+    } catch (e) {}
+    return supportsPassiveOption;
+  }(),
+
+  /**
     Whether the browser supports CSS animations.
 
     @type Boolean


### PR DESCRIPTION
If passive event listeners is supported by the browser, we always set passive to `false` as SC already take care to always call `preventDefault` for `touchstart` and `touchmove` events.