### PR TITLE
fix two implied globals

### DIFF
--- a/frameworks/desktop/views/date_picker.js
+++ b/frameworks/desktop/views/date_picker.js
@@ -338,7 +338,7 @@ SC.DatePickerView = SC.View.extend(SC.ActionSupport, {
         mouseDownDate = this.get('_beingSelectedDate'),
         todaysDate = SC.DateTime.create(),
         weekdayStrings = this.get('weekdayStrings') || SC.DateTime.abbreviatedDayNames,
-        classNames, uniqueDayIdentifier, isCurrentMonth, isActiveDate, isToday;
+        classNames, uniqueDayIdentifier, isCurrentMonth, isActiveDate, isToday, isSelectedDate, isBeingSelectedDate;
 
     // Render header
     context = context.begin().addClass('header')


### PR DESCRIPTION
Because of a missing this reference inside a few forEach function callbacks, when removing an event listener, the listeners themselves were not removed, causing a small memory leak.