### PR TITLE
Remove the listeners on the correct object

### DIFF
--- a/frameworks/core_foundation/system/root_responder.js
+++ b/frameworks/core_foundation/system/root_responder.js
@@ -953,7 +953,7 @@ SC.RootResponder = SC.Object.extend(
         SC.Event.remove(document, keyName, this, this[keyName]);
         this[keyName] = null;
     }
-    });
+    }, this);
   },
 
   /**
@@ -981,7 +981,7 @@ SC.RootResponder = SC.Object.extend(
         SC.Event.remove(document, keyName, this, this[keyName]);
         this[keyName] = null;
     }
-    });
+    }, this);
 
     actualEventName = SC.platform.animationiterationEventName;
     variation1 = lowerDomPrefix + 'animationiteration';
@@ -992,7 +992,7 @@ SC.RootResponder = SC.Object.extend(
         SC.Event.remove(document, keyName, this, this[keyName]);
         this[keyName] = null;
       }
-    });
+    }, this);
 
     actualEventName = SC.platform.animationstartEventName;
     variation1 = lowerDomPrefix + 'animationstart';
@@ -1003,7 +1003,7 @@ SC.RootResponder = SC.Object.extend(
         SC.Event.remove(document, keyName, this, this[keyName]);
         this[keyName] = null;
       }
-    });
+    }, this);
   },
 
   // ...........................................................................
@@ -1954,7 +1954,7 @@ SC.RootResponder = SC.Object.extend(
     trigger a keyDown.
   */
   keypress: function(evt) {
-    // Firefox 
+    // Firefox
     if (this._isFunctionOrNonPrintableKey(evt)) return YES;
 
     var ret,


### PR DESCRIPTION
Because of a missing this reference inside a few forEach function callbacks, when removing an event listener, the listeners themselves were not removed, causing a small memory leak.