### PR TITLE
Trigger observers whenever a record array changes

### DIFF
--- a/frameworks/datastore/system/record_array.js
+++ b/frameworks/datastore/system/record_array.js
@@ -681,8 +681,12 @@ SC.RecordArray = SC.Object.extend(SC.Enumerable, SC.Array,
         this.set('storeKeys', SC.clone(storeKeys)); // replace content
       }
     }
-    if (readyPacing) this.set('status', SC.Record.READY_CLEAN);
-
+    if (readyPacing) {
+      this.set('status', SC.Record.READY_CLEAN);
+      // make sure that observers will be fired even if the status
+      // was already READY_CLEAN
+      if (didChange) this.notifyPropertyChange('status');
+    }
     return this;
   },
 


### PR DESCRIPTION
When a record array is empty because the backing query is still in flight, setting the record array as content of an array controller will cause the status to become READY_CLEAN despite the query being in flight, as it doesn't find any records in the store. When the store indicates it has fetched the query, the status will stay READY_CLEAN and observers late to the chase (such as stateObservers)
will not be notified when the data comes in. Calling the this.notifyPropertyDidChange() for the status causes these observers to be fired.