### PR TITLE
Make sure the content is clear when reconfiguring a collection itemView with undefined content

### DIFF
--- a/frameworks/desktop/views/collection.js
+++ b/frameworks/desktop/views/collection.js
@@ -3443,7 +3443,7 @@ SC.CollectionView = SC.View.extend(SC.ActionSupport, SC.CollectionViewDelegate, 
     itemView.beginPropertyChanges();
 
     // Update the view with the new properties.
-    itemView.set('content', attrs.content);
+    itemView.set('content', attrs.content !== undefined ? attrs.content : null);
     itemView.set('contentIndex', attrs.contentIndex);
     itemView.set('isEnabled', attrs.isEnabled);
     itemView.set('isEditable', attrs.isEditable);


### PR DESCRIPTION
This was leading old content to keep being displayed (instead of displaying nothing) when a collection with incremental loading was scrolled quickly.