### PR TITLE
Adds media queries support to SC.View

### DIFF
--- a/frameworks/core_foundation/system/application.js
+++ b/frameworks/core_foundation/system/application.js
@@ -214,6 +214,8 @@ SC.Application = SC.Responder.extend(SC.ResponderContext,
       responder.set('designModes', designModes);
       // UNUSED.
       // this.bind('designMode', SC.Binding.from('SC.RootResponder.responder.currentDesignMode'));
+
+      responder.mediaViews = SC.Set.create();
     }
   }
 

--- a/frameworks/core_foundation/system/root_responder.js
+++ b/frameworks/core_foundation/system/root_responder.js
@@ -312,6 +312,7 @@ SC.RootResponder = SC.Object.extend(
   resize: function() {
     this._resize();
     this._assignDesignMode();
+    this._handleMediaQueries();
 
     return YES; //always allow normal processing to continue.
   },
@@ -352,6 +353,17 @@ SC.RootResponder = SC.Object.extend(
         }, this);
       }
     }
+  },
+
+  /** @private */
+  _handleMediaQueries: function () {
+    var mediaViews = this.mediaViews;
+
+    mediaViews.forEach(function(view) {
+      SC.run(function() {
+        view.handleMediaQueries();
+      });
+    });
   },
 
   /**

--- a/frameworks/core_foundation/views/view.js
+++ b/frameworks/core_foundation/views/view.js
@@ -2494,12 +2494,15 @@ SC.View = SC.CoreView.extend(/** @scope SC.View.prototype */{
     // Theming
     this._lastTheme = this.get('theme');
 
+    this.registerMediaQueries();
   },
 
   /** @private */
   destroy: function () {
     // Clean up.
     this._previousLayout = null;
+
+    this.unregisterMediaQueries();
 
     return sc_super();
   },
@@ -2526,5 +2529,3 @@ SC.View = SC.CoreView.extend(/** @scope SC.View.prototype */{
 
 //unload views for IE, trying to collect memory.
 if (SC.browser.isIE) SC.Event.add(window, 'unload', SC.View, SC.View.unload);
-
-

--- a/frameworks/core_foundation/views/view/media_queries.js
+++ b/frameworks/core_foundation/views/view/media_queries.js
@@ -1,0 +1,89 @@
+// ==========================================================================
+// Project:   Sproutcore
+// Copyright: ©2013 GestiXi
+// License:   Licensed under MIT license (see license.js)
+// ==========================================================================
+
+sc_require("views/view");
+
+/** @private This adds media queries support to SC.View. */
+SC.View.reopen(
+  /** @scope SC.View.prototype */ {
+
+  // ------------------------------------------------------------------------
+  // Properties
+  //
+
+  /**
+    The dynamic adjustments to apply to this view depending on the current
+    window width.
+
+    The media hash will be applied if the window width is smaller than the
+    media key.
+    If several hash matches, they will all be applied.
+    If some hashes contains the same property, the one from the smaller
+    applicable media will be used.
+
+    exemple:
+
+        SC.LabelView.extend({
+          layout: { left: 20 },
+          title: 'Hello World',
+          media: {
+            500: { layout: { left: 5 } },
+            1000: { title: 'Hello', layout: { left: 10 } }
+          }
+        })
+
+
+    @property {Object}
+    @default null
+  */
+  media: null,
+
+  // ------------------------------------------------------------------------
+  // Methods
+  //
+
+  /** @private */
+  registerMediaQueries: function () {
+    var media = this.media;
+    if (!media) return;
+
+    SC.RootResponder.responder.mediaViews.add(this);
+
+    var mediaWidths = [];
+    for (maxWidth in media) {
+      mediaWidths.push(parseInt(maxWidth));
+    }
+    this._mediaWidths = mediaWidths.sort(function(a, b) { return a - b; });
+
+    this.handleMediaQueries();
+  },
+
+  unregisterMediaQueries: function () {
+    var media = this.media;
+    if (!media) return;
+
+    SC.RootResponder.responder.mediaViews.remove(this);
+  },
+
+  handleMediaQueries: function() {
+    var ws = SC.RootResponder.responder.get('currentWindowSize').width,
+      mediaWidths = this._mediaWidths,
+      query, properties;
+
+    for (var i = mediaWidths.length-1; i >= 0; i--) {
+      query = mediaWidths[i];
+      if (ws < query) {
+        var props = SC.copy(this.media[query]);
+
+        if (!properties) properties = props;
+        else SC.mixin(properties, props);
+      }
+    }
+
+    this._applyDesignMode(properties);
+  },
+
+});


### PR DESCRIPTION
This PR adds support for a `media` property which can be defined to views and allows you to define an object where the keys are a maximum width and the values a hash of properties to apply.

Example:

        SC.LabelView.extend({
          layout: { left: 20 },
          title: 'Hello World',
          media: {
            500: { layout: { left: 5 } },
            1000: { title: 'Hello', layout: { left: 10 } }
          }
        })