### PR TITLE
 Fixes an issue where most recent messages where removed when pruning to log

### DIFF
--- a/frameworks/runtime/system/logger.js
+++ b/frameworks/runtime/system/logger.js
@@ -278,7 +278,7 @@ SC.Logger = SC.Object.create(
 
     @type Number
   */
-  recordedLogMessagesPruningMinimumLength: 100,
+  recordedLogMessagesPruningMinimumLength: 400,
 
 
   /**

--- a/frameworks/runtime/system/logger.js
+++ b/frameworks/runtime/system/logger.js
@@ -1509,7 +1509,7 @@ SC.Logger = SC.Object.create(
     // Have we exceeded the maximum size?  If so, do some pruning.
     len = recordedMessages.length;
     if (len > this.get('recordedLogMessagesMaximumLength')) {
-      recordedMessages.splice(0, (len - this.get('recordedLogMessagesPruningMinimumLength')));
+      recordedMessages.splice(-this.get('recordedLogMessagesPruningMinimumLength'));
     }
 
     // Notify that the array content changed.


### PR DESCRIPTION
Also adjust `recordedLogMessagesPruningMinimumLength` to prevent removing most of the log when pruning.