### PR TITLE
Adds media queries support to SC.View

### DIFF
--- a/frameworks/core_foundation/system/application.js
+++ b/frameworks/core_foundation/system/application.js
@@ -214,6 +214,8 @@ SC.Application = SC.Responder.extend(SC.ResponderContext,
       responder.set('designModes', designModes);
       // UNUSED.
       // this.bind('designMode', SC.Binding.from('SC.RootResponder.responder.currentDesignMode'));
+
+      responder.mediaViews = SC.Set.create();
     }
   }
 

--- a/frameworks/core_foundation/system/root_responder.js
+++ b/frameworks/core_foundation/system/root_responder.js
@@ -312,6 +312,7 @@ SC.RootResponder = SC.Object.extend(
   resize: function() {
     this._resize();
     this._assignDesignMode();
+    this._handleMediaQueries();
 
     return YES; //always allow normal processing to continue.
   },
@@ -352,6 +353,17 @@ SC.RootResponder = SC.Object.extend(
         }, this);
       }
     }
+  },
+
+  /** @private */
+  _handleMediaQueries: function () {
+    var mediaViews = this.mediaViews;
+
+    if (mediaViews) mediaViews.forEach(function(view) {
+      SC.run(function() {
+        view.handleMediaQueries();
+      });
+    });
   },
 
   /**

--- a/frameworks/core_foundation/tests/system/root_responder/design_modes_test.js
+++ b/frameworks/core_foundation/tests/system/root_responder/design_modes_test.js
@@ -38,17 +38,17 @@ test("When you set designModes on the root responder, it preps internal arrays."
   equals(responder._designModeNames, undefined, "If no designModes value is set, there should not be any _designModeNames internal array.");
   equals(responder._designModeThresholds, undefined, "If no designModes value is set, there should not be any _designModeNames internal array.");
 
-  designModes = { small: ((windowSize.width - 10) * (windowSize.height - 10)) / window.devicePixelRatio, large: Infinity };
+  designModes = { small: ((windowSize.width - 10) * (windowSize.height - 10)), large: Infinity };
 
   responder.set('designModes', designModes);
   same(responder._designModeNames, ['small', 'large'], "If designModes value is set, there should be an ordered _designModeNames internal array.");
-  same(responder._designModeThresholds, [((windowSize.width - 10) * (windowSize.height - 10)) / window.devicePixelRatio, Infinity], "If designModes value is set, there should be an ordered_designModeNames internal array.");
+  same(responder._designModeThresholds, [((windowSize.width - 10) * (windowSize.height - 10)), Infinity], "If designModes value is set, there should be an ordered_designModeNames internal array.");
 
-  designModes = { small: ((windowSize.width - 10) * (windowSize.height - 10)) / window.devicePixelRatio, medium: ((windowSize.width + 10) * (windowSize.height + 10)) / window.devicePixelRatio, large: Infinity };
+  designModes = { small: ((windowSize.width - 10) * (windowSize.height - 10)), medium: ((windowSize.width + 10) * (windowSize.height + 10)), large: Infinity };
 
   responder.set('designModes', designModes);
   same(responder._designModeNames, ['small', 'medium', 'large'], "If designModes value is set, there should be an ordered _designModeNames internal array.");
-  same(responder._designModeThresholds, [((windowSize.width - 10) * (windowSize.height - 10)) / window.devicePixelRatio, ((windowSize.width + 10) * (windowSize.height + 10)) / window.devicePixelRatio, Infinity], "If designModes value is set, there should be an ordered_designModeNames internal array.");
+  same(responder._designModeThresholds, [((windowSize.width - 10) * (windowSize.height - 10)), ((windowSize.width + 10) * (windowSize.height + 10)), Infinity], "If designModes value is set, there should be an ordered_designModeNames internal array.");
 
   responder.set('designModes', null);
   equals(responder._designModeNames, undefined, "If no designModes value is set, there should not be any _designModeNames internal array.");
@@ -65,13 +65,13 @@ test("When you set designModes on the root responder, it calls updateDesignMode 
   pane1.updateDesignMode.expect(1);
   pane2.updateDesignMode.expect(1);
 
-  designModes = { small: ((windowSize.width - 10) * (windowSize.height - 10)) / window.devicePixelRatio, large: Infinity };
+  designModes = { small: ((windowSize.width - 10) * (windowSize.height - 10)), large: Infinity };
 
   responder.set('designModes', designModes);
   pane1.updateDesignMode.expect(2);
   pane2.updateDesignMode.expect(2);
 
-  designModes = { small: ((windowSize.width - 10) * (windowSize.height - 10)) / window.devicePixelRatio, medium: ((windowSize.width + 10) * (windowSize.height + 10)) / window.devicePixelRatio, large: Infinity };
+  designModes = { small: ((windowSize.width - 10) * (windowSize.height - 10)), medium: ((windowSize.width + 10) * (windowSize.height + 10)), large: Infinity };
 
   responder.set('designModes', designModes);
   pane1.updateDesignMode.expect(3);

--- a/frameworks/core_foundation/tests/views/pane/design_mode_test.js
+++ b/frameworks/core_foundation/tests/views/pane/design_mode_test.js
@@ -148,7 +148,7 @@ test("When RootResponder has designModes, it sets designMode on its panes and th
     orientation = SC.device.orientation;
 
   windowSize = responder.get('currentWindowSize');
-  responder.set('designModes', { s: ((windowSize.width - 10) * (windowSize.height - 10)) / window.devicePixelRatio, l: Infinity });
+  responder.set('designModes', { s: ((windowSize.width - 10) * (windowSize.height - 10)), l: Infinity });
 
   pane = pane.create();
 
@@ -191,7 +191,7 @@ test("When updateDesignMode() is called on a pane, it sets designMode properly o
     orientation = SC.device.orientation;
 
   windowSize = responder.get('currentWindowSize');
-  responder.set('designModes', { s: ((windowSize.width - 10) * (windowSize.height - 10)) / window.devicePixelRatio, l: Infinity });
+  responder.set('designModes', { s: ((windowSize.width - 10) * (windowSize.height - 10)), l: Infinity });
 
   SC.run(function () {
     pane = pane.create().append();
@@ -253,7 +253,7 @@ test("When RootResponder has designModes, and you add a view to a pane, it sets 
     orientation = SC.device.orientation;
 
   windowSize = responder.get('currentWindowSize');
-  responder.set('designModes', { s: ((windowSize.width - 10) * (windowSize.height - 10)) / window.devicePixelRatio, l: Infinity });
+  responder.set('designModes', { s: ((windowSize.width - 10) * (windowSize.height - 10)), l: Infinity });
 
   SC.run(function () {
     pane = pane.create().append();
@@ -284,7 +284,7 @@ test("When you set designModes on RootResponder, it sets designMode on its panes
   view4.set.expect(0);
 
   windowSize = responder.get('currentWindowSize');
-  responder.set('designModes', { s: ((windowSize.width - 10) * (windowSize.height - 10)) / window.devicePixelRatio, l: Infinity });
+  responder.set('designModes', { s: ((windowSize.width - 10) * (windowSize.height - 10)), l: Infinity });
 
   // designMode should be set (for initialization)
   view1.set.expect(1);
@@ -315,7 +315,7 @@ test("When you change designModes on RootResponder, it sets designMode on the pa
     orientation = SC.device.orientation;
 
   windowSize = responder.get('currentWindowSize');
-  responder.set('designModes', { s: ((windowSize.width - 10) * (windowSize.height - 10)) / window.devicePixelRatio, l: Infinity });
+  responder.set('designModes', { s: ((windowSize.width - 10) * (windowSize.height - 10)), l: Infinity });
 
   SC.run(function () {
     pane = pane.create().append();
@@ -344,7 +344,7 @@ test("When you change designModes on RootResponder, it sets designMode on the pa
   same(view4.get('classNames'), ['sc-view', 'sc-large'], "classNames for view4 should be");
 
   // Change the small threshold
-  responder.set('designModes', { s: ((windowSize.width + 10) * (windowSize.height + 10)) / window.devicePixelRatio, l: Infinity });
+  responder.set('designModes', { s: ((windowSize.width + 10) * (windowSize.height + 10)), l: Infinity });
 
   // designMode should be set
   view1.set.expect(2);
@@ -370,8 +370,8 @@ test("When you change designModes on RootResponder, it sets designMode on the pa
 
   // Add a medium threshold
   responder.set('designModes', {
-    s: ((windowSize.width - 10) * (windowSize.height - 10)) / window.devicePixelRatio,
-    m: ((windowSize.width + 10) * (windowSize.height + 10)) / window.devicePixelRatio,
+    s: ((windowSize.width - 10) * (windowSize.height - 10)),
+    m: ((windowSize.width + 10) * (windowSize.height + 10)),
     l: Infinity
   });
 
@@ -406,7 +406,7 @@ test("When the design mode changes, overrides are reverted.");
 //     orientation = SC.device.orientation;
 
 //   windowSize = responder.get('currentWindowSize');
-//   responder.set('designModes', { s: ((windowSize.width - 10) * (windowSize.height - 10)) / window.devicePixelRatio, l: Infinity });
+//   responder.set('designModes', { s: ((windowSize.width - 10) * (windowSize.height - 10)), l: Infinity });
 
 //   SC.run(function () {
 //     pane = pane.create().append();
@@ -440,7 +440,7 @@ test("When you unset designModes on RootResponder, it clears designMode on its p
     orientation = SC.device.orientation;
 
   windowSize = responder.get('currentWindowSize');
-  responder.set('designModes', { s: ((windowSize.width - 10) * (windowSize.height - 10)) / window.devicePixelRatio, l: Infinity });
+  responder.set('designModes', { s: ((windowSize.width - 10) * (windowSize.height - 10)), l: Infinity });
 
   SC.run(function () {
     pane = pane.create().append();

--- a/frameworks/core_foundation/views/view.js
+++ b/frameworks/core_foundation/views/view.js
@@ -2494,12 +2494,15 @@ SC.View = SC.CoreView.extend(/** @scope SC.View.prototype */{
     // Theming
     this._lastTheme = this.get('theme');
 
+    this.registerMediaQueries();
   },
 
   /** @private */
   destroy: function () {
     // Clean up.
     this._previousLayout = null;
+
+    this.unregisterMediaQueries();
 
     return sc_super();
   },
@@ -2526,5 +2529,3 @@ SC.View = SC.CoreView.extend(/** @scope SC.View.prototype */{
 
 //unload views for IE, trying to collect memory.
 if (SC.browser.isIE) SC.Event.add(window, 'unload', SC.View, SC.View.unload);
-
-

--- a/frameworks/core_foundation/views/view/design_mode.js
+++ b/frameworks/core_foundation/views/view/design_mode.js
@@ -166,47 +166,13 @@ SC.View.reopen(
 
     modeAdjust = this.get('modeAdjust');
     if (modeAdjust) {
-      // Stop observing changes for a moment.
-      this.beginPropertyChanges();
-
-      // Unset any previous properties.
-      prevProperties = this._originalProperties;
-      if (prevProperties) {
-        //@if(debug)
-        if (SC.LOG_DESIGN_MODE || this.SC_LOG_DESIGN_MODE) {
-          SC.Logger.log('%@ — Removing previous design property overrides set by "%@":'.fmt(this, lastDesignMode));
-        }
-        //@endif
-
-        for (key in prevProperties) {
-          this._sc_revertProperty(key, prevProperties[key]);
-        }
-
-        // Remove the cache.
-        this._originalProperties = null;
-      }
-
       if (designMode) {
         // Apply new properties. The orientation specific properties override the size properties.
         if (modeAdjust[size] || modeAdjust[designMode]) {
           newProperties = SC.merge(modeAdjust[size], modeAdjust[designMode]);
-
-          //@if(debug)
-          if (SC.LOG_DESIGN_MODE || this.SC_LOG_DESIGN_MODE) {
-            SC.Logger.log('%@ — Applying design properties for "%@":'.fmt(this, designMode));
-          }
-          //@endif
-
-          // Cache the original properties for reset.
-          this._originalProperties = {};
-          for (key in newProperties) {
-            this._sc_assignProperty(key, newProperties[key]);
-          }
         }
       }
-
-      // Resume observing.
-      this.endPropertyChanges();
+      this._applyDesignMode(newProperties);
     }
 
     // Apply the design mode as a class name.
@@ -241,6 +207,33 @@ SC.View.reopen(
 
     // Set the designMode on each child view (may be null).
     this.adjustChildDesignModes(lastDesignMode, designMode);
+  },
+
+  _applyDesignMode: function (newProperties) {
+    // Stop observing changes for a moment.
+    this.beginPropertyChanges();
+
+    // Unset any previous properties.
+    prevProperties = this._originalProperties;
+    if (prevProperties) {
+      for (key in prevProperties) {
+        this._sc_revertProperty(key, prevProperties[key]);
+      }
+
+      // Remove the cache.
+      this._originalProperties = null;
+    }
+
+    if (newProperties) {
+      // Cache the original properties for reset.
+      this._originalProperties = {};
+      for (key in newProperties) {
+        this._sc_assignProperty(key, newProperties[key]);
+      }
+    }
+
+    // Resume observing.
+    this.endPropertyChanges();
   }
 
 });

--- a/frameworks/core_foundation/views/view/media_queries.js
+++ b/frameworks/core_foundation/views/view/media_queries.js
@@ -1,0 +1,89 @@
+// ==========================================================================
+// Project:   Sproutcore
+// Copyright: ©2013 GestiXi
+// License:   Licensed under MIT license (see license.js)
+// ==========================================================================
+
+sc_require("views/view");
+
+/** @private This adds media queries support to SC.View. */
+SC.View.reopen(
+  /** @scope SC.View.prototype */ {
+
+  // ------------------------------------------------------------------------
+  // Properties
+  //
+
+  /**
+    The dynamic adjustments to apply to this view depending on the current
+    window width.
+
+    The media hash will be applied if the window width is smaller than the
+    media key.
+    If several hash matches, they will all be applied.
+    If some hashes contains the same property, the one from the smaller
+    applicable media will be used.
+
+    exemple:
+
+        SC.LabelView.extend({
+          layout: { left: 20 },
+          title: 'Hello World',
+          media: {
+            500: { layout: { left: 5 } },
+            1000: { title: 'Hello', layout: { left: 10 } }
+          }
+        })
+
+
+    @property {Object}
+    @default null
+  */
+  media: null,
+
+  // ------------------------------------------------------------------------
+  // Methods
+  //
+
+  /** @private */
+  registerMediaQueries: function () {
+    var media = this.media;
+    if (!media) return;
+
+    SC.RootResponder.responder.mediaViews.add(this);
+
+    var mediaWidths = [];
+    for (maxWidth in media) {
+      mediaWidths.push(parseInt(maxWidth));
+    }
+    this._mediaWidths = mediaWidths.sort(function(a, b) { return a - b; });
+
+    this.handleMediaQueries();
+  },
+
+  unregisterMediaQueries: function () {
+    var media = this.media;
+    if (!media) return;
+
+    SC.RootResponder.responder.mediaViews.remove(this);
+  },
+
+  handleMediaQueries: function() {
+    var ws = SC.RootResponder.responder.get('currentWindowSize').width,
+      mediaWidths = this._mediaWidths,
+      query, properties;
+
+    for (var i = mediaWidths.length-1; i >= 0; i--) {
+      query = mediaWidths[i];
+      if (ws < query) {
+        var props = SC.copy(this.media[query]);
+
+        if (!properties) properties = props;
+        else SC.mixin(properties, props);
+      }
+    }
+
+    this._applyDesignMode(properties);
+  },
+
+});


### PR DESCRIPTION
This PR adds support for a `media` property which can be defined to views and allows you to define an object where the keys are a maximum width and the values are a hash of properties to apply.

Example:

        SC.LabelView.extend({
          layout: { left: 20 },
          title: 'Hello World',
          media: {
            500: { layout: { left: 5 } },
            1000: { title: 'Hello', layout: { left: 10 } }
          }
        })