### PR TITLE
replace aria-selected by aria-current for button

### DIFF
--- a/frameworks/desktop/render_delegates/button.js
+++ b/frameworks/desktop/render_delegates/button.js
@@ -72,7 +72,7 @@ SC.BaseTheme.buttonRenderDelegate = SC.RenderDelegate.create({
 
     // accessibility
     if(dataSource.get('isSegment')){
-      context.setAttr('aria-selected', isSelected.toString());
+      context.setAttr('aria-current', isSelected.toString());
     }else if(isToggle) {
       context.setAttr('aria-pressed', isActive.toString());
     }


### PR DESCRIPTION
The `aria-selected` attribute is not allowed for other tags than `gridcell`, `option`, `row`, or `tab`. As the segmented button uses `role="button"`, it is better to use `aria-current`.